### PR TITLE
feat(phase-2): bump version to 0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "rc-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2155,7 +2155,7 @@ dependencies = [
 
 [[package]]
 name = "rc-s3"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2321,7 +2321,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/core", "crates/s3"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rc-core = { path = "./crates/core", version = "0.1.7" }
-rc-s3 = { path = "./crates/s3", version = "0.1.7" }
-rustfs-cli = { path = "./crates/cli", version = "0.1.7" }
+rc-core = { path = "./crates/core", version = "0.1.8" }
+rc-s3 = { path = "./crates/s3", version = "0.1.8" }
+rustfs-cli = { path = "./crates/cli", version = "0.1.8" }
 
 # Async runtime
 tokio = { version = "1.49", features = ["full"] }


### PR DESCRIPTION
## Related issue(s)
- N/A

## Background and user impact
- The workspace version was still `0.1.7` on the latest `main` branch.
- Releasing the recent changes requires a new crate and binary version.

## Root cause summary
- The workspace package version and internal crate dependency versions had not been advanced for the next release.

## Solution overview
- Bump the workspace version from `0.1.7` to `0.1.8`.
- Update internal workspace dependency version references to `0.1.8`.
- Refresh `Cargo.lock` so local package entries match the new workspace version.

## Test status
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
