### PR TITLE
test(cli): cover noun-first remove parser

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -579,4 +579,43 @@ mod tests {
             other => panic!("expected bucket command, got {:?}", other),
         }
     }
+
+    #[test]
+    fn cli_accepts_bucket_remove_subcommand() {
+        let cli = Cli::try_parse_from(["rc", "bucket", "remove", "local/my-bucket"])
+            .expect("parse bucket remove");
+
+        match cli.command {
+            Commands::Bucket(args) => match args.command {
+                bucket::BucketCommands::Remove(arg) => {
+                    assert_eq!(arg.target, "local/my-bucket");
+                }
+                other => panic!("expected bucket remove command, got {:?}", other),
+            },
+            other => panic!("expected bucket command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_object_remove_subcommand() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "object",
+            "remove",
+            "local/my-bucket/report.csv",
+            "--dry-run",
+        ])
+        .expect("parse object remove");
+
+        match cli.command {
+            Commands::Object(args) => match args.command {
+                object::ObjectCommands::Remove(arg) => {
+                    assert_eq!(arg.paths, vec!["local/my-bucket/report.csv".to_string()]);
+                    assert!(arg.dry_run);
+                }
+                other => panic!("expected object remove command, got {:?}", other),
+            },
+            other => panic!("expected object command, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Summary
This adds focused parser coverage for the noun-first remove entrypoints introduced by the recent bucket/object command-group work.

The command-group PR added help-contract coverage and a few parser assertions around bucket cors, but the remove paths still had no direct parser tests. That left a small regression window where clap wiring for rc bucket remove or rc object remove could drift without a fast unit test catching it.

## User impact
Users now have explicit regression coverage for two public noun-first removal entrypoints:

- rc bucket remove local/my-bucket
- rc object remove local/my-bucket/report.csv --dry-run

If either path stops parsing correctly in the future, the unit suite will fail immediately instead of relying on broader help output or runtime behavior to detect the breakage.

## Root cause
The noun-first command groups were added in #76, but parser tests in crates/cli/src/commands/mod.rs only exercised bucket cors routing. The remove subcommands delegated into existing argument types without any direct assertion that their positional arguments and flags survived clap parsing.

## Fix
This PR adds two narrow parser tests in crates/cli/src/commands/mod.rs:

- one verifies rc bucket remove reaches bucket::BucketCommands::Remove with the expected target;
- one verifies rc object remove reaches object::ObjectCommands::Remove, preserves the path list, and keeps --dry-run enabled.

The scope stays limited to the recently changed noun-first command surface and does not modify production code.

## Validation
I ran the following successfully:

- cargo test -p rustfs-cli cli_accepts_bucket_remove_subcommand --lib -- --nocapture
- cargo test -p rustfs-cli cli_accepts_object_remove_subcommand --lib -- --nocapture
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace

I also ran make pre-commit per the automation instructions, but this checkout does not define that target and exits with:

text
make: *** No rule to make target pre-commit'.  Stop.


