### PR TITLE
test(ls): cover alias recursive listing mode

### DIFF
--- a/crates/cli/src/commands/ls.rs
+++ b/crates/cli/src/commands/ls.rs
@@ -91,14 +91,14 @@ pub async fn execute(args: LsArgs, output_config: OutputConfig) -> ExitCode {
         }
     };
 
-    if bucket.is_none() {
-        if args.recursive {
-            // If no bucket specified & recursive flag is provided, list all objects on the server
-            return list_all_objects(&client, alias_name, &formatter, args.summarize).await;
-        } else {
-            // Else no bucket specified, list buckets
-            return list_buckets(&client, &formatter, args.summarize).await;
-        }
+    if let Some(list_mode) = alias_listing_mode(bucket.as_ref(), args.recursive) {
+        return match list_mode {
+            AliasListingMode::Buckets => list_buckets(&client, &formatter, args.summarize).await,
+            // Keep mc-compatible behavior for `ls alias/ -r`.
+            AliasListingMode::AllObjects => {
+                list_all_objects(&client, alias_name, &formatter, args.summarize).await
+            }
+        };
     }
 
     let bucket = bucket.unwrap();
@@ -390,6 +390,24 @@ async fn list_objects_with_paging(
     Ok((all_items, is_truncated, continuation_token))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AliasListingMode {
+    Buckets,
+    AllObjects,
+}
+
+fn alias_listing_mode(bucket: Option<&String>, recursive: bool) -> Option<AliasListingMode> {
+    if bucket.is_some() {
+        return None;
+    }
+
+    if recursive {
+        Some(AliasListingMode::AllObjects)
+    } else {
+        Some(AliasListingMode::Buckets)
+    }
+}
+
 /// Parse ls path into (alias, bucket, prefix)
 fn parse_ls_path(path: &str) -> Result<(String, Option<String>, Option<String>), String> {
     let path = path.trim_end_matches('/');
@@ -451,5 +469,28 @@ mod tests {
     #[test]
     fn test_parse_ls_path_empty() {
         assert!(parse_ls_path("").is_err());
+    }
+
+    #[test]
+    fn test_alias_listing_mode_lists_all_objects_for_recursive_alias_path() {
+        assert_eq!(
+            alias_listing_mode(None, true),
+            Some(AliasListingMode::AllObjects)
+        );
+    }
+
+    #[test]
+    fn test_alias_listing_mode_lists_buckets_without_recursive_flag() {
+        assert_eq!(
+            alias_listing_mode(None, false),
+            Some(AliasListingMode::Buckets)
+        );
+    }
+
+    #[test]
+    fn test_alias_listing_mode_ignores_alias_only_logic_when_bucket_is_present() {
+        let bucket = "demo".to_string();
+        assert_eq!(alias_listing_mode(Some(&bucket), false), None);
+        assert_eq!(alias_listing_mode(Some(&bucket), true), None);
     }
 }


### PR DESCRIPTION
## Summary
A recent `ls` behavior change made `rc ls <alias>/ --recursive` traverse every bucket and list objects server-wide, but that alias-only recursive branch had no direct unit coverage. That left the command selection logic unguarded even though it changed user-visible behavior.

## User Impact
If that branch regresses, `ls alias/ -r` can silently fall back to bucket listing instead of object listing. Users would still get successful output, but it would be the wrong mode and the regression would be easy to miss.

## Root Cause
The branch that distinguishes alias-only bucket listing from alias-only recursive object listing lived inline inside `execute`, so the changed path was only indirectly exercised. Existing tests covered path parsing, but not the mode decision introduced by the recent `-r` behavior change.

## Fix
This PR extracts the alias-only listing decision into a small `alias_listing_mode` helper and adds focused unit tests for the three relevant cases:

- alias-only path with `--recursive` selects all-object listing
- alias-only path without `--recursive` selects bucket listing
- bucket-qualified paths bypass the alias-only branch entirely

The implementation behavior is unchanged; the refactor is only there to make the recent branch testable and keep the scope tight to the changed area.

## Validation
I ran the required checks locally:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
