### PR TITLE
test(cli): cover rm purge default option

### DIFF
--- a/crates/cli/src/commands/rm.rs
+++ b/crates/cli/src/commands/rm.rs
@@ -436,4 +436,21 @@ mod tests {
         let options = delete_request_options(&args);
         assert!(options.force_delete);
     }
+
+    #[test]
+    fn test_delete_request_options_disable_force_delete_by_default() {
+        let args = RmArgs {
+            paths: vec!["test/bucket/object.txt".to_string()],
+            recursive: false,
+            force: false,
+            dry_run: false,
+            incomplete: false,
+            versions: false,
+            bypass: false,
+            purge: false,
+        };
+
+        let options = delete_request_options(&args);
+        assert!(!options.force_delete);
+    }
 }


### PR DESCRIPTION
## Summary
This adds a focused unit test for the default `rm --purge` behavior.

The recent force-delete support already had coverage for the enabled path and integration coverage for permanent deletion behavior, but the opposite branch was still untested: when `--purge` is not supplied, the CLI should keep `force_delete` disabled in the delete request options. This PR adds that missing assertion without changing production code.

## Root Cause
PR #82 introduced the `purge` flag and added a unit test for the `true` case only. That left the default `false` branch unguarded, even though the flag wiring is security-sensitive because it controls whether RustFS permanent deletion headers are sent.

## Fix
Add `test_delete_request_options_disable_force_delete_by_default` in `crates/cli/src/commands/rm.rs` and assert that `delete_request_options` keeps `force_delete` set to `false` when `purge` is not provided.

## Validation
`make pre-commit` is not defined in this checkout, so I ran the repository's required checks directly:

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo test -p rustfs-cli test_delete_request_options_disable_force_delete_by_default`

## Notes
I also checked for an existing open PR on this topic and avoided duplicating the parser coverage already proposed in PR #98.
