### PR TITLE
test(cli): cover cors parser alias and force

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -440,6 +440,19 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_top_level_cors_get_alias() {
+        let cli = Cli::try_parse_from(["rc", "cors", "get", "local/my-bucket"])
+            .expect("parse top-level cors get");
+
+        match cli.command {
+            Commands::Cors(cors::CorsCommands::List(arg)) => {
+                assert_eq!(arg.path, "local/my-bucket");
+            }
+            other => panic!("expected top-level cors get alias, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_bucket_cors_get_alias() {
         let cli = Cli::try_parse_from(["rc", "bucket", "cors", "get", "local/my-bucket"])
             .expect("parse bucket cors get");
@@ -450,6 +463,24 @@ mod tests {
                     assert_eq!(arg.path, "local/my-bucket");
                 }
                 other => panic!("expected bucket cors get alias, got {:?}", other),
+            },
+            other => panic!("expected bucket command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_bucket_cors_list_force_flag() {
+        let cli =
+            Cli::try_parse_from(["rc", "bucket", "cors", "list", "local/my-bucket", "--force"])
+                .expect("parse bucket cors list with force");
+
+        match cli.command {
+            Commands::Bucket(args) => match args.command {
+                bucket::BucketCommands::Cors(cors::CorsCommands::List(arg)) => {
+                    assert_eq!(arg.path, "local/my-bucket");
+                    assert!(arg.force);
+                }
+                other => panic!("expected bucket cors list command, got {:?}", other),
             },
             other => panic!("expected bucket command, got {:?}", other),
         }


### PR DESCRIPTION
## Summary

Adds focused parser coverage for recent bucket CORS command surfaces.

The recent CORS command work supports both nested bucket commands and the deprecated top-level `rc cors` form. Existing tests covered several nested command paths, but they did not assert that the top-level `get` alias resolves to the list operation or that the CORS `--force` flag is preserved through nested list parsing.

This PR adds two narrow CLI parser tests in `crates/cli/src/commands/mod.rs`:

- `rc cors get local/my-bucket` maps to `CorsCommands::List`.
- `rc bucket cors list local/my-bucket --force` keeps `force = true`.

No runtime CORS behavior or S3 request code is changed.

## Validation

- `cargo fmt --all --check`
- `cargo test -p rustfs-cli cors`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

Note: `make pre-commit` was requested, but this checkout has no Makefile and `make` reports `No rule to make target pre-commit`.
