### PR TITLE
test(rm): reject empty alias paths

### DIFF
--- a/crates/cli/src/commands/rm.rs
+++ b/crates/cli/src/commands/rm.rs
@@ -369,6 +369,10 @@ fn parse_rm_path(path: &str) -> Result<(String, String, String), String> {
         String::new()
     };
 
+    if alias.is_empty() {
+        return Err("Alias name cannot be empty".to_string());
+    }
+
     if bucket.is_empty() {
         return Err("Bucket name cannot be empty".to_string());
     }
@@ -418,6 +422,11 @@ mod tests {
     #[test]
     fn test_parse_rm_path_empty() {
         assert!(parse_rm_path("").is_err());
+    }
+
+    #[test]
+    fn test_parse_rm_path_empty_alias() {
+        assert!(parse_rm_path("/mybucket/file.txt").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR adds focused regression coverage for an untested rm parser path introduced by the recent remove-command changes.

Users can pass malformed paths like /bucket/key to rc rm. Before this change, the parser accepted that shape, produced an empty alias, and only failed later during alias lookup. That surfaced the wrong class of error and left the path-validation contract under-tested.

## Root cause
parse_rm_path() validated the bucket segment but did not reject an empty alias segment. Existing tests covered missing buckets and empty input, but they did not cover a leading slash path where the alias portion is blank.

## Fix
The patch keeps scope tight to crates/cli/src/commands/rm.rs:

- reject empty aliases directly in parse_rm_path()
- add a regression test for /mybucket/file.txt

This keeps the failure at the parser boundary and prevents malformed remove paths from falling through into later alias resolution.

## Validation
I ran:

- cargo test -p rustfs-cli test_parse_rm_path_empty_alias --lib -- --nocapture
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace

I also ran make pre-commit per the automation instructions, but this checkout does not define that target:

text
make: *** No rule to make target pre-commit'.  Stop.


