### PR TITLE
test(event): reject slash-only bucket path

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -382,10 +382,12 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
         return Err("Bucket path must be in format alias/bucket".to_string());
     }
 
-    Ok((
-        parts[0].to_string(),
-        parts[1].trim_end_matches('/').to_string(),
-    ))
+    let bucket = parts[1].trim_end_matches('/');
+    if bucket.is_empty() {
+        return Err("Bucket path must be in format alias/bucket".to_string());
+    }
+
+    Ok((parts[0].to_string(), bucket.to_string()))
 }
 
 fn parse_event_list(values: &[String]) -> Vec<String> {
@@ -477,6 +479,7 @@ mod tests {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
+        assert!(parse_bucket_path("local///").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This change closes a small test gap in the recent bucket event command work. The event bucket path parser accepted inputs like `alias///`, because it trimmed trailing slashes after splitting but did not re-check whether the resulting bucket segment was still non-empty.

In practice that meant an invalid path could make it past argument parsing and fail later in a less precise code path. The `cors` command already rejects the same shape, so the event command was inconsistent with adjacent bucket command behavior.

## Root cause
`parse_bucket_path` in `crates/cli/src/commands/event.rs` only validated the raw second path segment before trimming trailing slashes. For an input such as `local///`, the pre-trim segment was non-empty, but the normalized bucket name became empty.

## Fix
The parser now trims trailing slashes into a local `bucket` variable and rejects the path when that normalized bucket value is empty. A focused unit test was added to prove that `local///` is invalid.

## Validation
I first added the new assertion and verified it failed against the current implementation with:

- `cargo test -p rustfs-cli parse_bucket_path_error -- --nocapture`

After the fix, I re-ran focused and repo-wide validation:

- `cargo test -p rustfs-cli commands::event:: -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

I also attempted `make pre-commit` per the automation constraint, but this checkout does not contain a `pre-commit` make target on `origin/main`.
