### PR TITLE
test(cors): reject object paths for bucket cors

### DIFF
--- a/crates/cli/src/commands/cors.rs
+++ b/crates/cli/src/commands/cors.rs
@@ -378,7 +378,7 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
     }
 
     let bucket = parts[1].trim_end_matches('/');
-    if bucket.is_empty() {
+    if bucket.is_empty() || bucket.contains('/') {
         return Err("Bucket path must be in format alias/bucket".to_string());
     }
 
@@ -534,6 +534,7 @@ mod tests {
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
         assert!(parse_bucket_path("local///").is_err());
+        assert!(parse_bucket_path("local/my-bucket/object.txt").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR closes a small test gap in the new bucket CORS path handling. The CORS commands are documented and implemented as bucket-level operations, so object-style targets such as local/my-bucket/object.txt should be rejected before any network operation is attempted.

The previous parser only split the path into alias and the remaining string, then trimmed trailing slashes. That meant local/my-bucket/object.txt was accepted as a bucket name containing a slash, which could lead users toward confusing downstream S3 errors instead of a direct usage error.

The fix keeps trailing slash support for local/my-bucket/ but rejects bucket targets that still contain a slash after normalization. The focused unit test covers this rejected object-path case alongside the existing invalid CORS bucket path cases.

## Validation

- cargo test -p rustfs-cli commands::cors::tests::test_parse_bucket_path_error
- make pre-commit (unavailable: no pre-commit target exists)
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace