### PR TITLE
test(cors): cover empty normalized bucket path

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -726,4 +726,54 @@ mod tests {
 
         assert!(cors_input_source(&args).is_err());
     }
+
+    #[tokio::test]
+    async fn test_execute_list_rejects_empty_normalized_bucket_path() {
+        let code = execute(
+            CorsArgs {
+                command: CorsCommands::List(BucketArg {
+                    path: "local///".to_string(),
+                    force: false,
+                }),
+            },
+            OutputConfig::default(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn test_execute_set_rejects_empty_normalized_bucket_path_before_reading_source() {
+        let code = execute(
+            CorsArgs {
+                command: CorsCommands::Set(SetCorsArgs {
+                    path: "local///".to_string(),
+                    source: Some("missing-cors.json".to_string()),
+                    file: None,
+                    force: false,
+                }),
+            },
+            OutputConfig::default(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn test_execute_remove_rejects_empty_normalized_bucket_path() {
+        let code = execute(
+            CorsArgs {
+                command: CorsCommands::Remove(BucketArg {
+                    path: "local///".to_string(),
+                    force: false,
+                }),
+            },
+            OutputConfig::default(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::UsageError);
+    }
 }


### PR DESCRIPTION
## Summary
This change adds focused command-level coverage for the recent CORS bucket-path normalization fix. The `cors` command already rejected `local///` in the helper, but the user-facing entrypoints still had no direct regression tests proving that `list`, `set`, and `remove` all stop at argument validation and return a usage error.

## Problem
The recent fix in `crates/cli/src/commands/cors.rs` rejects bucket paths whose normalized bucket name becomes empty after trimming trailing slashes. That behavior was only covered at the `parse_bucket_path` helper level. If a later refactor changed command validation order or accidentally let `set` read its source before validating the path, the regression would not be caught by the existing tests.

## Root Cause
Coverage stopped one layer too low. The helper test proved parsing behavior, but it did not verify the command entrypoints or the validation order for `set`.

## Fix
I added three async command tests in `crates/cli/src/commands/cors.rs`:

- `list` returns `UsageError` for `local///`
- `set` returns `UsageError` for `local///` before trying to read the source file
- `remove` returns `UsageError` for `local///`

These tests stay tightly scoped to the recent CORS change and avoid broader refactors or new harness code.

## Validation
I could not run `make pre-commit` because this repository does not define that target or a `Makefile`. I ran the documented equivalent checks directly instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
