### PR TITLE
test(cli): cover rm purge help output

### DIFF
--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -238,6 +238,7 @@ fn top_level_command_help_contract() {
             expected_tokens: &[
                 "--recursive",
                 "--force",
+                "--purge",
                 "--dry-run",
                 "--incomplete",
                 "--versions",


### PR DESCRIPTION
## Summary
The recent `rm --purge` addition introduced a new user-facing flag, but the CLI help contract did not assert that the flag remained discoverable. That left a small regression window where the option could disappear from `rc rm --help` without a focused test catching it.

This change adds a single help-contract assertion in `crates/cli/tests/help_contract.rs` so `rc rm --help` must continue to include `--purge`. The scope stays limited to the recently changed `rm` surface and does not alter production behavior.

## Root Cause
PR #82 added the `--purge` flag to the command implementation, but the help contract for `rm` still only checked the older options. The command behavior was tested, while the public discoverability contract for the new flag was not.

## Validation
This repository does not currently provide a `make pre-commit` target, so I ran the equivalent required checks directly:

- `cargo test --test help_contract top_level_command_help_contract -- --exact`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
