### PR TITLE
test: cover event shorthand normalization gaps

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -475,6 +475,31 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_event_list_deduplicates_shorthand_and_canonical_values() {
+        let events = parse_event_list(&[
+            " put ,s3:ObjectCreated:*".to_string(),
+            "GET,s3:ObjectAccessed:*".to_string(),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                "s3:ObjectAccessed:*".to_string(),
+                "s3:ObjectCreated:*".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_normalize_event_name_preserves_non_shorthand_values() {
+        assert_eq!(
+            normalize_event_name("s3:ObjectCreated:Post"),
+            "s3:ObjectCreated:Post"
+        );
+        assert_eq!(normalize_event_name("custom:event"), "custom:event");
+    }
+
+    #[test]
     fn test_infer_target_from_arn() {
         assert_eq!(
             infer_target_from_arn("arn:aws:sqs:us-east-1:123456789012:queue").expect("queue"),


### PR DESCRIPTION
## Summary
This change adds focused regression coverage for the event shorthand normalization fix merged on `main`.

Users were affected when shorthand event names such as `put`, `get`, `delete`, `replica`, and `ilm` needed to normalize to the persisted S3 notification event strings. The recent fix corrected the implementation, but there were still untested branches around how those normalized values interact with already-canonical inputs.

The root cause of the remaining test gap was that existing coverage only verified shorthand mapping in isolation. It did not verify that shorthand and canonical values collapse to the same persisted event after normalization, and it did not exercise the passthrough branch for already-canonical or custom event names.

This PR keeps scope tight by adding two unit tests in the event command:
- one verifies shorthand and canonical event names deduplicate after normalization
- one verifies non-shorthand values are preserved unchanged

## Validation
I ran the required repository checks after the test additions:
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
