### PR TITLE
test(cli): cover XML cors required-field validation

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -592,6 +592,38 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_cors_configuration_xml_rejects_missing_allowed_origin() {
+        let error = parse_cors_configuration(
+            r#"
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedMethod>GET</AllowedMethod>
+  </CORSRule>
+</CORSConfiguration>
+"#,
+        )
+        .expect_err("missing xml allowed origin");
+
+        assert!(error.contains("at least one allowed origin"));
+    }
+
+    #[test]
+    fn test_parse_cors_configuration_xml_rejects_missing_allowed_method() {
+        let error = parse_cors_configuration(
+            r#"
+<CORSConfiguration>
+  <CORSRule>
+    <AllowedOrigin>https://console.example.com</AllowedOrigin>
+  </CORSRule>
+</CORSConfiguration>
+"#,
+        )
+        .expect_err("missing xml allowed method");
+
+        assert!(error.contains("at least one allowed method"));
+    }
+
+    #[test]
     fn test_parse_cors_configuration_rejects_empty_allowed_origin() {
         let error = parse_cors_configuration(
             r#"{


### PR DESCRIPTION
## Summary
This PR adds focused CLI unit coverage for the XML CORS parser path. Recent CORS validation tests already exercised missing required fields for JSON input, but the equivalent XML path still relied on the same validation logic without dedicated tests.

The user-visible risk is quiet regression in XML-based `rc bucket cors set` workflows. If future parser changes accidentally stop rejecting rules that omit `AllowedOrigin` or `AllowedMethod`, the CLI could accept malformed XML configs until the backend rejects them later.

## Root cause
The recent parser hardening work validated required fields after decoding either JSON or XML into the shared `CorsConfiguration` shape, but the test suite only asserted those required-field failures with JSON fixtures. That left the XML decode-and-validate path uncovered for the same contract.

## Fix
Add two unit tests in `crates/cli/src/commands/cors.rs` that verify XML configs fail when a rule omits `AllowedOrigin` and when a rule omits `AllowedMethod`. The implementation is unchanged; this PR only locks in the intended validation behavior for XML input.

## Validation
- `cargo test --package rustfs-cli parse_cors_configuration_xml_rejects_missing`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Notes
The repository does not currently define a `make pre-commit` target, so validation used the CI-equivalent cargo commands above.
