### PR TITLE
test(rm): cover delete option default paths

### DIFF
--- a/crates/cli/src/commands/rm.rs
+++ b/crates/cli/src/commands/rm.rs
@@ -436,4 +436,21 @@ mod tests {
         let options = delete_request_options(&args);
         assert!(options.force_delete);
     }
+
+    #[test]
+    fn test_delete_request_options_disable_force_delete_without_purge() {
+        let args = RmArgs {
+            paths: vec!["test/bucket/object.txt".to_string()],
+            recursive: false,
+            force: false,
+            dry_run: false,
+            incomplete: false,
+            versions: false,
+            bypass: false,
+            purge: false,
+        };
+
+        let options = delete_request_options(&args);
+        assert!(!options.force_delete);
+    }
 }

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3196,6 +3196,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_without_force_delete_omits_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["key.txt".to_string()],
+                DeleteRequestOptions::default(),
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
This PR adds focused regression coverage for the default branch of the recent delete-options work introduced for `rm --purge`.

The recent change added `DeleteRequestOptions` and threaded it through the CLI and S3 delete paths so RustFS-specific purge requests can attach the `x-rustfs-force-delete` header. The force-delete path was already covered, but the default path was not. That left a gap where a future change could accidentally enable the purge header for ordinary deletes without a targeted test catching it.

## Root cause
The original follow-up tests centered on the new behavior when `--purge` is enabled. They did not assert the inverse behavior for the unchanged default flow.

## Fix
This PR adds two narrow tests:

- a CLI-layer unit test that verifies `delete_request_options()` keeps `force_delete` disabled when `--purge` is not set
- an S3 client unit test that verifies batch delete requests omit the RustFS force-delete header when default options are used

These tests stay inside the recently changed delete-options surface and do not alter runtime behavior.

## Validation
I could not run `make pre-commit` because this repository checkout does not contain a `Makefile` or a `pre-commit` target. I ran the documented equivalent checks from `AGENTS.md` instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
