### PR TITLE
test(formatter): cover conflict and network inference

### DIFF
--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -569,6 +569,18 @@ mod tests {
     }
 
     #[test]
+    fn test_error_descriptor_from_message_infers_retryable_network_error() {
+        let descriptor =
+            ErrorDescriptor::from_message("Service temporarily unavailable while connecting");
+        let json = descriptor.to_json_output();
+
+        let details = json.details.expect("details should be present");
+        assert_eq!(details.error_type, "network_error");
+        assert!(details.retryable);
+        assert_eq!(details.suggestion.as_deref(), Some(NETWORK_SUGGESTION));
+    }
+
+    #[test]
     fn test_error_with_suggestion_overrides_default_hint() {
         let descriptor = ErrorDescriptor::from_code(
             ExitCode::UnsupportedFeature,


### PR DESCRIPTION
## Summary

This change adds focused formatter coverage for the retryable network message-inference branch introduced by the structured error handling work.

## Root Cause

The formatter infers JSON error metadata from raw error strings, but unit coverage did not directly assert that temporary availability and network messages map to retryable network_error output.

## Fix

Add a narrow unit test in crates/cli/src/output/formatter.rs that verifies temporary service/network messages produce error_type = network_error, are retryable, and carry the network suggestion.

## Validation

- cargo test -p rustfs-cli output::formatter::tests::test_error_descriptor_from_message_infers_retryable_network_error
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace

## Note

The conflict inference branch is covered by the related formatter PR, so this PR stays focused on the network branch only.
