### PR TITLE
test(s3): cover missing bucket cors configuration

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3105,6 +3105,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_bucket_cors_missing_configuration_returns_empty_rules() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NoSuchCORSConfiguration")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NoSuchCORSConfiguration</Code>
+  <Message>The CORS configuration does not exist</Message>
+</Error>"#,
+            ))
+            .expect("build missing cors response");
+        let (client, _) = test_s3_client(Some(response));
+
+        let rules = client
+            .get_bucket_cors("bucket")
+            .await
+            .expect("missing cors config should be treated as empty");
+
+        assert!(rules.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_bucket_cors_missing_configuration_is_successful() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NoSuchCORSConfiguration")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NoSuchCORSConfiguration</Code>
+  <Message>The CORS configuration does not exist</Message>
+</Error>"#,
+            ))
+            .expect("build missing cors response");
+        let (client, _) = test_s3_client(Some(response));
+
+        client
+            .delete_bucket_cors("bucket")
+            .await
+            .expect("missing cors config should be treated as successful delete");
+    }
+
+    #[tokio::test]
     async fn reqwest_connector_insecure_without_ca_bundle_succeeds() {
         // When insecure is true and no CA bundle is provided, the connector should be created.
         let connector = ReqwestConnector::new(true, None).await;


### PR DESCRIPTION
## Summary

Add focused `rc-s3` coverage for bucket CORS operations when the backend reports that no CORS configuration exists. This keeps the scope on a recent CORS code path without changing runtime behavior.

## Problem

Recent bucket CORS support added logic to treat missing bucket CORS state as an empty configuration on reads and as a successful no-op on deletes. That behavior was implemented, but there was no direct unit coverage proving the S3 client maps the `NoSuchCORSConfiguration` 404 path correctly.

## Root Cause

The existing tests only covered the helper predicates that classify missing CORS responses. They did not exercise the public `get_bucket_cors` and `delete_bucket_cors` methods with an actual mocked SDK response, so a regression in the method-level handling could slip through.

## Fix

Add two `rc-s3` unit tests that feed mocked 404 `NoSuchCORSConfiguration` responses into the client. One verifies `get_bucket_cors` returns an empty rule list, and the other verifies `delete_bucket_cors` succeeds.

## Validation

- `cargo test -p rc-s3 get_bucket_cors_missing_configuration_returns_empty_rules`
- `cargo test -p rc-s3 delete_bucket_cors_missing_configuration_is_successful`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
