### PR TITLE
fix(formatter): classify unsupported feature errors

### DIFF
--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -148,7 +148,10 @@ fn infer_error_metadata(message: &str) -> (&'static str, bool, Option<String>) {
         return ("conflict", false, Some(CONFLICT_SUGGESTION.to_string()));
     }
 
-    if normalized.contains("does not support") || normalized.contains("unsupported") {
+    if normalized.contains("does not support")
+        || normalized.contains("unsupported")
+        || normalized.contains("not yet supported")
+    {
         return (
             "unsupported_feature",
             false,
@@ -539,6 +542,30 @@ mod tests {
                 "message: {message}"
             );
         }
+    }
+
+    #[test]
+    fn test_error_descriptor_from_message_infers_conflict() {
+        let descriptor = ErrorDescriptor::from_message("Destination exists: report.json");
+        let json = descriptor.to_json_output();
+
+        let details = json.details.expect("details should be present");
+        assert_eq!(details.error_type, "conflict");
+        assert!(!details.retryable);
+        assert_eq!(details.suggestion.as_deref(), Some(CONFLICT_SUGGESTION));
+    }
+
+    #[test]
+    fn test_error_descriptor_from_message_infers_unsupported_feature() {
+        let descriptor = ErrorDescriptor::from_message(
+            "Cross-alias S3-to-S3 copy not yet supported. Use download + upload.",
+        );
+        let json = descriptor.to_json_output();
+
+        let details = json.details.expect("details should be present");
+        assert_eq!(details.error_type, "unsupported_feature");
+        assert!(!details.retryable);
+        assert_eq!(details.suggestion.as_deref(), Some(UNSUPPORTED_SUGGESTION));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This change closes a formatter regression in the phase-3 structured error work. The formatter already inferred `unsupported_feature` for messages containing `unsupported` or `does not support`, but one of the new command error strings uses the phrase `not yet supported` instead. That path fell through to `general_error`, which meant JSON error output lost the expected error type and recovery hint.

The fix keeps scope narrow. It adds focused regression tests for the message-based `conflict` and `unsupported_feature` inference branches, then extends the unsupported-feature classifier to recognize `not yet supported` messages. The new unsupported test failed before this change and now passes with the classifier update.

## Validation

I attempted to run `make pre-commit`, but this repository does not define that target or a `Makefile`/`justfile`. I ran the equivalent required checks from `AGENTS.md` instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
