### PR TITLE
test(s3): cover empty optional cors headers

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3004,6 +3004,19 @@ mod tests {
     }
 
     #[test]
+    fn sdk_cors_rule_to_core_drops_empty_optional_headers() {
+        let sdk_rule = aws_sdk_s3::types::CorsRule::builder()
+            .allowed_origins("https://app.example.com")
+            .allowed_methods("GET")
+            .build()
+            .expect("build cors rule");
+
+        let rule = sdk_cors_rule_to_core(&sdk_rule);
+        assert_eq!(rule.allowed_headers, None);
+        assert_eq!(rule.expose_headers, None);
+    }
+
+    #[test]
     fn core_cors_rule_to_sdk_normalizes_method_case() {
         let rule = CorsRule {
             id: Some("public-read".to_string()),
@@ -3020,6 +3033,22 @@ mod tests {
         assert_eq!(sdk_rule.allowed_methods(), ["GET", "POST"]);
         assert_eq!(sdk_rule.allowed_headers(), ["*"]);
         assert_eq!(sdk_rule.max_age_seconds(), Some(600));
+    }
+
+    #[test]
+    fn core_cors_rule_to_sdk_drops_empty_optional_headers() {
+        let rule = CorsRule {
+            id: None,
+            allowed_origins: vec!["https://app.example.com".to_string()],
+            allowed_methods: vec!["GET".to_string()],
+            allowed_headers: Some(Vec::new()),
+            expose_headers: Some(Vec::new()),
+            max_age_seconds: None,
+        };
+
+        let sdk_rule = core_cors_rule_to_sdk(&rule).expect("convert cors rule");
+        assert!(sdk_rule.allowed_headers().is_empty());
+        assert!(sdk_rule.expose_headers().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Recent bucket CORS support added helper conversions between SDK CORS rules and the core `CorsRule` type. Those helpers intentionally normalize empty optional header lists away, but the existing tests only covered populated header fields and method normalization.

This change adds focused unit coverage for the missing normalization paths in `crates/s3/src/client.rs`:
- `sdk_cors_rule_to_core_drops_empty_optional_headers` verifies SDK rules without optional headers become `None` in the core type.
- `core_cors_rule_to_sdk_drops_empty_optional_headers` verifies empty optional header vectors do not leak meaningful values back into the SDK rule representation.

## User Impact
Without these tests, a regression in empty optional header normalization could slip through future refactors in the new bucket CORS code path. That would risk inconsistent behavior between SDK responses and CLI-managed CORS configs, especially when optional header fields are omitted.

## Root Cause
The recent CORS feature introduced normalization helpers for optional header collections, but only the populated-field path was explicitly covered. The empty-field path remained implicit and unverified.

## Validation
I could not run `make pre-commit` because this repository checkout does not contain a `Makefile` or `pre-commit` target. I validated with the repo's documented Rust checks instead:
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
