### PR TITLE
test(cli): cover empty cors bucket segment

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -532,6 +532,7 @@ mod tests {
     fn test_parse_bucket_path_error() {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
+        assert!(parse_bucket_path("local/").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
         assert!(parse_bucket_path("local///").is_err());
     }


### PR DESCRIPTION
## Summary
This adds a focused regression test for the recent CORS bucket-path normalization fix. The new assertion covers `local/`, where the bucket segment becomes empty after trimming trailing slashes.

## Problem
The recent fix in `parse_bucket_path` rejects bucket paths whose bucket segment normalizes to an empty string. The existing test only covered `local///`, so the simpler `local/` input remained untested even though it exercises the same user-facing edge case.

## Root Cause
The implementation was corrected, but the regression coverage did not include the shortest form of the empty normalized bucket path. That left the fix vulnerable to accidental changes in the parser contract.

## Fix
I extended the existing parser error test in `crates/cli/src/commands/cors.rs` with an assertion that `parse_bucket_path("local/")` returns an error. The scope stays limited to the changed parser behavior and avoids unrelated command changes.

## Validation
I ran:
- `cargo test -p rustfs-cli test_parse_bucket_path_error`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Note: this repository does not currently contain a `make pre-commit` target, so I ran the underlying CI-equivalent checks directly.
