### PR TITLE
test(cli): cover object remove purge help contract

### DIFF
--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -176,6 +176,21 @@ fn top_level_command_help_contract() {
             ],
         },
         HelpCase {
+            args: &["object", "remove"],
+            usage: "Usage: rc object remove [OPTIONS] <PATHS>...",
+            expected_tokens: &[
+                "--recursive",
+                "--force",
+                "--dry-run",
+                "--incomplete",
+                "--versions",
+                "--bypass",
+                "--purge",
+                "Examples:",
+                "rc object remove local/my-bucket/reports/2026-04.csv",
+            ],
+        },
+        HelpCase {
             args: &["ls"],
             usage: "Usage: rc ls [OPTIONS] <PATH>",
             expected_tokens: &["--recursive", "--versions", "--incomplete", "--summarize"],


### PR DESCRIPTION
## Summary
This change adds a focused help-contract test for the noun-first `rc object remove` command. The recent `rm --purge` work changed the shared remove argument surface, but the help-contract suite only covered the legacy `rc rm` entrypoint and did not verify that the noun-first alias exposed the same option set.

## Problem
Users can reach object deletion through both `rc rm` and `rc object remove`. Because `object remove` reuses `RmArgs`, option changes such as `--purge` should remain discoverable through both entrypoints. Without a contract test on the noun-first command, a future clap wiring or command-group change could silently drop or alter that help surface while the existing `rm` help test still passed.

## Fix
The test suite now asserts the `rc object remove --help` usage line, the inherited delete options, and a representative example. The new case includes `--purge`, which ties the test directly to the recent remove-command change while keeping the scope limited to help-contract coverage.

## Validation
I could not run `make pre-commit` because this repository does not contain a `Makefile` or a `pre-commit` target. I ran the equivalent required checks from the repository instructions instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
