### PR TITLE
feat(rm): add purge support for force delete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -385,23 +395,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e62db736db19c488966c8d787f52e6270be565727236fd5579eaa301e7bc4a"
 dependencies = [
  "aws-smithy-async",
+ "aws-smithy-protocol-test",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
+ "bytes",
  "h2 0.3.27",
  "h2 0.4.13",
  "http 0.2.12",
  "http 1.4.0",
  "http-body 0.4.6",
+ "http-body 1.0.1",
  "hyper 0.14.32",
  "hyper 1.8.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.7",
  "hyper-util",
+ "indexmap",
  "pin-project-lite",
  "rustls 0.21.12",
  "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
+ "serde",
+ "serde_json",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower",
@@ -424,6 +440,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f616c3f2260612fe44cede278bafa18e73e6479c4e393e2c4518cf2a9a228a"
 dependencies = [
  "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-protocol-test"
+version = "0.63.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01317a9e3c5c06f1af35001ef0c873c1e34e458c20b2ee1eee0fb431e6dbb010"
+dependencies = [
+ "assert-json-diff",
+ "aws-smithy-runtime-api",
+ "base64-simd",
+ "cbor-diag",
+ "ciborium",
+ "http 0.2.12",
+ "pretty_assertions",
+ "regex-lite",
+ "roxmltree",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -570,6 +605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +633,25 @@ checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
 dependencies = [
  "bytes",
  "either",
+]
+
+[[package]]
+name = "cbor-diag"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc245b6ecd09b23901a4fbad1ad975701fd5061ceaef6afa93a2d70605a64429"
+dependencies = [
+ "bs58",
+ "chrono",
+ "data-encoding",
+ "half",
+ "nom",
+ "num-bigint",
+ "num-rational",
+ "num-traits",
+ "separator",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -614,6 +677,42 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -807,6 +906,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-bigint"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,6 +944,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
 name = "der"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +967,12 @@ checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1218,6 +1335,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1672,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1779,6 +1909,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,12 +1952,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1836,6 +1992,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2006,6 +2173,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2340,7 @@ dependencies = [
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-sigv4",
+ "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
@@ -2302,6 +2480,15 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "921904a62e410e37e215c40381b7117f830d9d89ba60ab5236170541dd25646b"
+dependencies = [
+ "xmlparser",
 ]
 
 [[package]]
@@ -2513,6 +2700,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
+name = "separator"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f97841a747eef040fcd2e7b3b9a220a7205926e60488e673d9e4926d27772ce5"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,6 +2741,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",
@@ -3472,6 +3666,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/crates/cli/src/commands/rm.rs
+++ b/crates/cli/src/commands/rm.rs
@@ -4,7 +4,7 @@
 
 use clap::Args;
 use rc_core::{AliasManager, ListOptions, ObjectStore as _, RemotePath};
-use rc_s3::S3Client;
+use rc_s3::{DeleteRequestOptions, S3Client};
 use serde::Serialize;
 
 use crate::exit_code::ExitCode;
@@ -47,6 +47,10 @@ pub struct RmArgs {
     /// Bypass governance retention
     #[arg(long)]
     pub bypass: bool,
+
+    /// Permanently delete objects using the RustFS force-delete header
+    #[arg(long)]
+    pub purge: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -186,7 +190,10 @@ async fn delete_single(
         return Ok(vec![full_path]);
     }
 
-    match client.delete_object(&path).await {
+    match client
+        .delete_object_with_options(&path, delete_request_options(args))
+        .await
+    {
         Ok(()) => {
             if !formatter.is_json() {
                 let styled_path = formatter.style_file(&full_path);
@@ -307,7 +314,10 @@ async fn delete_recursive(
     for chunk in keys_to_delete.chunks(1000) {
         let chunk_keys: Vec<String> = chunk.to_vec();
 
-        match client.delete_objects(bucket, chunk_keys.clone()).await {
+        match client
+            .delete_objects_with_options(bucket, chunk_keys.clone(), delete_request_options(args))
+            .await
+        {
             Ok(deleted_keys) => {
                 for key in &deleted_keys {
                     let full_path = format!("{alias_name}/{bucket}/{key}");
@@ -366,6 +376,12 @@ fn parse_rm_path(path: &str) -> Result<(String, String, String), String> {
     Ok((alias, bucket, key))
 }
 
+fn delete_request_options(args: &RmArgs) -> DeleteRequestOptions {
+    DeleteRequestOptions {
+        force_delete: args.purge,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -402,5 +418,22 @@ mod tests {
     #[test]
     fn test_parse_rm_path_empty() {
         assert!(parse_rm_path("").is_err());
+    }
+
+    #[test]
+    fn test_delete_request_options_enable_force_delete_for_purge() {
+        let args = RmArgs {
+            paths: vec!["test/bucket/object.txt".to_string()],
+            recursive: false,
+            force: false,
+            dry_run: false,
+            incomplete: false,
+            versions: false,
+            bypass: false,
+            purge: true,
+        };
+
+        let options = delete_request_options(&args);
+        assert!(options.force_delete);
     }
 }

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -2375,6 +2375,181 @@ mod version_operations {
         // Cleanup
         cleanup_bucket(config_dir.path(), &bucket_name);
     }
+
+    #[test]
+    fn test_rm_purge_permanently_deletes_versioned_object() {
+        let (config_dir, bucket_name) = match setup_with_alias("rmpurge") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        let enable_output = run_rc(
+            &[
+                "version",
+                "enable",
+                &format!("test/{}", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        if !enable_output.status.success() {
+            eprintln!(
+                "Enable versioning not supported: {}",
+                String::from_utf8_lossy(&enable_output.stderr)
+            );
+            cleanup_bucket(config_dir.path(), &bucket_name);
+            return;
+        }
+
+        let temp_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
+        std::fs::write(temp_file.path(), "versioned delete content").expect("Failed to write");
+
+        let normal_key = "normal-delete.txt";
+        let purge_key = "purge-delete.txt";
+
+        let upload_output = run_rc(
+            &[
+                "cp",
+                temp_file
+                    .path()
+                    .to_str()
+                    .expect("Temp file path should be UTF-8"),
+                &format!("test/{}/{}", bucket_name, normal_key),
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            upload_output.status.success(),
+            "Failed to upload normal delete object: {}",
+            String::from_utf8_lossy(&upload_output.stderr)
+        );
+
+        let delete_output = run_rc(
+            &[
+                "rm",
+                &format!("test/{}/{}", bucket_name, normal_key),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            delete_output.status.success(),
+            "Failed to delete versioned object: {}",
+            String::from_utf8_lossy(&delete_output.stderr)
+        );
+
+        let normal_versions_output = run_rc(
+            &[
+                "version",
+                "list",
+                &format!("test/{}/{}", bucket_name, normal_key),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            normal_versions_output.status.success(),
+            "Failed to list versions after normal rm: {}",
+            String::from_utf8_lossy(&normal_versions_output.stderr)
+        );
+
+        let normal_stdout = String::from_utf8_lossy(&normal_versions_output.stdout);
+        let normal_versions: serde_json::Value =
+            serde_json::from_str(&normal_stdout).expect("Invalid JSON version list");
+        let normal_versions = normal_versions
+            .as_array()
+            .expect("Version list should be a JSON array");
+        assert_eq!(
+            normal_versions.len(),
+            2,
+            "Expected one object version plus one delete marker after normal rm"
+        );
+        assert!(
+            normal_versions.iter().any(|entry| {
+                entry["is_delete_marker"].as_bool() == Some(true)
+                    && entry["is_latest"].as_bool() == Some(true)
+            }),
+            "Expected latest version to be a delete marker after normal rm"
+        );
+
+        let purge_upload_output = run_rc(
+            &[
+                "cp",
+                temp_file
+                    .path()
+                    .to_str()
+                    .expect("Temp file path should be UTF-8"),
+                &format!("test/{}/{}", bucket_name, purge_key),
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            purge_upload_output.status.success(),
+            "Failed to upload purge delete object: {}",
+            String::from_utf8_lossy(&purge_upload_output.stderr)
+        );
+
+        let purge_delete_output = run_rc(
+            &[
+                "rm",
+                &format!("test/{}/{}", bucket_name, purge_key),
+                "--purge",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            purge_delete_output.status.success(),
+            "Failed to purge versioned object: {}",
+            String::from_utf8_lossy(&purge_delete_output.stderr)
+        );
+
+        let purge_versions_output = run_rc(
+            &[
+                "version",
+                "list",
+                &format!("test/{}/{}", bucket_name, purge_key),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            purge_versions_output.status.success(),
+            "Failed to list versions after purge rm: {}",
+            String::from_utf8_lossy(&purge_versions_output.stderr)
+        );
+
+        let purge_stdout = String::from_utf8_lossy(&purge_versions_output.stdout);
+        let purge_versions: serde_json::Value =
+            serde_json::from_str(&purge_stdout).expect("Invalid JSON version list");
+        let purge_versions = purge_versions
+            .as_array()
+            .expect("Version list should be a JSON array");
+        assert!(
+            purge_versions.is_empty(),
+            "Expected purge rm to permanently remove all versions"
+        );
+
+        let normal_cleanup_output = run_rc(
+            &[
+                "rm",
+                &format!("test/{}/{}", bucket_name, normal_key),
+                "--purge",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            normal_cleanup_output.status.success(),
+            "Failed to purge cleanup object: {}",
+            String::from_utf8_lossy(&normal_cleanup_output.stderr)
+        );
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
 }
 
 mod tag_operations {

--- a/crates/s3/Cargo.toml
+++ b/crates/s3/Cargo.toml
@@ -53,5 +53,6 @@ serde_json.workspace = true
 quick-xml.workspace = true
 
 [dev-dependencies]
+aws-smithy-http-client = { version = "1.1.5", features = ["test-util"] }
 tempfile.workspace = true
 mockall.workspace = true

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -37,6 +37,7 @@ use tokio::io::AsyncReadExt;
 const SINGLE_PUT_OBJECT_MAX_SIZE: u64 = crate::multipart::DEFAULT_PART_SIZE;
 const S3_SERVICE_NAME: &str = "s3";
 const S3_REPLICATION_XML_NAMESPACE: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
+const RUSTFS_FORCE_DELETE_HEADER: &str = "x-rustfs-force-delete";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BucketPolicyErrorKind {
@@ -651,6 +652,13 @@ pub struct S3Client {
     alias: Alias,
 }
 
+/// Request-level options for delete operations.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DeleteRequestOptions {
+    /// Ask RustFS to permanently delete data instead of creating delete markers.
+    pub force_delete: bool,
+}
+
 impl S3Client {
     /// Create a new S3 client from an alias configuration
     pub async fn new(alias: Alias) -> Result<Self> {
@@ -711,6 +719,104 @@ impl S3Client {
     /// Get the underlying aws-sdk-s3 client
     pub fn inner(&self) -> &aws_sdk_s3::Client {
         &self.inner
+    }
+
+    /// Delete an object with RustFS-specific request options.
+    pub async fn delete_object_with_options(
+        &self,
+        path: &RemotePath,
+        options: DeleteRequestOptions,
+    ) -> Result<()> {
+        let mut request = self
+            .inner
+            .delete_object()
+            .bucket(&path.bucket)
+            .key(&path.key)
+            .customize();
+
+        if options.force_delete {
+            request = request.mutate_request(|request| {
+                request
+                    .headers_mut()
+                    .insert(RUSTFS_FORCE_DELETE_HEADER, "true");
+            });
+        }
+
+        request.send().await.map_err(|e| {
+            let err_str = e.to_string();
+            if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
+                Error::NotFound(path.to_string())
+            } else {
+                Error::Network(err_str)
+            }
+        })?;
+
+        Ok(())
+    }
+
+    /// Delete multiple objects with RustFS-specific request options.
+    pub async fn delete_objects_with_options(
+        &self,
+        bucket: &str,
+        keys: Vec<String>,
+        options: DeleteRequestOptions,
+    ) -> Result<Vec<String>> {
+        use aws_sdk_s3::types::{Delete, ObjectIdentifier};
+
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let objects: Vec<ObjectIdentifier> =
+            keys.iter()
+                .map(|key| {
+                    ObjectIdentifier::builder().key(key).build().map_err(|e| {
+                        Error::General(format!("invalid delete object identifier: {e}"))
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+        let delete = Delete::builder()
+            .set_objects(Some(objects))
+            .build()
+            .map_err(|e| Error::General(e.to_string()))?;
+
+        let mut request = self
+            .inner
+            .delete_objects()
+            .bucket(bucket)
+            .delete(delete)
+            .customize();
+
+        if options.force_delete {
+            request = request.mutate_request(|request| {
+                request
+                    .headers_mut()
+                    .insert(RUSTFS_FORCE_DELETE_HEADER, "true");
+            });
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| Error::Network(e.to_string()))?;
+
+        let deleted: Vec<String> = response
+            .deleted()
+            .iter()
+            .filter_map(|d| d.key().map(|k| k.to_string()))
+            .collect();
+
+        if !response.errors().is_empty() {
+            let error_keys: Vec<String> = response
+                .errors()
+                .iter()
+                .filter_map(|e| e.key().map(|k| k.to_string()))
+                .collect();
+            tracing::warn!("Failed to delete some objects: {:?}", error_keys);
+        }
+
+        Ok(deleted)
     }
 
     /// Format AWS SDK error into a detailed error message
@@ -1636,68 +1742,13 @@ impl ObjectStore for S3Client {
     }
 
     async fn delete_object(&self, path: &RemotePath) -> Result<()> {
-        self.inner
-            .delete_object()
-            .bucket(&path.bucket)
-            .key(&path.key)
-            .send()
+        self.delete_object_with_options(path, DeleteRequestOptions::default())
             .await
-            .map_err(|e| {
-                let err_str = e.to_string();
-                if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
-                    Error::NotFound(path.to_string())
-                } else {
-                    Error::Network(err_str)
-                }
-            })?;
-
-        Ok(())
     }
 
     async fn delete_objects(&self, bucket: &str, keys: Vec<String>) -> Result<Vec<String>> {
-        use aws_sdk_s3::types::{Delete, ObjectIdentifier};
-
-        if keys.is_empty() {
-            return Ok(vec![]);
-        }
-
-        let objects: Vec<ObjectIdentifier> = keys
-            .iter()
-            .map(|k| ObjectIdentifier::builder().key(k).build().unwrap())
-            .collect();
-
-        let delete = Delete::builder()
-            .set_objects(Some(objects))
-            .build()
-            .map_err(|e| Error::General(e.to_string()))?;
-
-        let response = self
-            .inner
-            .delete_objects()
-            .bucket(bucket)
-            .delete(delete)
-            .send()
+        self.delete_objects_with_options(bucket, keys, DeleteRequestOptions::default())
             .await
-            .map_err(|e| Error::Network(e.to_string()))?;
-
-        // Collect deleted keys
-        let deleted: Vec<String> = response
-            .deleted()
-            .iter()
-            .filter_map(|d| d.key().map(|k| k.to_string()))
-            .collect();
-
-        // Check for errors
-        if !response.errors().is_empty() {
-            let error_keys: Vec<String> = response
-                .errors()
-                .iter()
-                .filter_map(|e| e.key().map(|k| k.to_string()))
-                .collect();
-            tracing::warn!("Failed to delete some objects: {:?}", error_keys);
-        }
-
-        Ok(deleted)
     }
 
     async fn copy_object(&self, src: &RemotePath, dst: &RemotePath) -> Result<ObjectInfo> {
@@ -2618,7 +2669,38 @@ impl ObjectStore for S3Client {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_smithy_http_client::test_util::{CaptureRequestReceiver, capture_request};
     use std::collections::HashMap;
+
+    fn test_s3_client(
+        response: Option<http::Response<SdkBody>>,
+    ) -> (S3Client, CaptureRequestReceiver) {
+        let (http_client, request_receiver) = capture_request(response);
+        let credentials = Credentials::new(
+            "access-key",
+            "secret-key",
+            None,
+            None,
+            "rc-test-credentials",
+        );
+        let config = aws_sdk_s3::config::Builder::new()
+            .credentials_provider(credentials)
+            .endpoint_url("https://example.com")
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .force_path_style(true)
+            .behavior_version_latest()
+            .http_client(http_client)
+            .build();
+
+        let alias = Alias::new("test", "https://example.com", "access-key", "secret-key");
+        let client = S3Client {
+            inner: aws_sdk_s3::Client::from_conf(config),
+            xml_http_client: reqwest::Client::new(),
+            alias,
+        };
+
+        (client, request_receiver)
+    }
 
     #[test]
     fn test_object_info_creation() {
@@ -3062,6 +3144,55 @@ mod tests {
             crate::multipart::DEFAULT_PART_SIZE
         ));
         assert!(!S3Client::should_use_multipart(SINGLE_PUT_OBJECT_MAX_SIZE));
+    }
+
+    #[tokio::test]
+    async fn delete_object_with_force_delete_sets_rustfs_header() {
+        let (client, request_receiver) = test_s3_client(None);
+        let path = RemotePath::new("test", "bucket", "key.txt");
+
+        let _ = client
+            .delete_object_with_options(&path, DeleteRequestOptions { force_delete: true })
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.headers().get("x-rustfs-force-delete"), Some("true"));
+    }
+
+    #[tokio::test]
+    async fn delete_object_without_force_delete_omits_rustfs_header() {
+        let (client, request_receiver) = test_s3_client(None);
+        let path = RemotePath::new("test", "bucket", "key.txt");
+
+        let _ = client
+            .delete_object_with_options(&path, DeleteRequestOptions::default())
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_objects_with_force_delete_sets_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["key.txt".to_string()],
+                DeleteRequestOptions { force_delete: true },
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.headers().get("x-rustfs-force-delete"), Some("true"));
     }
 
     #[tokio::test]

--- a/crates/s3/src/lib.rs
+++ b/crates/s3/src/lib.rs
@@ -10,5 +10,5 @@ pub mod client;
 pub mod multipart;
 
 pub use admin::AdminClient;
-pub use client::S3Client;
+pub use client::{DeleteRequestOptions, S3Client};
 pub use multipart::{MultipartConfig, UploadState};


### PR DESCRIPTION
## Summary
- add a `rm --purge` flag that sends the RustFS force-delete header for single-object and recursive deletes
- add purge-aware delete helpers in the S3 adapter and cover the request header behavior with unit tests
- add an integration test that verifies normal deletes leave a delete marker while `--purge` permanently removes versioned objects

## Background
RustFS already supports permanent deletion through the `x-rustfs-force-delete: true` request header, but the CLI did not expose that capability. As a result, versioned deletes always produced delete markers even when the backend could perform a permanent delete.

## Validation
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `TEST_S3_ENDPOINT=http://localhost:9000 TEST_S3_ACCESS_KEY=accesskey TEST_S3_SECRET_KEY=secretkey cargo test --package rustfs-cli --test integration --features integration version_operations::test_rm_purge_permanently_deletes_versioned_object -- --exact --nocapture`