### PR TITLE
test(s3): cover delete wrapper defaults

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3173,6 +3173,17 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_object_wrapper_uses_default_options_without_rustfs_header() {
+        let (client, request_receiver) = test_s3_client(None);
+        let path = RemotePath::new("test", "bucket", "key.txt");
+
+        let _ = ObjectStore::delete_object(&client, &path).await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
     async fn delete_objects_with_force_delete_sets_rustfs_header() {
         let response = http::Response::builder()
             .status(200)
@@ -3193,6 +3204,23 @@ mod tests {
 
         let request = request_receiver.expect_request();
         assert_eq!(request.headers().get("x-rustfs-force-delete"), Some("true"));
+    }
+
+    #[tokio::test]
+    async fn delete_objects_wrapper_uses_default_options_without_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = ObjectStore::delete_objects(&client, "bucket", vec!["key.txt".to_string()]).await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
This PR adds focused unit coverage for the legacy `ObjectStore` delete wrappers in the S3 client. The recent force-delete work introduced options-aware delete helpers and tests around `*_with_options`, but the wrapper methods that existing call sites still use did not have direct coverage proving they delegate through the default option path.

## Problem
Without a wrapper-level assertion, a future refactor could accidentally bypass the default options path and start sending the RustFS force-delete header for normal deletes. That would silently change ordinary delete behavior from delete-marker creation to permanent deletion on versioned buckets.

## Root Cause
The original test additions validated explicit option handling, including force-delete header emission and omission on the `*_with_options` methods. The `ObjectStore` trait implementation methods `delete_object` and `delete_objects` now delegate into those helpers, but there was no regression test pinning that delegation.

## Fix
The change adds two S3 client unit tests that call the wrapper methods directly and capture the generated HTTP requests. Each test asserts that the `x-rustfs-force-delete` header is absent when the wrapper uses default request options.

## Validation
I first ran the two new unit tests directly:
- `cargo test -p rc-s3 delete_object_wrapper_uses_default_options_without_rustfs_header`
- `cargo test -p rc-s3 delete_objects_wrapper_uses_default_options_without_rustfs_header`

I then ran the repo's CI-equivalent checks:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

`make pre-commit` was also requested by the automation prompt, but this checkout does not contain a Makefile or a `pre-commit` target, so I used the commands defined in `.github/workflows/ci.yml` instead.
