### PR TITLE
Add static musl builds for Linux and conditional crate publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,10 @@ jobs:
       - name: Add Rust target
         run: rustup target add ${{ matrix.target }}
 
+      - name: Install musl-tools
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+
       # Install cross for cross-compilation
       - name: Install cross
         if: matrix.cross


### PR DESCRIPTION
This PR introduces support for statically compiled binaries using musl libc for Linux targets (x86_64 and aarch64), making the rustfs-cli more portable across Linux distributions without glibc dependencies. It also adds a check for the presence of CARGO_REGISTRY_TOKEN to conditionally enable crate publishing to crates.io, preventing failures in forks or environments without the token.  

Key changes:
- **Build Matrix Updates:**  
Added new statically-compiled entries for x86_64-unknown-linux-musl and aarch64-unknown-linux-musl targets. Changed the dynamically-linked glibc x86_64 target to run on ubuntu-22.04 for better glibc compatibility across systems.

- **Workflow Steps:**  
Added `rustup target add` step for all targets and musl-tools installation for musl-based builds to support compilation of dependencies like ring.

- **Build Check Enhancements:**  
Detect if CARGO_REGISTRY_TOKEN is set and output has_token for conditional logic.

- **Publish Job:**  
Only run if it's a release build and the token is available.

These changes ensure broader compatibility for distributed binaries and safer publishing workflows.  
 
You can validate the successful compilation of the binaries from the workflow run in the fork:  
[https://github.com/aabmets/rustfs-cli/actions/runs/21518772103](https://github.com/aabmets/rustfs-cli/actions/runs/21518772103)  

You can test the binaries compiled in the fork from the release published in the fork:  
[https://github.com/aabmets/rustfs-cli/releases/tag/v0.1.3](https://github.com/aabmets/rustfs-cli/releases/tag/v0.1.3)