### PR TITLE
test(s3): cover batch delete partial response

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3425,6 +3425,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_objects_with_partial_errors_returns_deleted_keys() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<DeleteResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Deleted>
+    <Key>kept.txt</Key>
+  </Deleted>
+  <Error>
+    <Key>failed.txt</Key>
+    <Code>AccessDenied</Code>
+    <Message>Access Denied</Message>
+  </Error>
+</DeleteResult>"#,
+            ))
+            .expect("build partial delete response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let deleted = client
+            .delete_objects_with_options(
+                "bucket",
+                vec!["kept.txt".to_string(), "failed.txt".to_string()],
+                DeleteRequestOptions::default(),
+            )
+            .await
+            .expect("partial delete should still return deleted keys");
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.uri(), "https://example.com/bucket/?delete");
+        assert_eq!(deleted, vec!["kept.txt".to_string()]);
+    }
+
+    #[tokio::test]
     async fn read_next_part_fills_buffer_until_eof() {
         use tokio::io::AsyncWriteExt;
 


### PR DESCRIPTION
## Summary
This adds focused regression coverage for the batch delete path introduced with the recent RustFS force-delete work.

The new `delete_objects_with_options` helper now handles RustFS-specific request options and parses S3 batch delete responses. The existing tests cover the force-delete header behavior, but they do not exercise the branch where the backend returns a mixed response with both `<Deleted>` and `<Error>` entries. That left a gap in the changed code where a future refactor could incorrectly fail the whole request or drop successfully deleted keys.

## Root cause
The follow-up test coverage around `rm --purge` concentrated on request construction and the full purge flow. It did not assert the non-fatal partial-success behavior already implemented in `delete_objects_with_options`.

## Fix
This PR adds one narrow unit test in `crates/s3/src/client.rs` that feeds a mixed `DeleteResult` payload into the captured request client and verifies two things:

1. the batch delete request is still issued to the expected delete endpoint;
2. the client returns only the successfully deleted keys instead of treating the partial response as a hard failure.

The change is test-only and stays inside the recently modified S3 delete helper.

## Validation
I ran the required checks successfully:

- `cargo test -p rc-s3 delete_objects_with_partial_errors_returns_deleted_keys --lib`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

I also ran `make pre-commit` per the automation instruction, but this checkout does not define that target and `make` returned `No rule to make target 'pre-commit'.`
