### PR TITLE
test(cli): cover object remove purge parser

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -472,4 +472,27 @@ mod tests {
             other => panic!("expected bucket command, got {:?}", other),
         }
     }
+
+    #[test]
+    fn cli_accepts_object_remove_with_purge_flag() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "object",
+            "remove",
+            "local/my-bucket/object.txt",
+            "--purge",
+        ])
+        .expect("parse object remove with purge");
+
+        match cli.command {
+            Commands::Object(args) => match args.command {
+                object::ObjectCommands::Remove(arg) => {
+                    assert_eq!(arg.paths, vec!["local/my-bucket/object.txt".to_string()]);
+                    assert!(arg.purge);
+                }
+                other => panic!("expected object remove command, got {:?}", other),
+            },
+            other => panic!("expected object command, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Recent `--purge` support added parser and execution coverage for `rc rm`, but the noun-first `rc object remove` entrypoint reuses the same `RmArgs` without dedicated parser coverage.

This change adds one focused parser test in [`crates/cli/src/commands/mod.rs`](/Users/overtrue/.codex/worktrees/f20f/cli/crates/cli/src/commands/mod.rs) to verify that `rc object remove local/my-bucket/object.txt --purge` is accepted and sets `purge = true` on the delegated remove args.

## User impact
Without this test, a regression in the noun-first parser path could silently break `object remove --purge` while `rm --purge` kept passing. Users relying on the object-oriented command surface would lose the new flag behavior without a targeted signal in CI.

## Validation
I first ran the focused parser test:
- `cargo test cli_accepts_object_remove_with_purge_flag`

The repository does not define `make pre-commit`, so that target cannot be run in this checkout. I ran the CI-equivalent checks from `.github/workflows/ci.yml` instead:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
