### PR TITLE
test(cli): cover top-level cors set parsing

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -440,6 +440,46 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_top_level_cors_set_with_positional_source() {
+        let cli = Cli::try_parse_from(["rc", "cors", "set", "local/my-bucket", "cors.xml"])
+            .expect("parse top-level cors set with positional source");
+
+        match cli.command {
+            Commands::Cors(cors::CorsCommands::Set(arg)) => {
+                assert_eq!(arg.path, "local/my-bucket");
+                assert_eq!(arg.source.as_deref(), Some("cors.xml"));
+                assert_eq!(arg.file, None);
+                assert!(!arg.force);
+            }
+            other => panic!("expected top-level cors set command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_top_level_cors_set_with_legacy_file_flag() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "cors",
+            "set",
+            "local/my-bucket",
+            "--file",
+            "cors.json",
+            "--force",
+        ])
+        .expect("parse top-level cors set with --file");
+
+        match cli.command {
+            Commands::Cors(cors::CorsCommands::Set(arg)) => {
+                assert_eq!(arg.path, "local/my-bucket");
+                assert_eq!(arg.source, None);
+                assert_eq!(arg.file.as_deref(), Some("cors.json"));
+                assert!(arg.force);
+            }
+            other => panic!("expected top-level cors set command, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_bucket_cors_get_alias() {
         let cli = Cli::try_parse_from(["rc", "bucket", "cors", "get", "local/my-bucket"])
             .expect("parse bucket cors get");


### PR DESCRIPTION
## Summary
This change adds focused parser coverage for the deprecated top-level `rc cors set` entrypoint introduced with the recent bucket CORS management work. The current suite already covered `rc bucket cors set ...` and a few top-level `rc cors` flows, but it did not exercise the top-level `set` path itself.

The missing coverage mattered because the deprecated top-level command is still wired through Clap separately from `rc bucket cors`. A regression there would break users invoking `rc cors set` without being caught by the existing tests, even though the nested bucket command still worked.

## Root cause
The original CORS feature and follow-up tests focused on bucket-path validation, help discoverability, source reading, and a subset of command aliases. The top-level `set` parser branch, including its legacy `--file` flag wiring and `--force` propagation, was left untested.

## Fix
The test suite now verifies two narrow parser paths in [`crates/cli/src/commands/mod.rs`](https://github.com/rustfs/cli/blob/codex/top-level-cors-set-parser-gap/crates/cli/src/commands/mod.rs):

- `rc cors set local/my-bucket cors.xml`
- `rc cors set local/my-bucket --file cors.json --force`

These assertions confirm the deprecated top-level command still maps to `CorsCommands::Set`, preserves the bucket path, selects the expected source field, and forwards the `--force` flag.

## Validation
I ran the following checks successfully:

- `cargo test -p rustfs-cli cli_accepts_top_level_cors`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also attempted `make pre-commit` per automation instructions, but this repository currently has no `Makefile` or `pre-commit` target, so `make` exits with `No rule to make target 'pre-commit'.`
