### PR TITLE
Update ls command to recurse all objects if -r flag is provided with no bucket

### DIFF
--- a/crates/cli/src/commands/ls.rs
+++ b/crates/cli/src/commands/ls.rs
@@ -279,7 +279,15 @@ async fn list_all_objects(
 
     if formatter.is_json() {
         let output = LsOutput {
-            items: all_items.into_values().flatten().collect(),
+            items: all_items
+                .into_iter()
+                .flat_map(|(bucket, objects)| {
+                    objects.into_iter().map(move |mut obj| {
+                        obj.key = format!("{}/{}", bucket, obj.key);
+                        obj
+                    })
+                })
+                .collect(),
             truncated: is_truncated,
             continuation_token,
             summary: if summarize {


### PR DESCRIPTION
This brings rc more in line with mc's behaviour, specifically when using the recursive flag. No other behaviour changes other than if you provide the -r flag with an alias but no bucket specified. Previously this would have listed just the buckets (same as without the flag), now it lists all objects on the server.

Closes #47 