### PR TITLE
test(s3): cover empty delete batch

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3196,6 +3196,19 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_with_empty_keys_skips_request() {
+        let (client, request_receiver) = test_s3_client(None);
+
+        let deleted = client
+            .delete_objects_with_options("bucket", Vec::new(), DeleteRequestOptions::default())
+            .await
+            .expect("empty delete batch should succeed");
+
+        assert!(deleted.is_empty());
+        request_receiver.expect_no_request();
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
This change adds coverage for a small but important path introduced by the recent delete-options work in the S3 client. When `delete_objects_with_options` is called with an empty key list, the method should return successfully without constructing or sending an HTTP request.

That behavior matters because the rm purge and batch-delete flow now routes through the new delete-options helper, and empty batches are a legitimate no-op case during prefix cleanup or chunked deletion logic. Without an explicit regression test, a future refactor could accidentally remove the early return and start issuing malformed or unnecessary delete requests.

## Root Cause
The implementation already had the correct guard clause for an empty `keys` vector, but the path was not covered by unit tests. Recent work added option-aware delete wrappers and header mutation logic, increasing the chance that request-building code could be touched again without preserving the no-op behavior.

## Fix
Add a focused unit test in `crates/s3/src/client.rs` that:

- calls `delete_objects_with_options` with an empty key list
- asserts the returned deleted-key list is empty
- asserts the request capture harness observed no outbound request

## Validation
I could not run `make pre-commit` because this repository does not define that target. I ran the CI-equivalent checks used by the repo instead:

- `cargo test -p rc-s3 delete_objects_with_empty_keys_skips_request`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
