### PR TITLE
test(cli): cover rm purge option defaults

### DIFF
--- a/crates/cli/src/commands/rm.rs
+++ b/crates/cli/src/commands/rm.rs
@@ -436,4 +436,38 @@ mod tests {
         let options = delete_request_options(&args);
         assert!(options.force_delete);
     }
+
+    #[test]
+    fn test_delete_request_options_keep_force_delete_disabled_by_default() {
+        let args = RmArgs {
+            paths: vec!["test/bucket/object.txt".to_string()],
+            recursive: false,
+            force: false,
+            dry_run: false,
+            incomplete: false,
+            versions: false,
+            bypass: false,
+            purge: false,
+        };
+
+        let options = delete_request_options(&args);
+        assert!(!options.force_delete);
+    }
+
+    #[test]
+    fn test_delete_request_options_ignore_force_flag_without_purge() {
+        let args = RmArgs {
+            paths: vec!["test/bucket/object.txt".to_string()],
+            recursive: false,
+            force: true,
+            dry_run: false,
+            incomplete: false,
+            versions: false,
+            bypass: false,
+            purge: false,
+        };
+
+        let options = delete_request_options(&args);
+        assert!(!options.force_delete);
+    }
 }


### PR DESCRIPTION
## Summary
This adds focused unit coverage for the request-option mapping behind the recent `rm --purge` work.

The merged change in #82 introduced `delete_request_options` so the CLI can opt into RustFS force-delete semantics, but the unit tests only exercised the positive `purge = true` branch. That left the default branch and the easy-to-confuse `force = true, purge = false` branch unverified.

## Root cause
Recent follow-up PRs already covered `--purge` help and parser wiring, plus the S3 client header behavior. The small helper in [`crates/cli/src/commands/rm.rs`](/Users/overtrue/.codex/worktrees/14eb/cli/crates/cli/src/commands/rm.rs) still had a gap around the non-purge paths that feed those lower-level calls.

## Fix
The test module now adds two narrow assertions:

- default remove options keep `force_delete` disabled;
- `--force` alone does not enable `force_delete` unless `--purge` is also set.

This keeps the scope limited to the recent `rm` change surface and avoids production code changes.

## Validation
I ran these successfully:

- `cargo test -p rustfs-cli delete_request_options --lib`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also ran `make pre-commit` per the automation instructions, but this checkout does not define that target, so `make` exits with `No rule to make target 'pre-commit'.`
