### PR TITLE
fix(event): normalize shorthand notification event names

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -346,7 +346,7 @@ fn parse_event_list(values: &[String]) -> Vec<String> {
         .flat_map(|value| value.split(','))
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
+        .map(normalize_event_name)
         .collect();
 
     if events.is_empty() {
@@ -356,6 +356,17 @@ fn parse_event_list(values: &[String]) -> Vec<String> {
     events.sort();
     events.dedup();
     events
+}
+
+fn normalize_event_name(value: &str) -> String {
+    match value.to_ascii_lowercase().as_str() {
+        "put" => "s3:ObjectCreated:*".to_string(),
+        "get" => "s3:ObjectAccessed:*".to_string(),
+        "delete" => "s3:ObjectRemoved:*".to_string(),
+        "replica" => "s3:Replication:*".to_string(),
+        "ilm" => "s3:ObjectTransition:*".to_string(),
+        _ => value.to_string(),
+    }
 }
 
 fn infer_target_from_arn(arn: &str) -> Result<NotificationTarget, String> {
@@ -437,6 +448,22 @@ mod tests {
             vec![
                 "s3:ObjectCreated:Put".to_string(),
                 "s3:ObjectRemoved:*".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_event_list_normalizes_shorthand_events() {
+        let events = parse_event_list(&["put,get,delete,replica,ilm,PUT,delete".to_string()]);
+
+        assert_eq!(
+            events,
+            vec![
+                "s3:ObjectAccessed:*".to_string(),
+                "s3:ObjectCreated:*".to_string(),
+                "s3:ObjectRemoved:*".to_string(),
+                "s3:ObjectTransition:*".to_string(),
+                "s3:Replication:*".to_string(),
             ]
         );
     }


### PR DESCRIPTION
## Summary

Fixes `rc event add --event put` storing shorthand names literally instead of normalizing to S3 event patterns.

Closes #65.

## Problem

`parse_event_list()` passed `--event` values through unchanged. As a result, shorthand values such as `put` were persisted as-is in bucket notification configuration and never matched incoming RustFS events like `s3:ObjectCreated:Put`.

## Root Cause

Event normalization for shorthand names was missing in `crates/cli/src/commands/event.rs`.

## Solution

- Added `normalize_event_name()` in the event command parser.
- Normalized shorthand values (case-insensitive):
  - `put` -> `s3:ObjectCreated:*`
  - `get` -> `s3:ObjectAccessed:*`
  - `delete` -> `s3:ObjectRemoved:*`
  - `replica` -> `s3:Replication:*`
  - `ilm` -> `s3:ObjectTransition:*`
- Kept non-shorthand values unchanged.
- Added unit test `test_parse_event_list_normalizes_shorthand_events` to lock behavior and dedup semantics.

## Validation

### Docker Reproduction (before fix)

- Started `rustfs/rustfs:latest` in Docker.
- Ran:

```bash
rc alias set local http://localhost:19000 accesskey secretkey
rc mb local/test-bucket
rc event add local/test-bucket arn:rustfs:sqs::primary:mqtt --event put
rc event list local/test-bucket
```

- Observed (before fix):

```text
[queue] arn:rustfs:sqs::primary:mqtt -> put
```

### Docker Verification (after fix)

- Ran same command sequence against `rustfs/rustfs:latest`.
- Observed (after fix):

```text
[queue] arn:rustfs:sqs::primary:mqtt -> s3:ObjectCreated:*
```

### Quality Gates

```bash
cargo fmt --all --check
cargo clippy --workspace -- -D warnings
cargo test --workspace
```

All passed.
