### PR TITLE
test(cli): cover cors help discoverability

### DIFF
--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -123,6 +123,7 @@ fn top_level_command_help_contract() {
                 "share",
                 "version",
                 "tag",
+                "cors",
                 "quota",
                 "anonymous",
                 "ilm",
@@ -303,6 +304,11 @@ fn top_level_command_help_contract() {
             expected_tokens: &["list", "set", "remove"],
         },
         HelpCase {
+            args: &["cors"],
+            usage: "Usage: rc cors [OPTIONS] <COMMAND>",
+            expected_tokens: &["Deprecated: use `rc bucket cors`", "list", "set", "remove"],
+        },
+        HelpCase {
             args: &["quota"],
             usage: "Usage: rc quota [OPTIONS] <COMMAND>",
             expected_tokens: &["set", "info", "clear"],
@@ -435,6 +441,11 @@ fn nested_subcommand_help_contract() {
                 "Examples:",
                 "rc bucket event add local/my-bucket arn:aws:sqs:us-east-1:123456789012:jobs --event put",
             ],
+        },
+        HelpCase {
+            args: &["bucket", "cors"],
+            usage: "Usage: rc bucket cors [OPTIONS] <COMMAND>",
+            expected_tokens: &["list", "set", "remove"],
         },
         HelpCase {
             args: &["object", "copy"],


### PR DESCRIPTION
## Summary
The recent bucket CORS feature added two new discoverability surfaces: the deprecated top-level `rc cors` command and the nested `rc bucket cors` command group. Both command paths were covered by parser tests, but the CLI help contract did not assert that they remained visible in `--help` output.

This PR adds focused help-contract coverage in `crates/cli/tests/help_contract.rs` for those recent command surfaces. The top-level command help now must continue to list `cors` and show its deprecation guidance, and the nested `bucket cors` help now must continue to advertise the expected `list`, `set`, and `remove` subcommands.

## Root Cause
The original feature implementation verified command parsing and some option-level behavior, but it did not add help-contract assertions for the new command entry points. That left a small regression window where future Clap wiring changes could make the commands harder to discover without failing tests.

## Validation
I attempted to run `make pre-commit`, but this checkout does not define that target:

- `make pre-commit` -> `make: *** No rule to make target \`pre-commit'.  Stop.`

I then ran the repository's required checks directly:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also ran the focused help-contract checks while iterating on the assertions:

- `cargo test --test help_contract top_level_command_help_contract -- --exact`
- `cargo test --test help_contract nested_subcommand_help_contract -- --exact`
