### PR TITLE
test(cli): reject object paths for ilm rules

### DIFF
--- a/crates/cli/src/commands/ilm/rule.rs
+++ b/crates/cli/src/commands/ilm/rule.rs
@@ -799,15 +799,16 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
         return Err("Path cannot be empty".to_string());
     }
 
-    let parts: Vec<&str> = path.splitn(2, '/').collect();
+    let parts: Vec<&str> = path.split('/').collect();
     if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
         return Err("Bucket path must be in format alias/bucket".to_string());
     }
 
-    Ok((
-        parts[0].to_string(),
-        parts[1].trim_end_matches('/').to_string(),
-    ))
+    if parts.iter().skip(2).any(|part| !part.is_empty()) {
+        return Err("Bucket path must not include an object key".to_string());
+    }
+
+    Ok((parts[0].to_string(), parts[1].to_string()))
 }
 
 fn generate_rule_id() -> String {
@@ -866,6 +867,8 @@ mod tests {
         assert!(parse_bucket_path("").is_err());
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
+        assert!(parse_bucket_path("local/my-bucket/key.txt").is_err());
+        assert!(parse_bucket_path("local/my-bucket/path/to/key.txt").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR closes a small lifecycle command test gap in the ILM rule bucket path parser.

The `ilm rule` commands document bucket paths as `alias/bucket`, but the parser previously split at the first slash and accepted paths such as `local/my-bucket/key.txt`. That treated `my-bucket/key.txt` as the bucket name, so an object-style path could get past local validation and fail later as a confusing bucket lookup or backend request.

The fix keeps trailing slashes valid for bucket paths while rejecting any non-empty path segments after the bucket. The added regression assertions cover both one-segment and nested object keys.

## Validation

- `cargo test -p rustfs-cli commands::ilm::rule::tests::test_parse_bucket_path_error`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

`make pre-commit` was requested, but this repository checkout has no `Makefile` and no `pre-commit` target, so it could not be run.
