### PR TITLE
test(cli): cover event remove command contracts

### DIFF
--- a/crates/cli/src/commands/event.rs
+++ b/crates/cli/src/commands/event.rs
@@ -22,6 +22,11 @@ Examples:
   rc event add local/my-bucket arn:aws:sns:us-east-1:123456789012:alerts --event delete
   rc bucket event add local/my-bucket arn:aws:lambda:us-east-1:123456789012:function:thumbnail --event put,delete";
 
+const EVENT_REMOVE_AFTER_HELP: &str = "\
+Examples:
+  rc bucket event remove local/my-bucket arn:aws:sqs:us-east-1:123456789012:jobs
+  rc event remove local/my-bucket arn:aws:sns:us-east-1:123456789012:alerts";
+
 /// Manage bucket event notifications
 #[derive(Args, Debug)]
 #[command(after_help = EVENT_AFTER_HELP)]
@@ -71,6 +76,7 @@ pub struct AddArgs {
 }
 
 #[derive(Args, Debug)]
+#[command(after_help = EVENT_REMOVE_AFTER_HELP)]
 pub struct RemoveArgs {
     /// Path to the bucket (alias/bucket)
     pub path: String,

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -472,4 +472,28 @@ mod tests {
             other => panic!("expected bucket command, got {:?}", other),
         }
     }
+
+    #[test]
+    fn cli_accepts_bucket_event_remove_subcommand() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "bucket",
+            "event",
+            "remove",
+            "local/my-bucket",
+            "arn:aws:sns:us-east-1:123456789012:alerts",
+        ])
+        .expect("parse bucket event remove");
+
+        match cli.command {
+            Commands::Bucket(args) => match args.command {
+                bucket::BucketCommands::Event(event::EventCommands::Remove(arg)) => {
+                    assert_eq!(arg.path, "local/my-bucket");
+                    assert_eq!(arg.arn, "arn:aws:sns:us-east-1:123456789012:alerts");
+                }
+                other => panic!("expected bucket event remove command, got {:?}", other),
+            },
+            other => panic!("expected bucket command, got {:?}", other),
+        }
+    }
 }

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -437,6 +437,15 @@ fn nested_subcommand_help_contract() {
             ],
         },
         HelpCase {
+            args: &["bucket", "event", "remove"],
+            usage: "Usage: rc bucket event remove [OPTIONS] <PATH> <ARN>",
+            expected_tokens: &[
+                "--force",
+                "Examples:",
+                "rc event remove local/my-bucket arn:aws:sns:us-east-1:123456789012:alerts",
+            ],
+        },
+        HelpCase {
             args: &["object", "copy"],
             usage: "Usage: rc object copy [OPTIONS] <SOURCE> <TARGET>",
             expected_tokens: &[
@@ -731,6 +740,15 @@ fn nested_subcommand_help_contract() {
                 "--force",
                 "Examples:",
                 "rc event add local/my-bucket arn:aws:sns:us-east-1:123456789012:alerts --event delete",
+            ],
+        },
+        HelpCase {
+            args: &["event", "remove"],
+            usage: "Usage: rc event remove [OPTIONS] <PATH> <ARN>",
+            expected_tokens: &[
+                "--force",
+                "Examples:",
+                "rc event remove local/my-bucket arn:aws:sns:us-east-1:123456789012:alerts",
             ],
         },
         HelpCase {


### PR DESCRIPTION
## Summary
Recent CLI help/example work covered `event add`, but `event remove` still had an untested contract gap. The noun-first parser path `rc bucket event remove ...` also had no dedicated assertion. That left a regression hole in a recently changed area of the command surface.

This change adds focused coverage for both paths and fixes the missing help example output on the remove subcommand itself. `RemoveArgs` now exposes an `after_help` example block so the top-level and noun-first help text both advertise the remove workflow consistently.

## Root cause
The event command group defined shared help examples at the group level and dedicated examples for `add`, but `remove` had no subcommand-specific `after_help`. Help-contract coverage also skipped both `rc event remove` and `rc bucket event remove`, so the missing examples were never asserted.

## Validation
I first added the new help-contract assertions, which failed because `event remove` help did not include an examples section. After adding the remove-specific `after_help`, the targeted help-contract test passed.

The repository does not contain a `Makefile` or `justfile`, so `make pre-commit` cannot run in this checkout. I ran the equivalent required validations directly instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
