### PR TITLE
test(cors): cover empty normalized bucket paths

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -533,6 +533,8 @@ mod tests {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
+        assert!(parse_bucket_path("local/").is_err());
+        assert!(parse_bucket_path("local//").is_err());
         assert!(parse_bucket_path("local///").is_err());
     }
 


### PR DESCRIPTION
## Summary
This change adds focused unit coverage for the CORS bucket-path normalization fix introduced in the recent `cors` parser update.

The production code now rejects paths whose bucket segment becomes empty after trimming trailing slashes, but the existing regression test only covered the `local///` case. That left the simpler `local/` and `local//` variants on the same code path untested.

This PR adds assertions for those two inputs in the existing parser error test. The scope stays limited to the changed area and does not alter runtime behavior.

## User impact
Users were already protected by the parser fix, but these two empty-bucket forms were not pinned by tests. Adding them reduces the chance of a future regression reintroducing acceptance of invalid CORS bucket paths.

## Validation
- `cargo test test_parse_bucket_path_error`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Note: the automation requested `make pre-commit`, but this repository does not define that target. I ran the equivalent CI checks directly from `.github/workflows/ci.yml` instead.
