### PR TITLE
test(s3): skip request for empty delete batch

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3196,6 +3196,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_with_empty_keys_skips_request() {
+        let (client, request_receiver) = test_s3_client(None);
+
+        let deleted = client
+            .delete_objects_with_options("bucket", Vec::new(), DeleteRequestOptions::default())
+            .await
+            .expect("empty delete batch should succeed");
+
+        assert!(deleted.is_empty());
+        request_receiver.expect_no_request();
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
A recent delete-options refactor introduced an early return in `delete_objects_with_options` for empty batches. That branch is important because recursive delete flows can legally produce no keys after listing, and the client should return success locally instead of attempting an unnecessary S3 request.

This change adds one focused unit test in `crates/s3/src/client.rs` that calls `delete_objects_with_options` with an empty key list, asserts the returned deleted list is empty, and verifies that no HTTP request is emitted through the capture client. Production code is unchanged.

## Root Cause
The recent `rm --purge` work added targeted coverage for header handling on delete requests, but it did not cover the new no-op branch inside the batch delete helper. That left a regression window where a future refactor could accidentally send an empty delete request even when the function is supposed to short-circuit.

## Validation
I attempted to run `make pre-commit`, but this repository does not define that target in the current checkout (`make: *** No rule to make target 'pre-commit'.  Stop.`). I then ran the repository's required validation commands directly:

- `cargo test -p rc-s3 delete_objects_with_empty_keys_skips_request`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
