### PR TITLE
test(cli): cover malformed cors bucket paths

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -378,7 +378,7 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
     }
 
     let bucket = parts[1].trim_end_matches('/');
-    if bucket.is_empty() {
+    if bucket.is_empty() || bucket.contains('/') {
         return Err("Bucket path must be in format alias/bucket".to_string());
     }
 
@@ -533,6 +533,8 @@ mod tests {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
+        assert!(parse_bucket_path("local//bucket").is_err());
+        assert!(parse_bucket_path("local/my-bucket/nested").is_err());
         assert!(parse_bucket_path("local///").is_err());
     }
 


### PR DESCRIPTION
## Summary
This change closes a small test gap in the recent bucket CORS path validation work. The CORS parser normalized a trailing slash, but it still accepted malformed bucket paths such as `alias//bucket` and `alias/bucket/nested`, which do not match the documented `alias/bucket` contract.

## Root cause
`parse_bucket_path` only rejected an empty normalized bucket segment. Any remaining slash inside the bucket portion survived validation and was treated as part of the bucket name.

## Fix
The parser now rejects normalized bucket segments that still contain `/`, and the existing error-path unit test now covers both malformed inputs.

## Validation
I attempted `make pre-commit` first, but this repository does not define that target or a Makefile. I then ran the documented equivalent checks directly:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
