### PR TITLE
test(s3): cover delete option defaults

### DIFF
--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -2515,6 +2515,7 @@ mod version_operations {
         std::fs::write(temp_file.path(), "versioned delete content").expect("Failed to write");
 
         let normal_key = "normal-delete.txt";
+        let force_key = "force-delete.txt";
         let purge_key = "purge-delete.txt";
 
         let upload_output = run_rc(
@@ -2580,6 +2581,72 @@ mod version_operations {
                     && entry["is_latest"].as_bool() == Some(true)
             }),
             "Expected latest version to be a delete marker after normal rm"
+        );
+
+        let force_upload_output = run_rc(
+            &[
+                "cp",
+                temp_file
+                    .path()
+                    .to_str()
+                    .expect("Temp file path should be UTF-8"),
+                &format!("test/{}/{}", bucket_name, force_key),
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            force_upload_output.status.success(),
+            "Failed to upload force delete object: {}",
+            String::from_utf8_lossy(&force_upload_output.stderr)
+        );
+
+        let force_delete_output = run_rc(
+            &[
+                "rm",
+                &format!("test/{}/{}", bucket_name, force_key),
+                "--force",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            force_delete_output.status.success(),
+            "Failed to force delete versioned object: {}",
+            String::from_utf8_lossy(&force_delete_output.stderr)
+        );
+
+        let force_versions_output = run_rc(
+            &[
+                "version",
+                "list",
+                &format!("test/{}/{}", bucket_name, force_key),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            force_versions_output.status.success(),
+            "Failed to list versions after force rm: {}",
+            String::from_utf8_lossy(&force_versions_output.stderr)
+        );
+
+        let force_stdout = String::from_utf8_lossy(&force_versions_output.stdout);
+        let force_versions: serde_json::Value =
+            serde_json::from_str(&force_stdout).expect("Invalid JSON version list");
+        let force_versions = force_versions
+            .as_array()
+            .expect("Version list should be a JSON array");
+        assert_eq!(
+            force_versions.len(),
+            2,
+            "Expected --force rm to keep the object version and create a delete marker"
+        );
+        assert!(
+            force_versions.iter().any(|entry| {
+                entry["is_delete_marker"].as_bool() == Some(true)
+                    && entry["is_latest"].as_bool() == Some(true)
+            }),
+            "Expected latest version to be a delete marker after force rm"
         );
 
         let purge_upload_output = run_rc(
@@ -2654,6 +2721,21 @@ mod version_operations {
             normal_cleanup_output.status.success(),
             "Failed to purge cleanup object: {}",
             String::from_utf8_lossy(&normal_cleanup_output.stderr)
+        );
+
+        let force_cleanup_output = run_rc(
+            &[
+                "rm",
+                &format!("test/{}/{}", bucket_name, force_key),
+                "--purge",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            force_cleanup_output.status.success(),
+            "Failed to purge force cleanup object: {}",
+            String::from_utf8_lossy(&force_cleanup_output.stderr)
         );
 
         cleanup_bucket(config_dir.path(), &bucket_name);

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3350,6 +3350,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_without_force_delete_omits_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["key.txt".to_string()],
+                DeleteRequestOptions::default(),
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
     async fn delete_objects_wrapper_uses_default_options_without_rustfs_header() {
         let response = http::Response::builder()
             .status(200)
@@ -3364,6 +3387,19 @@ mod tests {
 
         let request = request_receiver.expect_request();
         assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_objects_with_empty_keys_skips_http_request() {
+        let (client, request_receiver) = test_s3_client(None);
+
+        let deleted = client
+            .delete_objects_with_options("bucket", Vec::new(), DeleteRequestOptions::default())
+            .await
+            .expect("empty delete should succeed");
+
+        assert!(deleted.is_empty());
+        request_receiver.expect_no_request();
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
Recent `rm --purge` work added RustFS-specific delete request options, and the follow-up test PR already covered the S3 client defaults for batch deletes. One command-layer behavior was still untested: ordinary `rm --force` should not silently enable RustFS permanent deletion unless `--purge` is explicitly set.

## Root Cause
The CLI wiring introduced `DeleteRequestOptions` and mapped `--purge` into `force_delete`, but the unit tests only asserted the positive `purge = true` path. That left a regression window where a future refactor could accidentally treat the long-standing `--force` flag as a permanent-delete signal.

## Fix
This PR now covers both sides of the option mapping:
- `purge = true` enables `force_delete`
- `force = true` with `purge = false` keeps `force_delete` disabled

The production code is unchanged. The diff stays limited to focused tests around the recent delete-option work.

## Validation
This checkout does not define a `make pre-commit` target, so I ran the repository's required Rust validation commands directly instead:
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
