### PR TITLE
test(cli): cover bucket lifecycle and replication parser

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -472,4 +472,55 @@ mod tests {
             other => panic!("expected bucket command, got {:?}", other),
         }
     }
+
+    #[test]
+    fn cli_accepts_bucket_lifecycle_subcommand() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "bucket",
+            "lifecycle",
+            "rule",
+            "list",
+            "local/my-bucket",
+        ])
+        .expect("parse bucket lifecycle rule list");
+
+        match cli.command {
+            Commands::Bucket(args) => match args.command {
+                bucket::BucketCommands::Lifecycle(ilm::IlmArgs {
+                    command: ilm::IlmCommands::Rule(ilm::rule::RuleCommands::List(arg)),
+                }) => {
+                    assert_eq!(arg.path, "local/my-bucket");
+                    assert!(!arg.force);
+                }
+                other => panic!(
+                    "expected bucket lifecycle rule list command, got {:?}",
+                    other
+                ),
+            },
+            other => panic!("expected bucket command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_bucket_replication_subcommand() {
+        let cli = Cli::try_parse_from(["rc", "bucket", "replication", "status", "local/my-bucket"])
+            .expect("parse bucket replication status");
+
+        match cli.command {
+            Commands::Bucket(args) => match args.command {
+                bucket::BucketCommands::Replication(replicate::ReplicateArgs {
+                    command: replicate::ReplicateCommands::Status(arg),
+                }) => {
+                    assert_eq!(arg.path, "local/my-bucket");
+                    assert!(!arg.force);
+                }
+                other => panic!(
+                    "expected bucket replication status command, got {:?}",
+                    other
+                ),
+            },
+            other => panic!("expected bucket command, got {:?}", other),
+        }
+    }
 }


### PR DESCRIPTION
## Related issue(s)

No linked issue. Automation run for recent test-gap detection.

## Background

The noun-first bucket command surface has direct parser coverage for bucket CORS routing, but the sibling bucket lifecycle and bucket replication routes only had help-contract coverage. That left the dispatch layer for these recently added aliases less explicitly guarded.

## Root cause

The command parser tests asserted top-level CORS and bucket CORS routing, but did not assert that `rc bucket lifecycle rule list ...` reaches the ILM rule command or that `rc bucket replication status ...` reaches the replication command with the expected path and force defaults.

## Solution

Added two focused parser unit tests in `crates/cli/src/commands/mod.rs` for the bucket lifecycle and bucket replication command routes.

## Validation

- `cargo test -p rustfs-cli cli_accepts_bucket_`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

Note: `make pre-commit` could not be run because this repository currently has no `Makefile` and no `pre-commit` make target. The documented equivalent Rust checks above passed.
