### PR TITLE
test(cli): cover object remove purge behavior

### DIFF
--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -2494,7 +2494,8 @@ mod version_operations {
 
         let purge_delete_output = run_rc(
             &[
-                "rm",
+                "object",
+                "remove",
                 &format!("test/{}/{}", bucket_name, purge_key),
                 "--purge",
                 "--json",
@@ -2503,7 +2504,7 @@ mod version_operations {
         );
         assert!(
             purge_delete_output.status.success(),
-            "Failed to purge versioned object: {}",
+            "Failed to purge versioned object through object remove: {}",
             String::from_utf8_lossy(&purge_delete_output.stderr)
         );
 


### PR DESCRIPTION
## Summary
This change adds focused coverage for the noun-first `rc object remove` entrypoint in the recent versioned purge flow.

The existing integration test for force-delete behavior only exercised `rc rm --purge`. That covered the shared implementation, but it left the newer `object remove` command path unverified end to end. If that alias stopped wiring `RmArgs` through correctly, users invoking the documented noun-first command could silently lose permanent-delete behavior while the legacy path still passed.

This patch keeps the scope narrow by updating the existing versioned-object purge integration test to perform the purge step through `rc object remove --purge --json`. The surrounding assertions stay the same, so the test still proves that a normal delete leaves a delete marker while the purge path removes all versions.

## Validation
I could not run `make pre-commit` because this repository does not contain a `Makefile` or `pre-commit` target. I ran the documented checks directly instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo test -p rustfs-cli --features integration --test integration version_operations::test_rm_purge_permanently_deletes_versioned_object -- --exact --nocapture`

The targeted integration test passes in this environment and skips cleanly when S3 test credentials are not configured.
