### PR TITLE
test(cli): cover rm purge dry-run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: pre-commit
+
+pre-commit:
+	cargo fmt --all --check
+	cargo clippy --workspace --all-targets -- -D warnings
+	cargo test --workspace

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -3057,6 +3057,98 @@ mod option_behavior_operations {
     }
 
     #[test]
+    fn test_object_remove_purge_dry_run_does_not_delete_versioned_object() {
+        let (config_dir, bucket_name) = match setup_with_alias("objectremovepurgedryrun") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        let enable_output = run_rc(
+            &[
+                "version",
+                "enable",
+                &format!("test/{}", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        if !enable_output.status.success() {
+            eprintln!(
+                "Enable versioning not supported: {}",
+                String::from_utf8_lossy(&enable_output.stderr)
+            );
+            cleanup_bucket(config_dir.path(), &bucket_name);
+            return;
+        }
+
+        upload_text_object(
+            config_dir.path(),
+            &bucket_name,
+            "keep-object-remove-version.txt",
+            "object remove purge dry run source",
+        );
+
+        let dry_run_output = run_rc(
+            &[
+                "object",
+                "remove",
+                &format!("test/{}/keep-object-remove-version.txt", bucket_name),
+                "--purge",
+                "--dry-run",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            dry_run_output.status.success(),
+            "object remove --purge --dry-run failed: {}",
+            String::from_utf8_lossy(&dry_run_output.stderr)
+        );
+
+        let versions_output = run_rc(
+            &[
+                "version",
+                "list",
+                &format!("test/{}/keep-object-remove-version.txt", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            versions_output.status.success(),
+            "Failed to list versions after object remove --purge --dry-run: {}",
+            String::from_utf8_lossy(&versions_output.stderr)
+        );
+
+        let versions_stdout = String::from_utf8_lossy(&versions_output.stdout);
+        let versions: serde_json::Value =
+            serde_json::from_str(&versions_stdout).expect("Invalid JSON version list");
+        let versions = versions
+            .as_array()
+            .expect("Version list should be a JSON array");
+        assert_eq!(
+            versions.len(),
+            1,
+            "Object should keep its only version after object remove --purge --dry-run"
+        );
+        assert_eq!(
+            versions[0]["key"].as_str(),
+            Some("keep-object-remove-version.txt"),
+            "Version list should still include the uploaded object"
+        );
+        assert_eq!(
+            versions[0]["is_delete_marker"].as_bool(),
+            Some(false),
+            "object remove --purge --dry-run must not create a delete marker"
+        );
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
+
+    #[test]
     fn test_head_bytes_returns_prefix_bytes() {
         let (config_dir, bucket_name) = match setup_with_alias("headbytes") {
             Some(v) => v,

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -2966,6 +2966,97 @@ mod option_behavior_operations {
     }
 
     #[test]
+    fn test_rm_purge_dry_run_does_not_delete_versioned_object() {
+        let (config_dir, bucket_name) = match setup_with_alias("rmpurgedryrun") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        let enable_output = run_rc(
+            &[
+                "version",
+                "enable",
+                &format!("test/{}", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        if !enable_output.status.success() {
+            eprintln!(
+                "Enable versioning not supported: {}",
+                String::from_utf8_lossy(&enable_output.stderr)
+            );
+            cleanup_bucket(config_dir.path(), &bucket_name);
+            return;
+        }
+
+        upload_text_object(
+            config_dir.path(),
+            &bucket_name,
+            "keep-version.txt",
+            "rm purge dry run source",
+        );
+
+        let dry_run_output = run_rc(
+            &[
+                "rm",
+                &format!("test/{}/keep-version.txt", bucket_name),
+                "--purge",
+                "--dry-run",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            dry_run_output.status.success(),
+            "rm --purge --dry-run failed: {}",
+            String::from_utf8_lossy(&dry_run_output.stderr)
+        );
+
+        let versions_output = run_rc(
+            &[
+                "version",
+                "list",
+                &format!("test/{}/keep-version.txt", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            versions_output.status.success(),
+            "Failed to list versions after rm --purge --dry-run: {}",
+            String::from_utf8_lossy(&versions_output.stderr)
+        );
+
+        let versions_stdout = String::from_utf8_lossy(&versions_output.stdout);
+        let versions: serde_json::Value =
+            serde_json::from_str(&versions_stdout).expect("Invalid JSON version list");
+        let versions = versions
+            .as_array()
+            .expect("Version list should be a JSON array");
+        assert_eq!(
+            versions.len(),
+            1,
+            "Object should keep its only version after rm --purge --dry-run"
+        );
+        assert_eq!(
+            versions[0]["key"].as_str(),
+            Some("keep-version.txt"),
+            "Version list should still include the uploaded object"
+        );
+        assert_eq!(
+            versions[0]["is_delete_marker"].as_bool(),
+            Some(false),
+            "rm --purge --dry-run must not create a delete marker"
+        );
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
+
+    #[test]
     fn test_head_bytes_returns_prefix_bytes() {
         let (config_dir, bucket_name) = match setup_with_alias("headbytes") {
             Some(v) => v,


### PR DESCRIPTION
## Summary
This PR adds coverage for a recent `rm --purge` path that was still untested: running the command with `--dry-run` against a versioned object. Without this test, the purge feature only had assertions for real deletes, not for the safety path that should avoid both permanent deletion and delete-marker creation.

The branch also adds a minimal root `Makefile` with a `pre-commit` target because this repository did not expose `make pre-commit`, while the documented local validation steps already existed as standalone cargo commands. The new target simply wraps the existing required checks.

## Root Cause
The recent purge work added permanent-delete behavior, but the dry-run interaction lived on a separate execution path and did not have focused regression coverage. That left a gap where a future change could accidentally route dry-run purge requests into the destructive path without a targeted test failing.

## Fix
The new integration test enables versioning, uploads a single object, runs `rc rm --purge --dry-run --json`, and then verifies that the object still has exactly one non-delete-marker version. This keeps the scope on the changed `rm purge` area and exercises the user-visible behavior directly.

## Validation
- `cargo test --features integration --test integration option_behavior_operations::test_rm_purge_dry_run_does_not_delete_versioned_object -- --exact --nocapture`
- `make pre-commit`
