### PR TITLE
test(s3): cover batch delete default force header

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3196,6 +3196,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_without_force_delete_omits_rustfs_header() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/" />"#,
+            ))
+            .expect("build delete objects response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let _ = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["key.txt".to_string()],
+                DeleteRequestOptions::default(),
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
This change adds focused coverage for the batch delete path introduced by the RustFS force-delete support.
The recent `rm --purge` work already verified that batched deletes send the custom header when force delete is enabled, but it did not cover the opposite branch.
Without this test, a regression could silently start sending the RustFS-specific header on ordinary batch deletes.

## Root cause
The feature added conditional header wiring in both single-object and batch delete requests.
Only the positive batch case was exercised, so the default path remained unverified.

## Fix
Add a unit test in `rc-s3` that issues `delete_objects_with_options` with `DeleteRequestOptions::default()` and asserts that `x-rustfs-force-delete` is omitted.
The change stays within the recent delete-path work and does not alter runtime behavior.

## Validation
- `cargo test -p rc-s3 delete_objects_without_force_delete_omits_rustfs_header`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

## Notes
`make pre-commit` is not available in this repository, so validation used the equivalent CI commands defined in `AGENTS.md` and `.github/workflows/ci.yml`.
