### PR TITLE
test(cli): reject nested event bucket paths

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -382,10 +382,12 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
         return Err("Bucket path must be in format alias/bucket".to_string());
     }
 
-    Ok((
-        parts[0].to_string(),
-        parts[1].trim_end_matches('/').to_string(),
-    ))
+    let bucket = parts[1].trim_end_matches('/');
+    if bucket.is_empty() || bucket.contains('/') {
+        return Err("Bucket path must be in format alias/bucket".to_string());
+    }
+
+    Ok((parts[0].to_string(), bucket.to_string()))
 }
 
 fn parse_event_list(values: &[String]) -> Vec<String> {
@@ -477,6 +479,7 @@ mod tests {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
+        assert!(parse_bucket_path("local/my-bucket/prefix").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
The recent bucket event command accepts bucket paths that contain extra object-style segments, such as `alias/bucket/prefix`, even though this command is only valid for bucket-level targets. That left an untested parser path in a newly added command surface and could route an invalid bucket name deeper into capability checks and backend calls instead of failing fast with a usage error.

This change tightens the event bucket-path parser so it only accepts `alias/bucket` with an optional trailing slash, and it adds a focused regression test that covers the malformed nested-path input. The test fails on the previous implementation and now passes with the parser fix.

## Root Cause
The parser split the input only once on `/` and then trimmed a trailing slash, but it never rejected additional `/` characters in the bucket component. As a result, bucket-only commands could silently accept object-like paths.

## Validation
I could not run `make pre-commit` because this repository does not define a `Makefile` or `pre-commit` target. I ran the documented equivalent checks from `AGENTS.md` instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
