### PR TITLE
test(cli): cover cors XML alias gaps

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -680,6 +680,28 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_cors_configuration_xml_drops_blank_optional_headers() {
+        let config = parse_cors_configuration(
+            r#"
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>https://console.example.com</AllowedOrigin>
+    <AllowedMethod>get</AllowedMethod>
+    <AllowedHeader>   </AllowedHeader>
+    <ExposeHeader></ExposeHeader>
+  </CORSRule>
+</CORSConfiguration>
+"#,
+        )
+        .expect("parse xml config with blank optional headers");
+
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(config.rules[0].allowed_headers, None);
+        assert_eq!(config.rules[0].expose_headers, None);
+        assert_eq!(config.rules[0].allowed_methods, vec!["GET".to_string()]);
+    }
+
+    #[test]
     fn test_cors_input_source_prefers_positional_argument() {
         let args = SetCorsArgs {
             path: "local/my-bucket".to_string(),

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -440,6 +440,19 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_top_level_cors_get_alias() {
+        let cli = Cli::try_parse_from(["rc", "cors", "get", "local/my-bucket"])
+            .expect("parse top-level cors get");
+
+        match cli.command {
+            Commands::Cors(cors::CorsCommands::List(arg)) => {
+                assert_eq!(arg.path, "local/my-bucket");
+            }
+            other => panic!("expected top-level cors get alias, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_bucket_cors_get_alias() {
         let cli = Cli::try_parse_from(["rc", "bucket", "cors", "get", "local/my-bucket"])
             .expect("parse bucket cors get");


### PR DESCRIPTION
## Summary
This PR adds focused regression coverage for two untested CORS paths introduced by the recent bucket CORS feature work.

The first gap was XML normalization when optional header fields are present but blank. The JSON parser path already had coverage for trimming empty `allowedHeaders` and `exposeHeaders`, but the XML path did not. This matters because `rc bucket cors set` accepts both JSON and XML inputs, and users can reasonably provide empty XML elements from exported or hand-edited configs.

The second gap was the deprecated top-level `rc cors get` alias. The newer nested `rc bucket cors get` path already had parser coverage, and `rc cors remove` was covered, but the top-level `get` alias was not. This PR verifies that the compatibility path still resolves to the list command and preserves the bucket argument.

## Validation
I attempted to run `make pre-commit` as requested by the automation, but this repository currently has no `Makefile` and no `pre-commit` target. I therefore ran the documented repository checks directly:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

All of the above passed.
