### PR TITLE
test(s3): cover bucket cors set request

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3022,6 +3022,48 @@ mod tests {
         assert_eq!(sdk_rule.max_age_seconds(), Some(600));
     }
 
+    #[tokio::test]
+    async fn set_bucket_cors_sends_rule_fields() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(""))
+            .expect("build put bucket cors response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        client
+            .set_bucket_cors(
+                "bucket",
+                vec![CorsRule {
+                    id: Some("web-app".to_string()),
+                    allowed_origins: vec!["https://app.example.com".to_string()],
+                    allowed_methods: vec!["GET".to_string(), "POST".to_string()],
+                    allowed_headers: Some(vec!["Authorization".to_string()]),
+                    expose_headers: Some(vec!["ETag".to_string()]),
+                    max_age_seconds: Some(600),
+                }],
+            )
+            .await
+            .expect("set bucket cors");
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.method(), http::Method::PUT);
+        assert!(
+            request.uri().to_string().contains("?cors"),
+            "expected bucket CORS subresource in URI: {}",
+            request.uri()
+        );
+
+        let body = request.body().bytes().expect("request body bytes");
+        let body = std::str::from_utf8(body).expect("request body is utf8");
+        assert!(body.contains("<ID>web-app</ID>"));
+        assert!(body.contains("<AllowedOrigin>https://app.example.com</AllowedOrigin>"));
+        assert!(body.contains("<AllowedMethod>GET</AllowedMethod>"));
+        assert!(body.contains("<AllowedMethod>POST</AllowedMethod>"));
+        assert!(body.contains("<AllowedHeader>Authorization</AllowedHeader>"));
+        assert!(body.contains("<ExposeHeader>ETag</ExposeHeader>"));
+        assert!(body.contains("<MaxAgeSeconds>600</MaxAgeSeconds>"));
+    }
+
     #[test]
     fn parse_cors_configuration_xml_round_trips_rule_fields() {
         let body = r#"


### PR DESCRIPTION
## Related issue

No specific issue. This follows the test-gap automation for recent bucket CORS changes.

## Background

Recent work added bucket CORS management through the S3 adapter. Existing unit coverage checked the core rule conversion and XML parsing paths, but did not assert that `set_bucket_cors` actually sends the expected PUT request and serialized CORS rule fields to the backend.

## Root cause

The request-building path was only covered indirectly. A regression in the SDK request wiring, subresource URI, or serialized CORS fields could pass the existing conversion tests while still producing an incorrect backend request.

## Solution

Added a focused S3 client unit test that captures the `set_bucket_cors` request and verifies the PUT method, CORS subresource URI, and serialized rule fields including ID, origins, methods, allowed headers, exposed headers, and max age seconds.

## Validation

`cargo test -p rc-s3 set_bucket_cors_sends_rule_fields`

`cargo fmt --all --check`

`cargo fmt --all && cargo clippy --workspace -- -D warnings`

`cargo test --workspace`

`make pre-commit` was requested but this repository does not contain a Makefile or a `pre-commit` target, so the equivalent required Rust checks above were run directly.
