### PR TITLE
test(cli): cover top-level event parser aliases

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -512,6 +512,33 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_top_level_event_add_subcommand() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "event",
+            "add",
+            "local/my-bucket",
+            "arn:aws:sqs:us-east-1:123456789012:jobs",
+            "--event",
+            "put,delete",
+            "--force",
+        ])
+        .expect("parse top-level event add");
+
+        match cli.command {
+            Commands::Event(event::EventArgs {
+                command: event::EventCommands::Add(arg),
+            }) => {
+                assert_eq!(arg.path, "local/my-bucket");
+                assert_eq!(arg.arn, "arn:aws:sqs:us-east-1:123456789012:jobs");
+                assert_eq!(arg.events, vec!["put,delete".to_string()]);
+                assert!(arg.force);
+            }
+            other => panic!("expected top-level event add command, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_object_list_alias() {
         let cli = Cli::try_parse_from(["rc", "object", "ls", "local/my-bucket/logs/"])
             .expect("parse object ls alias");
@@ -524,6 +551,30 @@ mod tests {
                 other => panic!("expected object list alias, got {:?}", other),
             },
             other => panic!("expected object command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_top_level_event_remove_subcommand() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "event",
+            "remove",
+            "local/my-bucket",
+            "arn:aws:sns:us-east-1:123456789012:alerts",
+            "--force",
+        ])
+        .expect("parse top-level event remove");
+
+        match cli.command {
+            Commands::Event(event::EventArgs {
+                command: event::EventCommands::Remove(arg),
+            }) => {
+                assert_eq!(arg.path, "local/my-bucket");
+                assert_eq!(arg.arn, "arn:aws:sns:us-east-1:123456789012:alerts");
+                assert!(arg.force);
+            }
+            other => panic!("expected top-level event remove command, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
## Summary
This adds focused parser coverage for the deprecated top-level `rc event` entrypoints that were rewired through `EventArgs` in the recent command-surface updates.

The current parser tests cover nested `rc bucket event ...` forms and one top-level `rc event list ...` compatibility path, but they do not assert that the top-level `add` and `remove` flows still deserialize correctly. That leaves a regression gap around the exact deprecated aliases users may still invoke after the `Commands::Event(event::EventArgs)` wiring change.

## Root cause
Coverage stopped at the list alias. The parser test suite did not exercise the more argument-heavy top-level `event add` and `event remove` branches, so a clap wiring regression there could go unnoticed while adjacent tests still passed.

## Fix
Add two parser tests in `crates/cli/src/commands/mod.rs` that verify:

- `rc event add <path> <arn> --event put,delete --force`
- `rc event remove <path> <arn> --force`

Both assertions confirm the top-level deprecated entrypoint still resolves through `EventArgs`, preserves the expected positional arguments, and forwards the `--force` and `--event` flags.

## Validation
I ran these successfully:

- `cargo test -p rustfs-cli cli_accepts_top_level_event_ --lib`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also attempted `make pre-commit` because the automation requires it, but `origin/main` does not define a `pre-commit` target, so `make` exits with `No rule to make target 'pre-commit'.`
