### PR TITLE
test(cli): reject object paths for replication

### DIFF
--- a/crates/cli/src/commands/replicate.rs
+++ b/crates/cli/src/commands/replicate.rs
@@ -994,10 +994,14 @@ fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
         return Err("Path cannot be empty".to_string());
     }
 
-    let parts: Vec<&str> = path.splitn(2, '/').collect();
+    let parts: Vec<&str> = path.splitn(3, '/').collect();
 
     if parts.len() < 2 || parts[0].is_empty() {
         return Err("Alias name is required (ALIAS/BUCKET)".to_string());
+    }
+
+    if parts.get(2).is_some_and(|key| !key.is_empty()) {
+        return Err("Replication path must target a bucket, not an object path".to_string());
     }
 
     let bucket = parts[1].trim_end_matches('/');
@@ -1279,6 +1283,7 @@ mod tests {
         assert!(parse_bucket_path("local").is_err());
         assert!(parse_bucket_path("/bucket").is_err());
         assert!(parse_bucket_path("local/").is_err());
+        assert!(parse_bucket_path("local/my-bucket/object.txt").is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Related issue(s)

No specific issue. This is a focused test-gap fix from recent replication command-path behavior.

## Background

Bucket replication commands operate at bucket scope. Before this change, the replication path parser accepted values like `local/my-bucket/object.txt` and treated `my-bucket/object.txt` as the bucket name. That delayed the error until bucket lookup and produced a misleading bucket-not-found style failure instead of rejecting the object path up front.

## Root cause

`parse_bucket_path` split the path into only two segments, so any additional slash stayed inside the bucket segment.

## Solution

The parser now splits enough to detect an extra object-key segment and returns a usage error for object paths. The existing parser error test now covers this regression case.

## Validation

- `cargo test -p rustfs-cli commands::replicate::tests::test_parse_bucket_path_errors` failed before the parser fix and passes after it.
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

Note: `make pre-commit` could not run because this repository checkout has no `Makefile` and no `pre-commit` make target.
