### PR TITLE
fix(cli): reject empty normalized bucket path in cors

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -377,10 +377,12 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
         return Err("Bucket path must be in format alias/bucket".to_string());
     }
 
-    Ok((
-        parts[0].to_string(),
-        parts[1].trim_end_matches('/').to_string(),
-    ))
+    let bucket = parts[1].trim_end_matches('/');
+    if bucket.is_empty() {
+        return Err("Bucket path must be in format alias/bucket".to_string());
+    }
+
+    Ok((parts[0].to_string(), bucket.to_string()))
 }
 
 fn parse_cors_configuration(contents: &str) -> Result<CorsConfiguration, String> {
@@ -531,6 +533,7 @@ mod tests {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
+        assert!(parse_bucket_path("local///").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The new bucket CORS commands accept paths in the `alias/bucket` form and normalize trailing slashes before talking to the backend. One untested edge case was `alias///`: after normalization, the bucket segment becomes empty, but the parser still returned success. That leaves the command flow treating an invalid path as a real bucket name.

## Root Cause
`parse_bucket_path` only checked whether the raw suffix after the first slash was non-empty. It did not re-check the bucket segment after trimming trailing slashes, so inputs made entirely of slashes slipped through as an empty bucket.

## Fix
This change trims trailing slashes first and rejects the path when the normalized bucket name is empty. A focused regression test now covers `local///` to lock the behavior down.

## Validation
I could not run `make pre-commit` because this repository does not define that target or a `Makefile`. I ran the equivalent required checks from [`AGENTS.md`](/Users/overtrue/.codex/worktrees/4c1e/cli/AGENTS.md):

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
