### PR TITLE
test(cli): cover output format overrides

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -411,6 +411,34 @@ mod tests {
     }
 
     #[test]
+    fn explicit_human_overrides_structured_default() {
+        let options = GlobalOutputOptions {
+            format: Some(OutputFormat::Human),
+            json: false,
+            no_color: false,
+            no_progress: false,
+            quiet: false,
+        };
+
+        let resolved = options.resolve(OutputBehavior::StructuredDefault);
+        assert!(!resolved.json);
+    }
+
+    #[test]
+    fn explicit_auto_overrides_human_default() {
+        let options = GlobalOutputOptions {
+            format: Some(OutputFormat::Auto),
+            json: false,
+            no_color: false,
+            no_progress: false,
+            quiet: false,
+        };
+
+        let resolved = options.resolve(OutputBehavior::HumanDefault);
+        assert_eq!(resolved.json, !std::io::stdout().is_terminal());
+    }
+
+    #[test]
     fn cli_accepts_bucket_cors_subcommand() {
         let cli = Cli::try_parse_from(["rc", "bucket", "cors", "list", "local/my-bucket"])
             .expect("parse bucket cors");


### PR DESCRIPTION
## Summary
This PR adds focused regression coverage for the recent output format selection work in `crates/cli/src/commands/mod.rs`.

The current command resolution logic supports explicit `--format` overrides on top of command-specific defaults, but the test suite only covered the default structured and human behaviors plus `--json` precedence. That left two recently added branches unexercised: forcing human output for a structured-default command, and forcing auto-detection for a human-default command.

## Root cause
The output-mode feature introduced multiple resolution paths in `GlobalOutputOptions::resolve`, but only part of the decision matrix had direct unit coverage. Without tests for the remaining override branches, a later refactor could silently regress explicit `--format` handling even while the existing default-path tests continued to pass.

## Fix
I added two unit tests that pin those branches explicitly:

- `explicit_human_overrides_structured_default`
- `explicit_auto_overrides_human_default`

These tests keep the scope tight to the recent output-format feature and avoid changing production code.

## Validation
The repository does not currently define a `make pre-commit` target, so I ran the equivalent CI checks directly from the repository workflow instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
