### PR TITLE
test(cli): cover cors source file reads

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -726,4 +726,34 @@ mod tests {
 
         assert!(cors_input_source(&args).is_err());
     }
+
+    #[tokio::test]
+    async fn test_read_cors_source_reads_file_contents() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let source_path = temp_dir.path().join("cors.json");
+        tokio::fs::write(
+            &source_path,
+            r#"{"rules":[{"allowedOrigins":["*"],"allowedMethods":["GET"]}]}"#,
+        )
+        .await
+        .expect("write cors source");
+
+        let contents = read_cors_source(source_path.to_str().expect("utf-8 path"))
+            .await
+            .expect("read cors source");
+
+        assert!(contents.contains("\"allowedOrigins\":[\"*\"]"));
+    }
+
+    #[tokio::test]
+    async fn test_read_cors_source_missing_file_returns_error() {
+        let temp_dir = tempfile::tempdir().expect("create temp dir");
+        let missing_path = temp_dir.path().join("missing-cors.json");
+
+        let error = read_cors_source(missing_path.to_str().expect("utf-8 path"))
+            .await
+            .expect_err("missing source should fail");
+
+        assert!(!error.is_empty());
+    }
 }


### PR DESCRIPTION
## Summary
This change closes a small test gap in the recent bucket CORS command work. The `cors set` flow added support for loading configuration from a file path or from standard input, but the helper responsible for reading those sources did not have direct unit coverage for the file-backed path.

## Problem
Recent CORS work already had parser and argument-selection tests, but it did not explicitly verify that `read_cors_source` can:
- read a valid file from disk, and
- surface an error when the requested file is missing.

That left a regression gap around the real source-loading path used by `rc bucket cors set ... <file>`.

## Fix
The PR adds two focused async tests in the existing `cors` command unit test module:
- one test writes a temporary CORS config file and verifies the helper reads it successfully;
- one test points to a missing file and verifies the helper returns an error.

The change is intentionally test-only and stays scoped to the recent CORS command implementation.

## Validation
I could not run `make pre-commit` because this repository checkout does not contain a `Makefile` or `pre-commit` target. I ran the documented Rust validation steps instead:
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
