### PR TITLE
test(s3): cover batch delete default header path

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3196,6 +3196,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_without_force_delete_omits_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["key.txt".to_string()],
+                DeleteRequestOptions::default(),
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
This change adds a focused unit test for the recent force-delete support in the S3 client batch delete path. The feature added coverage for setting the RustFS force-delete header when `DeleteRequestOptions.force_delete` is enabled, but the default path for batched deletes still had no explicit assertion that the header stays absent.

Without this test, a future refactor could accidentally send `x-rustfs-force-delete: true` on ordinary batched deletes and silently change deletion semantics for users who did not request purge behavior.

The fix is intentionally narrow. It adds one unit test that exercises `delete_objects_with_options` with `DeleteRequestOptions::default()` and asserts that the request omits the RustFS force-delete header.

## Validation
I first ran the focused target that covers the new path:
- `cargo test -p rc-s3 delete_objects_without_force_delete_omits_rustfs_header`

I then ran the repository validation commands documented in `AGENTS.md`:
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also attempted the automation-requested command `make pre-commit`, but this checkout does not contain a `Makefile` or a `pre-commit` target, so the command fails structurally with `make: *** No rule to make target 'pre-commit'.  Stop.`
