### PR TITLE
test(cli): cover noun-first list aliases

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -455,6 +455,22 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_bucket_list_alias() {
+        let cli =
+            Cli::try_parse_from(["rc", "bucket", "ls", "local/"]).expect("parse bucket ls alias");
+
+        match cli.command {
+            Commands::Bucket(args) => match args.command {
+                bucket::BucketCommands::List(arg) => {
+                    assert_eq!(arg.path, "local/");
+                }
+                other => panic!("expected bucket list alias, got {:?}", other),
+            },
+            other => panic!("expected bucket command, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_top_level_cors_subcommand() {
         let cli = Cli::try_parse_from(["rc", "cors", "remove", "local/my-bucket"])
             .expect("parse top-level cors");
@@ -492,6 +508,22 @@ mod tests {
                 assert_eq!(arg.path, "local/my-bucket");
             }
             other => panic!("expected top-level event list command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_object_list_alias() {
+        let cli = Cli::try_parse_from(["rc", "object", "ls", "local/my-bucket/logs/"])
+            .expect("parse object ls alias");
+
+        match cli.command {
+            Commands::Object(args) => match args.command {
+                object::ObjectCommands::List(arg) => {
+                    assert_eq!(arg.path, "local/my-bucket/logs/");
+                }
+                other => panic!("expected object list alias, got {:?}", other),
+            },
+            other => panic!("expected object command, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
## Summary
This adds focused parser coverage for the noun-first ls aliases introduced with the recent bucket/object command groups.

## Problem
The command-group work in #76 added bucket and object entrypoints with ls as an alias for list, but the parser tests in crates/cli/src/commands/mod.rs did not assert those alias routes. That left a small regression window where the alias wiring could drift without a fast unit test catching it.

## Root cause
Existing parser coverage around the noun-first surface focused on bucket cors and other follow-up gaps, but not on the ls aliases attached directly to BucketCommands::List and ObjectCommands::List.

## Fix
The patch keeps scope tight to crates/cli/src/commands/mod.rs:

- add cli_accepts_bucket_list_alias for rc bucket ls local/
- add cli_accepts_object_list_alias for rc object ls local/my-bucket/logs/

Both assertions verify clap dispatch reaches the expected noun-first command variants and preserves the parsed path.

## Validation
I ran:

- cargo test -p rustfs-cli cli_accepts_bucket_list_alias --lib -- --nocapture
- cargo test -p rustfs-cli cli_accepts_object_list_alias --lib -- --nocapture
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace

I also ran make pre-commit per the automation instructions, but this checkout does not define that target:

text
make: *** No rule to make target pre-commit'.  Stop.


