### PR TITLE
ci: upgrade GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       has_token: ${{ steps.check.outputs.has_token }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -234,7 +234,7 @@ jobs:
 
       # Upload artifacts for later jobs
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rustfs-cli-${{ matrix.os_name }}-${{ matrix.arch }}
           path: artifacts/*
@@ -318,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
@@ -340,7 +340,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload completions artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: completions
           path: completions.tar.gz
@@ -356,14 +356,14 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts
           pattern: rustfs-cli-*
           merge-multiple: true
 
       - name: Download completions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: completions
           path: artifacts
@@ -434,7 +434,7 @@ jobs:
     if: needs.build-check.outputs.is_release == 'true' && needs.build-check.outputs.has_token == 'true'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary
GitHub Actions is deprecating Node.js 20 on hosted runners, and this repository still had a few workflow steps pinned to action majors that run on Node 20 by default. That already produces deprecation warnings today and creates risk for the release and Docker publishing paths once GitHub switches JavaScript actions to Node 24 by default.

This change upgrades the remaining affected workflow steps to majors that officially support Node 24 so the repository is aligned with GitHub's migration timeline before the default runtime flips in June 2026.

## Root Cause
Most workflows in this repository had already moved to `actions/checkout@v6`, but the release and Docker workflows still referenced older majors:

- `actions/checkout@v4` in the release and Docker workflows
- `actions/upload-artifact@v4` in the release workflow
- `actions/download-artifact@v4` in the release workflow

Those versions are the source of the current Node 20 deprecation warnings.

## Solution
This PR updates the affected workflow steps without changing the release flow itself:

- Upgrade the remaining `actions/checkout` usages from `v4` to `v6`
- Upgrade `actions/upload-artifact` from `v4` to `v6`
- Upgrade `actions/download-artifact` from `v4` to `v7`

The artifact download action was moved to the smallest Node 24-compatible major so the upload/download path stays aligned while avoiding a larger jump to newer behavior changes that are not needed for this fix.

## User Impact
This removes the current deprecation warnings in the affected workflows and reduces the chance of release or Docker automation regressions when GitHub starts defaulting JavaScript actions to Node 24.

## Validation
I ran the repository's required checks before committing:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also verified that the edited workflow files still parse as valid YAML after the version updates.
