### PR TITLE
test(cli): cover rm purge parser

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -472,4 +472,41 @@ mod tests {
             other => panic!("expected bucket command, got {:?}", other),
         }
     }
+
+    #[test]
+    fn cli_accepts_rm_purge_flag() {
+        let cli = Cli::try_parse_from(["rc", "rm", "local/my-bucket/object.txt", "--purge"])
+            .expect("parse rm purge");
+
+        match cli.command {
+            Commands::Rm(arg) => {
+                assert_eq!(arg.paths, vec!["local/my-bucket/object.txt"]);
+                assert!(arg.purge);
+            }
+            other => panic!("expected rm command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_object_remove_purge_flag() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "object",
+            "remove",
+            "local/my-bucket/object.txt",
+            "--purge",
+        ])
+        .expect("parse object remove purge");
+
+        match cli.command {
+            Commands::Object(args) => match args.command {
+                object::ObjectCommands::Remove(arg) => {
+                    assert_eq!(arg.paths, vec!["local/my-bucket/object.txt"]);
+                    assert!(arg.purge);
+                }
+                other => panic!("expected object remove command, got {:?}", other),
+            },
+            other => panic!("expected object command, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
This adds focused parser coverage for the `--purge` flag introduced on `rm`.

The recent `rm --purge` work already had behavioral coverage for the delete path and a help-contract check for flag discoverability, but the CLI parser itself still had no direct assertion that the flag is accepted through both command entrypoints that share `RmArgs`: the legacy `rc rm` form and the noun-first `rc object remove` form.

This change adds two parser tests in `crates/cli/src/commands/mod.rs` that verify both entrypoints preserve the target path and set `purge = true`. The scope stays limited to the recent `rm` change surface and does not touch production code.

## Root Cause
PR #82 wired `--purge` into `RmArgs`, but parser coverage in `commands::tests` did not exercise that new flag. That left a small regression window where clap wiring could drift for one entrypoint without a focused unit test catching it.

## Validation
`make pre-commit` is not defined in this checkout, so I ran the repository's required checks directly:

- `cargo test -p rustfs-cli purge_flag --lib`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
