### PR TITLE
fix(formatter): classify invalid credentials as auth errors

### DIFF
--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -521,6 +521,27 @@ mod tests {
     }
 
     #[test]
+    fn test_error_descriptor_from_message_classifies_other_auth_failures() {
+        for message in [
+            "Unauthorized request for alias 'local'",
+            "Forbidden: bucket access denied",
+            "Authentication failed for alias 'local'",
+        ] {
+            let descriptor = ErrorDescriptor::from_message(message);
+            let json = descriptor.to_json_output();
+            let details = json.details.expect("details should be present");
+
+            assert_eq!(details.error_type, "auth_error", "message: {message}");
+            assert!(!details.retryable, "message: {message}");
+            assert_eq!(
+                details.suggestion.as_deref(),
+                Some(AUTH_SUGGESTION),
+                "message: {message}"
+            );
+        }
+    }
+
+    #[test]
     fn test_error_with_suggestion_overrides_default_hint() {
         let descriptor = ErrorDescriptor::from_code(
             ExitCode::UnsupportedFeature,

--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -121,6 +121,15 @@ fn infer_error_metadata(message: &str) -> (&'static str, bool, Option<String>) {
         return ("not_found", false, Some(NOT_FOUND_SUGGESTION.to_string()));
     }
 
+    if normalized.contains("access denied")
+        || normalized.contains("unauthorized")
+        || normalized.contains("forbidden")
+        || normalized.contains("authentication")
+        || normalized.contains("credentials")
+    {
+        return ("auth_error", false, Some(AUTH_SUGGESTION.to_string()));
+    }
+
     if normalized.contains("invalid")
         || normalized.contains("cannot be empty")
         || normalized.contains("must be")
@@ -129,15 +138,6 @@ fn infer_error_metadata(message: &str) -> (&'static str, bool, Option<String>) {
         || normalized.contains("use -r/--recursive")
     {
         return ("usage_error", false, Some(USAGE_SUGGESTION.to_string()));
-    }
-
-    if normalized.contains("access denied")
-        || normalized.contains("unauthorized")
-        || normalized.contains("forbidden")
-        || normalized.contains("authentication")
-        || normalized.contains("credentials")
-    {
-        return ("auth_error", false, Some(AUTH_SUGGESTION.to_string()));
     }
 
     if normalized.contains("already exists")
@@ -507,6 +507,17 @@ mod tests {
         assert_eq!(details.error_type, "usage_error");
         assert!(!details.retryable);
         assert_eq!(details.suggestion.as_deref(), Some(USAGE_SUGGESTION));
+    }
+
+    #[test]
+    fn test_error_descriptor_from_message_prefers_auth_for_invalid_credentials() {
+        let descriptor = ErrorDescriptor::from_message("Invalid credentials for alias 'local'");
+        let json = descriptor.to_json_output();
+
+        let details = json.details.expect("details should be present");
+        assert_eq!(details.error_type, "auth_error");
+        assert!(!details.retryable);
+        assert_eq!(details.suggestion.as_deref(), Some(AUTH_SUGGESTION));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
A recent structured-error path in the formatter classified auth-related messages containing the word "invalid" as usage errors. In practice that means messages such as "Invalid credentials for alias 'local'" were surfaced as `usage_error` with the generic help suggestion instead of `auth_error` with credential guidance.

This change keeps the scope tight to the formatter logic added in the phase-3 structured-error work. It adds a focused unit test that reproduces the misclassification and reorders the inference checks so auth markers are evaluated before the broader usage matcher.

## User impact
Before this change, users who hit invalid-credential failures could get the wrong structured error type and an unhelpful recovery suggestion telling them to review command syntax. After this change, the same failure is reported as an authentication problem with the expected credential-oriented hint.

## Root cause
`infer_error_metadata` matched the generic `invalid` token before it checked for auth-related markers such as `credentials` or `authentication`. That ordering caused an auth message with both terms to be bucketed as a usage error.

## Validation
I ran:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test -p rustfs-cli output::formatter::tests`

I also attempted `make pre-commit` because the automation requested it, but this checkout does not contain a `Makefile` or a `pre-commit` target, so the documented Rust validation commands above were used instead.
