### PR TITLE
test(event): cover shorthand normalization deduplication

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -475,6 +475,24 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_event_list_deduplicates_shorthand_and_canonical_names() {
+        let events = parse_event_list(&[
+            "put,s3:ObjectCreated:*".to_string(),
+            "GET,s3:ObjectAccessed:*".to_string(),
+            "delete,s3:ObjectRemoved:*".to_string(),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
+                "s3:ObjectAccessed:*".to_string(),
+                "s3:ObjectCreated:*".to_string(),
+                "s3:ObjectRemoved:*".to_string(),
+            ]
+        );
+    }
+
+    #[test]
     fn test_infer_target_from_arn() {
         assert_eq!(
             infer_target_from_arn("arn:aws:sqs:us-east-1:123456789012:queue").expect("queue"),


### PR DESCRIPTION
## Summary
This change closes a regression-test gap in the event notification parser.

The recent event shorthand normalization fix correctly maps aliases such as `put`, `get`, and `delete` to their canonical S3 event names before notification rules are persisted. That behavior was already covered for plain shorthand inputs, but there was still no test proving that shorthand aliases collapse with already-canonical event names into a single persisted value.

Without this regression test, a future refactor could accidentally reintroduce duplicate notification events whenever users mix shorthand flags and canonical event names in the same command invocation.

## Root cause
The changed code path normalizes event names first and only then sorts and deduplicates them. The existing tests did not exercise the specific case where shorthand inputs and canonical S3 event names should normalize to the same final string before deduplication.

## Fix
Add a focused unit test in `crates/cli/src/commands/event.rs` that covers mixed shorthand and canonical event inputs and asserts that the parser returns a deduplicated canonical event list.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
