### PR TITLE
test(cli): cover cors and rm help contracts

### DIFF
--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -122,6 +122,7 @@ fn top_level_command_help_contract() {
                 "tree",
                 "share",
                 "version",
+                "cors",
                 "tag",
                 "quota",
                 "anonymous",
@@ -148,6 +149,7 @@ fn top_level_command_help_contract() {
                 "create",
                 "remove",
                 "event",
+                "cors",
                 "version",
                 "quota",
                 "anonymous",
@@ -242,9 +244,15 @@ fn top_level_command_help_contract() {
                 "--incomplete",
                 "--versions",
                 "--bypass",
+                "--purge",
                 "Examples:",
                 "rc rm local/my-bucket/reports/ --recursive --dry-run",
             ],
+        },
+        HelpCase {
+            args: &["cors"],
+            usage: "Usage: rc cors [OPTIONS] <COMMAND>",
+            expected_tokens: &["Deprecated: use `rc bucket cors`", "list", "set", "remove"],
         },
         HelpCase {
             args: &["pipe"],
@@ -435,6 +443,16 @@ fn nested_subcommand_help_contract() {
                 "Examples:",
                 "rc bucket event add local/my-bucket arn:aws:sqs:us-east-1:123456789012:jobs --event put",
             ],
+        },
+        HelpCase {
+            args: &["bucket", "cors"],
+            usage: "Usage: rc bucket cors [OPTIONS] <COMMAND>",
+            expected_tokens: &["Manage bucket CORS rules", "list", "set", "remove"],
+        },
+        HelpCase {
+            args: &["bucket", "cors", "set"],
+            usage: "Usage: rc bucket cors set [OPTIONS] <PATH> [SOURCE]",
+            expected_tokens: &["--file", "--force", "read from stdin"],
         },
         HelpCase {
             args: &["object", "copy"],


### PR DESCRIPTION
## Summary
This change adds focused help-contract coverage for recent CLI surface that landed on `main` but was not yet asserted by the fast contract suite.

The gap was in recently added `cors` discoverability and the `rm --purge` option. Those paths were present in the CLI, but the contract tests did not verify that the root help, bucket help, and nested `bucket cors set` help continued to expose them. That leaves room for regressions in command discoverability without any fast test failing.

## What changed
The help contract now checks:
- top-level `rc` help lists `cors`
- `rc bucket` help lists `cors`
- `rc rm --help` exposes `--purge`
- `rc cors --help` exposes the deprecated top-level cors command surface
- `rc bucket cors --help` exposes the noun-first cors command group
- `rc bucket cors set --help` exposes its source input options

## Validation
I attempted to run `make pre-commit`, but this repository currently has no `Makefile` or `pre-commit` target. I ran the equivalent required checks directly instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
