### PR TITLE
test(s3): cover batch delete force-delete header omission

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3196,6 +3196,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_without_force_delete_omits_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["key.txt".to_string()],
+                DeleteRequestOptions::default(),
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
A recent force-delete change added RustFS-specific header handling for both single-object and batch-object deletes. The batch path already had a positive test for `force_delete = true`, but it did not verify the default path where the header must be omitted. That left room for a regression where ordinary batch deletes could start sending the RustFS purge header unintentionally.

This change adds a focused unit test in `crates/s3/src/client.rs` that exercises `delete_objects_with_options` with `DeleteRequestOptions::default()` and asserts that `x-rustfs-force-delete` is absent from the outgoing request. The scope stays limited to the recently changed codepath and does not alter production behavior.

## Root Cause
The recent test coverage around force-delete support validated the enabled branch for batch deletes and both enabled and disabled branches for single-object deletes. The disabled branch for batch deletes was left uncovered.

## Validation
The repository does not currently define a `make pre-commit` target, so I ran the CI-equivalent checks directly:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

I also ran the focused regression check:

- `cargo test -p rc-s3 delete_objects_ -- --nocapture`
