### PR TITLE
test(s3): cover delete object error mapping

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -789,8 +789,23 @@ impl S3Client {
         }
 
         request.send().await.map_err(|e| {
-            let err_str = e.to_string();
-            if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
+            let err_str = Self::format_sdk_error(&e);
+            let is_missing_key = if let aws_sdk_s3::error::SdkError::ServiceError(service_err) = &e
+            {
+                let code = service_err.err().code().or_else(|| {
+                    service_err
+                        .raw()
+                        .headers()
+                        .get("x-amz-error-code")
+                        .and_then(|value| std::str::from_utf8(value.as_bytes()).ok())
+                });
+                matches!(code, Some("NoSuchKey") | Some("NotFound"))
+                    || service_err.raw().status().as_u16() == 404
+            } else {
+                err_str.contains("NotFound") || err_str.contains("NoSuchKey")
+            };
+
+            if is_missing_key {
                 Error::NotFound(path.to_string())
             } else {
                 Error::Network(err_str)
@@ -3346,6 +3361,58 @@ mod tests {
 
         let request = request_receiver.expect_request();
         assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_object_with_options_maps_missing_keys_to_not_found() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NoSuchKey")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NoSuchKey</Code>
+  <Message>The specified key does not exist.</Message>
+</Error>"#,
+            ))
+            .expect("build delete object response");
+        let (client, _request_receiver) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "bucket", "missing.txt");
+
+        let result = client
+            .delete_object_with_options(&path, DeleteRequestOptions::default())
+            .await;
+
+        match result {
+            Err(Error::NotFound(message)) => assert_eq!(message, path.to_string()),
+            other => panic!("Expected NotFound for missing key, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_object_with_options_maps_other_failures_to_network() {
+        let response = http::Response::builder()
+            .status(500)
+            .header("x-amz-error-code", "InternalError")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>Something went wrong.</Message>
+</Error>"#,
+            ))
+            .expect("build delete object response");
+        let (client, _request_receiver) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "bucket", "key.txt");
+
+        let result = client
+            .delete_object_with_options(&path, DeleteRequestOptions::default())
+            .await;
+
+        match result {
+            Err(Error::Network(message)) => assert!(message.contains("InternalError")),
+            other => panic!("Expected Network for delete failure, got: {other:?}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
This change closes a test gap in the recent RustFS force-delete work by covering the delete-object error path in `crates/s3/src/client.rs`.

The recent delete-with-options implementation already had tests for the custom `x-rustfs-force-delete` header, but it did not verify how SDK service errors were classified. That left a real behavior gap: when the backend returned a missing-key service error, the code collapsed it to a generic `"service error"` string and surfaced it as a network error instead of `Error::NotFound`.

This patch adds focused unit tests for the two relevant branches and updates the delete-object path to inspect service error metadata before mapping the result. Missing-key responses now map to `Error::NotFound`, while other service failures remain network errors with a more informative message.

## Validation
I first added the missing tests and confirmed they failed against the original implementation. After the minimal fix, the focused `rc-s3` tests passed.

The repository does not contain a `Makefile` or a `make pre-commit` target, so I ran the documented project checks directly instead:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
