### PR TITLE
test(cli): cover top-level alias parsing

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -440,6 +440,34 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_top_level_cors_get_alias() {
+        let cli =
+            Cli::try_parse_from(["rc", "cors", "get", "local/my-bucket"]).expect("parse cors get");
+
+        match cli.command {
+            Commands::Cors(cors::CorsCommands::List(arg)) => {
+                assert_eq!(arg.path, "local/my-bucket");
+            }
+            other => panic!("expected top-level cors get alias, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_top_level_event_subcommand() {
+        let cli = Cli::try_parse_from(["rc", "event", "list", "local/my-bucket"])
+            .expect("parse top-level event");
+
+        match cli.command {
+            Commands::Event(event::EventArgs {
+                command: event::EventCommands::List(arg),
+            }) => {
+                assert_eq!(arg.path, "local/my-bucket");
+            }
+            other => panic!("expected top-level event list command, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_bucket_cors_get_alias() {
         let cli = Cli::try_parse_from(["rc", "bucket", "cors", "get", "local/my-bucket"])
             .expect("parse bucket cors get");


### PR DESCRIPTION
## Summary
This change adds focused parser coverage for deprecated top-level command aliases introduced in the recent bucket CORS and event work.

## Problem
The recent command surface expansion added deprecated top-level `rc cors` and `rc event` entry points alongside the nested `rc bucket ...` forms. Existing tests already covered the nested bucket forms and one top-level `cors remove` case, but two parser paths were still untested:

- `rc cors get <alias/bucket>` should resolve to the `List` command through the `get` alias.
- `rc event list <alias/bucket>` should continue to parse through the deprecated top-level entry point.

Without direct assertions, a future clap refactor could silently break these compatibility paths while leaving adjacent tests green.

## Fix
The patch adds two small command parser tests in `crates/cli/src/commands/mod.rs`:

- `cli_accepts_top_level_cors_get_alias`
- `cli_accepts_top_level_event_subcommand`

The production code is unchanged. The diff is intentionally limited to command-surface tests around the recently added aliases.

## Validation
`make pre-commit` is not available in this checkout because the repository does not define a `pre-commit` target.

The branch was validated with:
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
