### PR TITLE
fix(event): normalize shorthand event names before persisting notifications

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -346,7 +346,7 @@ fn parse_event_list(values: &[String]) -> Vec<String> {
         .flat_map(|value| value.split(','))
         .map(str::trim)
         .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
+        .map(normalize_event_name)
         .collect();
 
     if events.is_empty() {
@@ -356,6 +356,17 @@ fn parse_event_list(values: &[String]) -> Vec<String> {
     events.sort();
     events.dedup();
     events
+}
+
+fn normalize_event_name(value: &str) -> String {
+    match value.to_ascii_lowercase().as_str() {
+        "put" => "s3:ObjectCreated:*".to_string(),
+        "get" => "s3:ObjectAccessed:*".to_string(),
+        "delete" => "s3:ObjectRemoved:*".to_string(),
+        "replica" => "s3:Replication:*".to_string(),
+        "ilm" => "s3:ObjectTransition:*".to_string(),
+        _ => value.to_string(),
+    }
 }
 
 fn infer_target_from_arn(arn: &str) -> Result<NotificationTarget, String> {
@@ -437,6 +448,28 @@ mod tests {
             vec![
                 "s3:ObjectCreated:Put".to_string(),
                 "s3:ObjectRemoved:*".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_event_list_normalizes_shorthand_names() {
+        let events = parse_event_list(&[
+            "put,get,delete".to_string(),
+            "replica".to_string(),
+            "ilm,s3:ObjectCreated:Post".to_string(),
+            "PUT".to_string(),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                "s3:ObjectAccessed:*".to_string(),
+                "s3:ObjectCreated:*".to_string(),
+                "s3:ObjectCreated:Post".to_string(),
+                "s3:ObjectRemoved:*".to_string(),
+                "s3:ObjectTransition:*".to_string(),
+                "s3:Replication:*".to_string(),
             ]
         );
     }


### PR DESCRIPTION
## Related issue
- Closes #65

## Background
`rc event add --event put` stored `put` literally in bucket notification configuration. RustFS matches concrete S3 event patterns (for example `s3:ObjectCreated:Put`), so the shorthand token never matched and notifications were not emitted.

## Root cause
`parse_event_list()` in `crates/cli/src/commands/event.rs` passed `--event` values through without normalization.

## Solution
- Added shorthand normalization in `event add` parsing:
  - `put` -> `s3:ObjectCreated:*`
  - `get` -> `s3:ObjectAccessed:*`
  - `delete` -> `s3:ObjectRemoved:*`
  - `replica` -> `s3:Replication:*`
  - `ilm` -> `s3:ObjectTransition:*`
- Kept existing behavior for fully qualified S3 event names.
- Preserved sorting and deduplication behavior after normalization.

## Tests
- Added unit test: `test_parse_event_list_normalizes_shorthand_names`

## Validation
- Docker reproduction (before fix): `event list` showed `-> put`.
- Docker verification (after fix): `event list` shows `-> s3:ObjectCreated:*`.

## CI / Quality checks
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
