### PR TITLE
[codex] fix local path alias ambiguity in cp and mv

### DIFF
--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -110,11 +110,9 @@ fn parse_cp_path(path: &str, alias_manager: Option<&AliasManager>) -> rc_core::R
         return Ok(parsed);
     };
 
-    if let Some(manager) = alias_manager {
-        if matches!(manager.exists(&remote.alias), Ok(true)) {
-            return Ok(parsed);
-        }
-    } else {
+    if let Some(manager) = alias_manager
+        && matches!(manager.exists(&remote.alias), Ok(true))
+    {
         return Ok(parsed);
     }
 
@@ -674,19 +672,17 @@ mod tests {
 
     #[test]
     fn test_parse_cp_path_prefers_existing_local_path_when_alias_missing() {
-        let (alias_manager, _temp_dir) = temp_alias_manager();
-        let relative = format!("target/issue-2094-{}-local/file.txt", std::process::id());
-        let full = Path::new(&relative);
+        let (alias_manager, temp_dir) = temp_alias_manager();
+        let full = temp_dir.path().join("issue-2094-local").join("file.txt");
+        let full_str = full.to_string_lossy().to_string();
 
         if let Some(parent) = full.parent() {
             std::fs::create_dir_all(parent).expect("create parent dirs");
         }
-        std::fs::write(full, b"test").expect("write local file");
+        std::fs::write(&full, b"test").expect("write local file");
 
-        let parsed = parse_cp_path(&relative, Some(&alias_manager)).expect("parse path");
+        let parsed = parse_cp_path(&full_str, Some(&alias_manager)).expect("parse path");
         assert!(matches!(parsed, ParsedPath::Local(_)));
-
-        std::fs::remove_file(full).expect("remove temp file");
     }
 
     #[test]

--- a/crates/cli/src/commands/mv.rs
+++ b/crates/cli/src/commands/mv.rs
@@ -92,11 +92,9 @@ fn parse_mv_path(path: &str, alias_manager: Option<&AliasManager>) -> rc_core::R
         return Ok(parsed);
     };
 
-    if let Some(manager) = alias_manager {
-        if matches!(manager.exists(&remote.alias), Ok(true)) {
-            return Ok(parsed);
-        }
-    } else {
+    if let Some(manager) = alias_manager
+        && matches!(manager.exists(&remote.alias), Ok(true))
+    {
         return Ok(parsed);
     }
 
@@ -367,19 +365,17 @@ mod tests {
 
     #[test]
     fn test_parse_mv_path_prefers_existing_local_path_when_alias_missing() {
-        let (alias_manager, _temp_dir) = temp_alias_manager();
-        let relative = format!("target/issue-2094-{}-mv-local/file.txt", std::process::id());
-        let full = Path::new(&relative);
+        let (alias_manager, temp_dir) = temp_alias_manager();
+        let full = temp_dir.path().join("issue-2094-mv-local").join("file.txt");
+        let full_str = full.to_string_lossy().to_string();
 
         if let Some(parent) = full.parent() {
             std::fs::create_dir_all(parent).expect("create parent dirs");
         }
-        std::fs::write(full, b"test").expect("write local file");
+        std::fs::write(&full, b"test").expect("write local file");
 
-        let parsed = parse_mv_path(&relative, Some(&alias_manager)).expect("parse path");
+        let parsed = parse_mv_path(&full_str, Some(&alias_manager)).expect("parse path");
         assert!(matches!(parsed, ParsedPath::Local(_)));
-
-        std::fs::remove_file(full).expect("remove temp file");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR fixes path disambiguation for local relative paths in `cp` and `mv` when the first path segment looks like an alias name.

Users reported that a command such as:

```bash
rc cp 'downloaded-product/[stemcells-ubuntu-jammy,1.1065]bosh-stemcell-1.1065-vsphere-esxi-ubuntu-jammy-go_agent.tgz' local_s3/tiles/stemcells/
```

was incorrectly treated as remote-to-remote and failed with a cross-alias error unless `./` was prefixed.

Fixes rustfs/rustfs#2094.

## Root Cause
`rc_core::parse_path()` is syntax-based and treats `alias/bucket[/key]`-shaped inputs as remote paths without checking whether the alias actually exists.

For local relative paths like `downloaded-product/file.tgz`, if `downloaded-product` matches alias naming rules, the path was parsed as remote.

## What Changed
### `cp`
- Added `parse_cp_path()` in `crates/cli/src/commands/cp.rs`.
- Behavior:
  - Keep remote parsing when alias exists.
  - If parsed as remote but alias does not exist and local path exists, reinterpret as local.
  - Otherwise keep the original parse result.

### `mv`
- Added the same disambiguation strategy via `parse_mv_path()` in `crates/cli/src/commands/mv.rs`.
- This prevents the same false remote classification in `mv`.

### Tests
Added regression tests for both commands to cover:
- alias missing + local path exists => local
- alias exists => remote
- alias missing + local path missing => remote

## Validation
All required checks passed:
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

Manual reproduction and verification completed:
- Reproduced original failure before fix.
- Verified `cp` and `mv` both work with local relative subdirectory paths without requiring `./`.
- Verified against Docker `rustfs/rustfs:1.0.0-alpha.85`.
