### PR TITLE
test: add command and option contract gate for e2e

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,18 @@ env:
   TEST_S3_SECRET_KEY: secretkey
 
 jobs:
+  cli-contract:
+    name: CLI Contract (Commands and Options)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run CLI help contract tests
+        run: cargo test --package rustfs-cli --test help_contract
+
   smoke-latest:
     name: Smoke (RustFS latest)
     runs-on: ubuntu-latest

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -1,0 +1,499 @@
+//! CLI help contract tests.
+//!
+//! These tests verify command and option discoverability through `--help` output.
+//! They provide a fast contract layer for all command paths, without requiring
+//! a running S3 backend.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+const GLOBAL_OPTIONS: &[&str] = &[
+    "--json",
+    "--no-color",
+    "--no-progress",
+    "--quiet",
+    "--debug",
+    "--help",
+    "--version",
+];
+
+#[derive(Debug)]
+struct HelpCase {
+    args: &'static [&'static str],
+    usage: &'static str,
+    expected_tokens: &'static [&'static str],
+}
+
+fn rc_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rc") {
+        return PathBuf::from(path);
+    }
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has parent directory")
+        .parent()
+        .expect("workspace root exists")
+        .to_path_buf();
+
+    let debug_binary = workspace_root.join("target/debug/rc");
+    if debug_binary.exists() {
+        return debug_binary;
+    }
+
+    workspace_root.join("target/release/rc")
+}
+
+fn run_rc(args: &[&str]) -> Output {
+    Command::new(rc_binary())
+        .args(args)
+        .output()
+        .expect("failed to execute rc")
+}
+
+fn assert_help_case(case: &HelpCase) {
+    let mut args = case.args.to_vec();
+    args.push("--help");
+
+    let output = run_rc(&args);
+    let command_label = if case.args.is_empty() {
+        "rc".to_string()
+    } else {
+        format!("rc {}", case.args.join(" "))
+    };
+
+    assert!(
+        output.status.success(),
+        "help should succeed for {command_label}: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(case.usage),
+        "usage marker `{}` missing for {command_label}\nstdout:\n{}",
+        case.usage,
+        stdout
+    );
+
+    for option in GLOBAL_OPTIONS {
+        assert!(
+            stdout.contains(option),
+            "global option `{option}` missing in help for {command_label}\nstdout:\n{}",
+            stdout
+        );
+    }
+
+    for token in case.expected_tokens {
+        assert!(
+            stdout.contains(token),
+            "expected token `{token}` missing in help for {command_label}\nstdout:\n{}",
+            stdout
+        );
+    }
+}
+
+#[test]
+fn top_level_command_help_contract() {
+    let cases = [
+        HelpCase {
+            args: &[],
+            usage: "Usage: rc [OPTIONS] <COMMAND>",
+            expected_tokens: &[
+                "alias",
+                "admin",
+                "ls",
+                "mb",
+                "rb",
+                "cat",
+                "head",
+                "stat",
+                "cp",
+                "mv",
+                "rm",
+                "pipe",
+                "find",
+                "diff",
+                "mirror",
+                "tree",
+                "share",
+                "version",
+                "tag",
+                "quota",
+                "completions",
+            ],
+        },
+        HelpCase {
+            args: &["alias"],
+            usage: "Usage: rc alias [OPTIONS] <COMMAND>",
+            expected_tokens: &["set", "list", "remove"],
+        },
+        HelpCase {
+            args: &["admin"],
+            usage: "Usage: rc admin [OPTIONS] <COMMAND>",
+            expected_tokens: &["info", "heal", "user", "policy", "group", "service-account"],
+        },
+        HelpCase {
+            args: &["ls"],
+            usage: "Usage: rc ls [OPTIONS] <PATH>",
+            expected_tokens: &["--recursive", "--versions", "--incomplete", "--summarize"],
+        },
+        HelpCase {
+            args: &["mb"],
+            usage: "Usage: rc mb [OPTIONS] <TARGET>",
+            expected_tokens: &[
+                "--ignore-existing",
+                "--region",
+                "--with-lock",
+                "--with-versioning",
+            ],
+        },
+        HelpCase {
+            args: &["rb"],
+            usage: "Usage: rc rb [OPTIONS] <TARGET>",
+            expected_tokens: &["--force", "--dangerous"],
+        },
+        HelpCase {
+            args: &["cat"],
+            usage: "Usage: rc cat [OPTIONS] <PATH>",
+            expected_tokens: &["--enc-key", "--rewind", "--version-id"],
+        },
+        HelpCase {
+            args: &["head"],
+            usage: "Usage: rc head [OPTIONS] <PATH>",
+            expected_tokens: &["--lines", "--bytes", "--version-id"],
+        },
+        HelpCase {
+            args: &["stat"],
+            usage: "Usage: rc stat [OPTIONS] <PATH>",
+            expected_tokens: &["--version-id", "--rewind"],
+        },
+        HelpCase {
+            args: &["cp"],
+            usage: "Usage: rc cp [OPTIONS] <SOURCE> <TARGET>",
+            expected_tokens: &[
+                "--recursive",
+                "--preserve",
+                "--continue-on-error",
+                "--overwrite",
+                "--dry-run",
+                "--storage-class",
+                "--content-type",
+            ],
+        },
+        HelpCase {
+            args: &["mv"],
+            usage: "Usage: rc mv [OPTIONS] <SOURCE> <TARGET>",
+            expected_tokens: &["--recursive", "--continue-on-error", "--dry-run"],
+        },
+        HelpCase {
+            args: &["rm"],
+            usage: "Usage: rc rm [OPTIONS] <PATHS>...",
+            expected_tokens: &[
+                "--recursive",
+                "--force",
+                "--dry-run",
+                "--incomplete",
+                "--versions",
+                "--bypass",
+            ],
+        },
+        HelpCase {
+            args: &["pipe"],
+            usage: "Usage: rc pipe [OPTIONS] <TARGET>",
+            expected_tokens: &["--content-type", "--storage-class"],
+        },
+        HelpCase {
+            args: &["find"],
+            usage: "Usage: rc find [OPTIONS] <PATH>",
+            expected_tokens: &[
+                "--name",
+                "--larger",
+                "--smaller",
+                "--newer",
+                "--older",
+                "--maxdepth",
+                "--count",
+                "--exec",
+                "--print",
+            ],
+        },
+        HelpCase {
+            args: &["diff"],
+            usage: "Usage: rc diff [OPTIONS] <FIRST> <SECOND>",
+            expected_tokens: &["--recursive", "--diff-only"],
+        },
+        HelpCase {
+            args: &["mirror"],
+            usage: "Usage: rc mirror [OPTIONS] <SOURCE> <TARGET>",
+            expected_tokens: &["--remove", "--overwrite", "--dry-run", "--parallel"],
+        },
+        HelpCase {
+            args: &["tree"],
+            usage: "Usage: rc tree [OPTIONS] <PATH>",
+            expected_tokens: &[
+                "--level",
+                "--size",
+                "--dirs-only",
+                "--pattern",
+                "--full-path",
+            ],
+        },
+        HelpCase {
+            args: &["share"],
+            usage: "Usage: rc share [OPTIONS] <PATH>",
+            expected_tokens: &["--expire", "--upload", "--content-type"],
+        },
+        HelpCase {
+            args: &["version"],
+            usage: "Usage: rc version [OPTIONS] <COMMAND>",
+            expected_tokens: &["enable", "suspend", "info", "list"],
+        },
+        HelpCase {
+            args: &["tag"],
+            usage: "Usage: rc tag [OPTIONS] <COMMAND>",
+            expected_tokens: &["list", "set", "remove"],
+        },
+        HelpCase {
+            args: &["quota"],
+            usage: "Usage: rc quota [OPTIONS] <COMMAND>",
+            expected_tokens: &["set", "info", "clear"],
+        },
+        HelpCase {
+            args: &["completions"],
+            usage: "Usage: rc completions [OPTIONS] <SHELL>",
+            expected_tokens: &["[possible values: bash, elvish, fish, powershell, zsh]"],
+        },
+    ];
+
+    for case in cases {
+        assert_help_case(&case);
+    }
+}
+
+#[test]
+fn nested_subcommand_help_contract() {
+    let cases = [
+        HelpCase {
+            args: &["alias", "set"],
+            usage: "Usage: rc alias set [OPTIONS] <NAME> <ENDPOINT> <ACCESS_KEY> <SECRET_KEY>",
+            expected_tokens: &["--region", "--signature", "--bucket-lookup", "--insecure"],
+        },
+        HelpCase {
+            args: &["alias", "list"],
+            usage: "Usage: rc alias list [OPTIONS]",
+            expected_tokens: &["--long"],
+        },
+        HelpCase {
+            args: &["alias", "remove"],
+            usage: "Usage: rc alias remove [OPTIONS] <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "info", "cluster"],
+            usage: "Usage: rc admin info cluster [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "info", "server"],
+            usage: "Usage: rc admin info server [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "info", "disk"],
+            usage: "Usage: rc admin info disk [OPTIONS] <ALIAS>",
+            expected_tokens: &["--offline", "--healing"],
+        },
+        HelpCase {
+            args: &["admin", "heal", "status"],
+            usage: "Usage: rc admin heal status [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "heal", "start"],
+            usage: "Usage: rc admin heal start [OPTIONS] <ALIAS>",
+            expected_tokens: &[
+                "--bucket",
+                "--prefix",
+                "--scan-mode",
+                "--remove",
+                "--recreate",
+                "--dry-run",
+            ],
+        },
+        HelpCase {
+            args: &["admin", "heal", "stop"],
+            usage: "Usage: rc admin heal stop [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "user", "ls"],
+            usage: "Usage: rc admin user ls [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "user", "add"],
+            usage: "Usage: rc admin user add [OPTIONS] <ALIAS> <ACCESS_KEY> <SECRET_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "user", "info"],
+            usage: "Usage: rc admin user info [OPTIONS] <ALIAS> <ACCESS_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "user", "rm"],
+            usage: "Usage: rc admin user rm [OPTIONS] <ALIAS> <ACCESS_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "user", "enable"],
+            usage: "Usage: rc admin user enable [OPTIONS] <ALIAS> <ACCESS_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "user", "disable"],
+            usage: "Usage: rc admin user disable [OPTIONS] <ALIAS> <ACCESS_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "policy", "ls"],
+            usage: "Usage: rc admin policy ls [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "policy", "create"],
+            usage: "Usage: rc admin policy create [OPTIONS] <ALIAS> <NAME> <POLICY_FILE>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "policy", "info"],
+            usage: "Usage: rc admin policy info [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "policy", "rm"],
+            usage: "Usage: rc admin policy rm [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "policy", "attach"],
+            usage: "Usage: rc admin policy attach [OPTIONS] <ALIAS> <POLICIES>",
+            expected_tokens: &["--user", "--group"],
+        },
+        HelpCase {
+            args: &["admin", "group", "ls"],
+            usage: "Usage: rc admin group ls [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "group", "add"],
+            usage: "Usage: rc admin group add [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &["--members"],
+        },
+        HelpCase {
+            args: &["admin", "group", "info"],
+            usage: "Usage: rc admin group info [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "group", "rm"],
+            usage: "Usage: rc admin group rm [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "group", "enable"],
+            usage: "Usage: rc admin group enable [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "group", "disable"],
+            usage: "Usage: rc admin group disable [OPTIONS] <ALIAS> <NAME>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "group", "add-members"],
+            usage: "Usage: rc admin group add-members [OPTIONS] <ALIAS> <NAME> <MEMBERS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "group", "rm-members"],
+            usage: "Usage: rc admin group rm-members [OPTIONS] <ALIAS> <NAME> <MEMBERS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "service-account", "ls"],
+            usage: "Usage: rc admin service-account ls [OPTIONS] <ALIAS>",
+            expected_tokens: &["--user"],
+        },
+        HelpCase {
+            args: &["admin", "service-account", "create"],
+            usage: "Usage: rc admin service-account create [OPTIONS] <ALIAS> <ACCESS_KEY> <SECRET_KEY>",
+            expected_tokens: &["--name", "--description", "--policy", "--expiry"],
+        },
+        HelpCase {
+            args: &["admin", "service-account", "info"],
+            usage: "Usage: rc admin service-account info [OPTIONS] <ALIAS> <ACCESS_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "service-account", "rm"],
+            usage: "Usage: rc admin service-account rm [OPTIONS] <ALIAS> <ACCESS_KEY>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["version", "enable"],
+            usage: "Usage: rc version enable [OPTIONS] <PATH>",
+            expected_tokens: &["--force"],
+        },
+        HelpCase {
+            args: &["version", "suspend"],
+            usage: "Usage: rc version suspend [OPTIONS] <PATH>",
+            expected_tokens: &["--force"],
+        },
+        HelpCase {
+            args: &["version", "info"],
+            usage: "Usage: rc version info [OPTIONS] <PATH>",
+            expected_tokens: &["--force"],
+        },
+        HelpCase {
+            args: &["version", "list"],
+            usage: "Usage: rc version list [OPTIONS] <PATH>",
+            expected_tokens: &["--max", "--force"],
+        },
+        HelpCase {
+            args: &["tag", "list"],
+            usage: "Usage: rc tag list [OPTIONS] <PATH>",
+            expected_tokens: &["--force"],
+        },
+        HelpCase {
+            args: &["tag", "set"],
+            usage: "Usage: rc tag set [OPTIONS] <PATH>",
+            expected_tokens: &["--tags", "--force"],
+        },
+        HelpCase {
+            args: &["tag", "remove"],
+            usage: "Usage: rc tag remove [OPTIONS] <PATH>",
+            expected_tokens: &["--force"],
+        },
+        HelpCase {
+            args: &["quota", "set"],
+            usage: "Usage: rc quota set [OPTIONS] <PATH> <SIZE>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["quota", "info"],
+            usage: "Usage: rc quota info [OPTIONS] <PATH>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["quota", "clear"],
+            usage: "Usage: rc quota clear [OPTIONS] <PATH>",
+            expected_tokens: &[],
+        },
+    ];
+
+    for case in cases {
+        assert_help_case(&case);
+    }
+}


### PR DESCRIPTION
## Summary
This PR continues the test hardening work by adding a command/option contract layer and wiring it into integration CI.

## What Changed
- Added a new CLI contract test suite:
  - `crates/cli/tests/help_contract.rs`
- The suite validates `--help` output for:
  - all top-level commands
  - all nested subcommands (including admin trees)
  - global options availability across command paths
  - command-specific option discoverability
- Added a dedicated CI gate in integration workflow:
  - `CLI Contract (Commands and Options)` job in `.github/workflows/integration.yml`
  - Runs `cargo test --package rustfs-cli --test help_contract`

## Why
Current integration tests focus on runtime behavior with S3/RustFS, but they do not provide a strict contract guard for command tree and option surface. This PR adds a fast, deterministic safety net that catches regressions in command/option UX before runtime integration phases.

## Validation
All required checks were run locally and passed:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo test --package rustfs-cli --test help_contract`

## Scope
- No protected files modified
- No CLI behavior-breaking schema/config contract changes
