### PR TITLE
test(cli): cover cp local json error

### DIFF
--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -1,0 +1,75 @@
+//! CLI error output contract tests.
+//!
+//! These tests cover local validation paths that do not require a running S3
+//! backend but still need stable JSON error metadata.
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+fn rc_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rc") {
+        return PathBuf::from(path);
+    }
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has parent directory")
+        .parent()
+        .expect("workspace root exists")
+        .to_path_buf();
+
+    let debug_binary = workspace_root.join("target/debug/rc");
+    if debug_binary.exists() {
+        return debug_binary;
+    }
+
+    workspace_root.join("target/release/rc")
+}
+
+fn run_rc(args: &[&str]) -> Output {
+    Command::new(rc_binary())
+        .args(args)
+        .output()
+        .expect("failed to execute rc")
+}
+
+#[test]
+fn cp_local_to_local_json_error_reports_usage_metadata() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let source = temp_dir.path().join("source.txt");
+    let target = temp_dir.path().join("target.txt");
+    std::fs::write(&source, b"source").expect("write source file");
+    std::fs::write(&target, b"target").expect("write target file");
+
+    let output = run_rc(&[
+        "cp",
+        source.to_str().expect("source path is valid utf-8"),
+        target.to_str().expect("target path is valid utf-8"),
+        "--json",
+    ]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
+
+    assert_eq!(
+        json["error"],
+        "Cannot copy between two local paths. Use system cp command."
+    );
+    assert_eq!(json["code"], 2);
+    assert_eq!(json["details"]["type"], "usage_error");
+    assert_eq!(
+        json["details"]["message"],
+        "Cannot copy between two local paths. Use system cp command."
+    );
+    assert_eq!(json["details"]["retryable"], false);
+    assert_eq!(
+        json["details"]["suggestion"],
+        "Use your local shell cp command when both paths are on the filesystem."
+    );
+}


### PR DESCRIPTION
## Related issue

Automated test-gap detection for recent CLI structured-error changes.

## Background and user impact

The cp command now emits structured JSON usage errors for local validation failures. The local-to-local copy path does not need S3, so it is a good candidate for a small regression test that proves users get machine-readable error metadata when they request JSON output.

## Root cause

Existing tests covered cp parsing helpers and output serialization, but did not exercise the CLI binary path where two local filesystem paths are rejected under --json. That left the stderr JSON shape, exit code, error type, retryability flag, and custom suggestion unverified.

## Solution

Added a focused error contract test that creates two temporary local files, runs rc cp source target --json, and asserts the command exits with usage code 2 while emitting the expected structured JSON error on stderr and no stdout.

## Validation

- make pre-commit was requested but unavailable because this checkout has no Makefile or pre-commit target.
- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo test -p rustfs-cli --test error_contract cp_local_to_local_json_error_reports_usage_metadata
