### PR TITLE
test(cli): cover noun-first stat and share help

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -472,4 +472,20 @@ mod tests {
             other => panic!("expected bucket command, got {:?}", other),
         }
     }
+
+    #[test]
+    fn cli_accepts_object_stat_subcommand() {
+        let cli = Cli::try_parse_from(["rc", "object", "stat", "local/my-bucket/report.json"])
+            .expect("parse object stat");
+
+        match cli.command {
+            Commands::Object(args) => match args.command {
+                object::ObjectCommands::Stat(arg) => {
+                    assert_eq!(arg.path, "local/my-bucket/report.json");
+                }
+                other => panic!("expected object stat command, got {:?}", other),
+            },
+            other => panic!("expected object command, got {:?}", other),
+        }
+    }
 }

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -457,6 +457,16 @@ fn nested_subcommand_help_contract() {
             expected_tokens: &["--enc-key", "--rewind", "--version-id"],
         },
         HelpCase {
+            args: &["object", "stat"],
+            usage: "Usage: rc object stat [OPTIONS] <PATH>",
+            expected_tokens: &["--version-id", "--rewind"],
+        },
+        HelpCase {
+            args: &["object", "share"],
+            usage: "Usage: rc object share [OPTIONS] <PATH>",
+            expected_tokens: &["--expire", "--upload", "--content-type"],
+        },
+        HelpCase {
             args: &["admin", "user", "info"],
             usage: "Usage: rc admin user info [OPTIONS] <ALIAS> <ACCESS_KEY>",
             expected_tokens: &[],


### PR DESCRIPTION
## Summary
This change adds focused contract coverage for the noun-first object commands introduced in the recent bucket/object command-group work. The existing help contract suite already covered `rc object copy` and `rc object show`, but it did not assert discoverability for delegated `rc object stat` and `rc object share` subcommands, and there was no direct parser test for `rc object stat`.

## Root cause
The noun-first command groups were added with thin delegation to the existing command implementations, but only a subset of those delegated paths received fast parser/help coverage. That left a gap where regressions in `rc object stat` or `rc object share` discoverability could slip through even though those commands are part of the user-facing noun-first surface.

## Fix
The help contract test matrix now includes `rc object stat --help` and `rc object share --help`, asserting the usage shape and their key option tokens. The CLI unit tests also now parse `rc object stat local/my-bucket/report.json` and verify it routes to `ObjectCommands::Stat` with the expected path.

## Validation
I first ran focused tests for the touched areas:
- `cargo test -p rustfs-cli --test help_contract nested_subcommand_help_contract`
- `cargo test -p rustfs-cli cli_accepts_object_stat_subcommand`

I then ran the repository's documented checks:
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also attempted `make pre-commit` because the automation requested it, but this repository currently has no `Makefile` or `pre-commit` target, so that exact command cannot be executed in this checkout.
