### PR TITLE
test(event): cover mixed-case canonical event names

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -410,11 +410,11 @@ fn parse_event_list(values: &[String]) -> Vec<String> {
 
 fn normalize_event_name(value: &str) -> String {
     match value.to_ascii_lowercase().as_str() {
-        "put" => "s3:ObjectCreated:*".to_string(),
-        "get" => "s3:ObjectAccessed:*".to_string(),
-        "delete" => "s3:ObjectRemoved:*".to_string(),
-        "replica" => "s3:Replication:*".to_string(),
-        "ilm" => "s3:ObjectTransition:*".to_string(),
+        "put" | "s3:objectcreated:*" => "s3:ObjectCreated:*".to_string(),
+        "get" | "s3:objectaccessed:*" => "s3:ObjectAccessed:*".to_string(),
+        "delete" | "s3:objectremoved:*" => "s3:ObjectRemoved:*".to_string(),
+        "replica" | "s3:replication:*" => "s3:Replication:*".to_string(),
+        "ilm" | "s3:objecttransition:*" => "s3:ObjectTransition:*".to_string(),
         _ => value.to_string(),
     }
 }
@@ -574,6 +574,22 @@ mod tests {
             events,
             vec![
                 "s3:ObjectAccessed:*".to_string(),
+                "s3:ObjectCreated:*".to_string(),
+                "s3:ObjectRemoved:*".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_event_list_deduplicates_mixed_case_canonical_names() {
+        let events = parse_event_list(&[
+            "PUT,S3:objectcreated:*".to_string(),
+            "delete,S3:OBJECTREMOVED:*".to_string(),
+        ]);
+
+        assert_eq!(
+            events,
+            vec![
                 "s3:ObjectCreated:*".to_string(),
                 "s3:ObjectRemoved:*".to_string(),
             ]


### PR DESCRIPTION
## Summary
This change closes a small regression gap in the recent event shorthand normalization work.

The event add path already normalizes shorthand values like put and delete before persisting notifications, and there are tests covering shorthand inputs plus exact canonical values. What was still untested was the mixed-case canonical wildcard path, where users pass values like S3:objectcreated:* alongside shorthand aliases.

## Problem
Without canonicalizing those wildcard names before deduplication, the parser treated PUT and S3:objectcreated:* as different events. That allowed duplicate logical event entries to survive normalization and be written back to notification configuration.

## Root Cause
normalize_event_name() only mapped shorthand aliases onto canonical wildcard names. It did not also collapse the equivalent canonical wildcard strings when they arrived in a different case.

## Fix
The parser now normalizes the canonical wildcard forms for the same five shorthand-backed event families:

- s3:ObjectCreated:*
- s3:ObjectAccessed:*
- s3:ObjectRemoved:*
- s3:Replication:*
- s3:ObjectTransition:*

I also added a focused unit test that fails on the old behavior and proves mixed-case canonical values deduplicate correctly with shorthand aliases.

## Validation
I ran:

- cargo test -p rustfs-cli mixed_case_canonical
- cargo test -p rustfs-cli parse_event_list
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace

I also attempted make pre-commit, per the automation requirement, but this checkout does not define a pre-commit target:

text
make: *** No rule to make target pre-commit'.  Stop.


