### PR TITLE
fix(cp): show progress for large downloads

### DIFF
--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -205,6 +205,27 @@ async fn copy_local_to_s3(
 
 /// Multipart upload threshold: files at least this size use multipart upload (64 MiB)
 const MULTIPART_THRESHOLD: u64 = 64 * 1024 * 1024;
+/// Download progress threshold: avoid flicker for tiny downloads while surfacing meaningful waits.
+const DOWNLOAD_PROGRESS_THRESHOLD: u64 = 4 * 1024 * 1024;
+
+fn update_download_progress(
+    progress: &mut Option<ProgressBar>,
+    output_config: &OutputConfig,
+    bytes_downloaded: u64,
+    total_size: Option<u64>,
+) {
+    let Some(total_size) = total_size else {
+        return;
+    };
+
+    if total_size < DOWNLOAD_PROGRESS_THRESHOLD {
+        return;
+    }
+
+    let progress_bar =
+        progress.get_or_insert_with(|| ProgressBar::new(output_config.clone(), total_size));
+    progress_bar.set_position(bytes_downloaded);
+}
 
 fn print_upload_success(
     formatter: &Formatter,
@@ -484,8 +505,21 @@ async fn download_file(
         );
     }
 
+    let output_config = formatter.output_config();
+    let mut progress = None;
+
     // Download object
-    match client.get_object(src).await {
+    let result = client
+        .get_object_with_progress(src, |bytes_downloaded, total_size| {
+            update_download_progress(&mut progress, &output_config, bytes_downloaded, total_size);
+        })
+        .await;
+
+    if let Some(ref pb) = progress {
+        pb.finish_and_clear();
+    }
+
+    match result {
         Ok(data) => {
             let size = data.len() as i64;
 
@@ -765,6 +799,38 @@ mod tests {
             assert_eq!(r.bucket, "bucket");
             assert_eq!(r.key, "dir1/dir2/file.txt");
         }
+    }
+
+    #[test]
+    fn test_download_progress_created_for_large_transfer() {
+        let output_config = OutputConfig::default();
+        let mut progress = None;
+
+        update_download_progress(
+            &mut progress,
+            &output_config,
+            1024,
+            Some(DOWNLOAD_PROGRESS_THRESHOLD),
+        );
+
+        let progress = progress.expect("large download should create progress bar");
+        assert!(progress.is_visible());
+        progress.finish_and_clear();
+    }
+
+    #[test]
+    fn test_download_progress_skips_small_transfer() {
+        let output_config = OutputConfig::default();
+        let mut progress = None;
+
+        update_download_progress(
+            &mut progress,
+            &output_config,
+            1024,
+            Some(DOWNLOAD_PROGRESS_THRESHOLD - 1),
+        );
+
+        assert!(progress.is_none());
     }
 
     #[test]

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -721,6 +721,52 @@ impl S3Client {
         &self.inner
     }
 
+    /// Download object content and report downloaded bytes after each received chunk.
+    pub async fn get_object_with_progress(
+        &self,
+        path: &RemotePath,
+        mut on_progress: impl FnMut(u64, Option<u64>) + Send,
+    ) -> Result<Vec<u8>> {
+        let response = self
+            .inner
+            .get_object()
+            .bucket(&path.bucket)
+            .key(&path.key)
+            .send()
+            .await
+            .map_err(|e| {
+                let err_str = e.to_string();
+                if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
+                    Error::NotFound(path.to_string())
+                } else {
+                    Error::Network(err_str)
+                }
+            })?;
+
+        let content_length = response
+            .content_length()
+            .and_then(|length| u64::try_from(length).ok());
+        let mut data = Vec::with_capacity(
+            content_length
+                .and_then(|length| usize::try_from(length).ok())
+                .unwrap_or_default(),
+        );
+        let mut body = response.body;
+        let mut bytes_downloaded = 0u64;
+
+        while let Some(chunk) = body
+            .try_next()
+            .await
+            .map_err(|e| Error::Network(e.to_string()))?
+        {
+            bytes_downloaded += chunk.len() as u64;
+            data.extend_from_slice(&chunk);
+            on_progress(bytes_downloaded, content_length);
+        }
+
+        Ok(data)
+    }
+
     /// Delete an object with RustFS-specific request options.
     pub async fn delete_object_with_options(
         &self,
@@ -1680,31 +1726,7 @@ impl ObjectStore for S3Client {
     }
 
     async fn get_object(&self, path: &RemotePath) -> Result<Vec<u8>> {
-        let response = self
-            .inner
-            .get_object()
-            .bucket(&path.bucket)
-            .key(&path.key)
-            .send()
-            .await
-            .map_err(|e| {
-                let err_str = e.to_string();
-                if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
-                    Error::NotFound(path.to_string())
-                } else {
-                    Error::Network(err_str)
-                }
-            })?;
-
-        let data = response
-            .body
-            .collect()
-            .await
-            .map_err(|e| Error::Network(e.to_string()))?
-            .into_bytes()
-            .to_vec();
-
-        Ok(data)
+        self.get_object_with_progress(path, |_, _| {}).await
     }
 
     async fn put_object(


### PR DESCRIPTION
## Related Issue

Closes #90.

## Background

Large remote-to-local copy operations currently finish with only the final success line. The issue screenshot shows `rc cp rustfs/test/rustfs.zip ./` downloading a 67.56 MiB object without any progress output.

## Root Cause

Upload progress is wired through a progress callback, but remote-to-local downloads collect the response body without reporting received bytes to the CLI progress layer.

## Solution

- Add a download helper that reports received bytes after each response chunk.
- Use that helper in the copy download path.
- Show download progress for objects at or above 4 MiB while preserving the existing output suppression rules for JSON, quiet mode, no-progress mode, and non-TTY output.
- Keep the upload multipart threshold unchanged.

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p rustfs-cli commands::cp::tests::test_download_progress --lib`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`