### PR TITLE
docs(readme): add Scoop installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ If you specifically need glibc-linked builds, use `linux-amd64-gnu` / `linux-arm
 brew install rustfs/tap/rc
 ```
 
+### Scoop (Windows)
+
+```powershell
+scoop bucket add rustfs https://github.com/rustfs/scoop-bucket
+scoop install rustfs/rc
+```
+
 ### Cargo
 
 ```bash


### PR DESCRIPTION
## Summary

This documentation update adds Scoop installation instructions for Windows users in the main README.

The project now has a dedicated Scoop bucket at https://github.com/rustfs/scoop-bucket, so the README should document Scoop alongside the existing Homebrew, Cargo, Docker, and binary installation paths.

## User Impact

Windows users can now discover an official Scoop-based installation flow directly from the README instead of having to find the bucket manually.

## Validation

- Markdown-only documentation update.
- Per repository policy for markdown-only changes, cargo fmt, clippy, and test commands were not run.
- The published Scoop bucket and Windows smoke-install workflow were validated separately in rustfs/scoop-bucket.
