### PR TITLE
test(cli): cover cors parser edge cases

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -621,6 +621,28 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_cors_configuration_drops_blank_optional_headers() {
+        let config = parse_cors_configuration(
+            r#"{
+                "rules": [
+                    {
+                        "allowedOrigins": ["https://app.example.com"],
+                        "allowedMethods": ["get"],
+                        "allowedHeaders": ["   "],
+                        "exposeHeaders": ["", "   "]
+                    }
+                ]
+            }"#,
+        )
+        .expect("parse config with blank optional headers");
+
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].allowed_headers, None);
+        assert_eq!(config.rules[0].expose_headers, None);
+        assert_eq!(config.rules[0].allowed_methods, vec!["GET".to_string()]);
+    }
+
+    #[test]
     fn test_cors_input_source_prefers_positional_argument() {
         let args = SetCorsArgs {
             path: "local/my-bucket".to_string(),
@@ -642,6 +664,18 @@ mod tests {
         };
 
         assert_eq!(cors_input_source(&args).as_deref(), Ok("cors.json"));
+    }
+
+    #[test]
+    fn test_cors_input_source_rejects_conflicting_inputs() {
+        let args = SetCorsArgs {
+            path: "local/my-bucket".to_string(),
+            source: Some("cors.xml".to_string()),
+            file: Some("cors.json".to_string()),
+            force: false,
+        };
+
+        assert!(cors_input_source(&args).is_err());
     }
 
     #[test]

--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -589,6 +589,40 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_cors_configuration_rejects_empty_allowed_origin() {
+        let error = parse_cors_configuration(
+            r#"{
+                "rules": [
+                    {
+                        "allowedOrigins": [" https://app.example.com ", "   "],
+                        "allowedMethods": ["GET"]
+                    }
+                ]
+            }"#,
+        )
+        .expect_err("empty allowed origin");
+
+        assert!(error.contains("empty allowed origin"));
+    }
+
+    #[test]
+    fn test_parse_cors_configuration_rejects_empty_allowed_method() {
+        let error = parse_cors_configuration(
+            r#"{
+                "rules": [
+                    {
+                        "allowedOrigins": ["*"],
+                        "allowedMethods": ["GET", " "]
+                    }
+                ]
+            }"#,
+        )
+        .expect_err("empty allowed method");
+
+        assert!(error.contains("empty allowed method"));
+    }
+
+    #[test]
     fn test_parse_cors_configuration_accepts_xml() {
         let config = parse_cors_configuration(
             r#"


### PR DESCRIPTION
## Summary
This change adds focused regression coverage for two untested helper paths in the new bucket CORS command parser. The new tests confirm that blank optional header lists are normalized away during JSON parsing and that conflicting input-source arguments are rejected consistently at the helper layer.

## Background
Bucket CORS support was added recently, and the first pass included solid happy-path coverage for command parsing and CORS document normalization. A few narrow branches in the helper logic were still untested, which left low-level behavior around source selection and optional-field cleanup dependent on manual reasoning instead of executable checks.

## Root Cause
The CORS parser tests covered successful JSON/XML parsing, invalid methods, and missing sources, but they did not exercise the branch that rejects simultaneous positional and `--file` inputs or the branch that collapses whitespace-only optional header collections to `None`.

## Solution
I added two targeted unit tests in `crates/cli/src/commands/cors.rs`:

- verify `parse_cors_configuration` drops blank `allowedHeaders` and `exposeHeaders` entries while still normalizing method case
- verify `cors_input_source` rejects conflicting positional and `--file` inputs

The implementation is unchanged; this PR only tightens regression coverage for the newly added CORS command helpers.

## Validation
I attempted `make pre-commit`, but this repository currently has no `pre-commit` make target.

I then ran the equivalent required checks directly:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
