### PR TITLE
test(s3): cover admin heal API request contract

### DIFF
--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -888,7 +888,114 @@ impl AdminApi for AdminClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::mpsc;
+    use std::thread;
     use tempfile::tempdir;
+
+    #[derive(Debug)]
+    struct CapturedAdminRequest {
+        method: String,
+        target: String,
+        body: Vec<u8>,
+    }
+
+    fn read_admin_request(stream: &mut TcpStream) -> CapturedAdminRequest {
+        let mut buffer = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("read HTTP request");
+            assert!(read > 0, "client closed connection before headers");
+            buffer.extend_from_slice(&chunk[..read]);
+
+            if let Some(position) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+                break position + 4;
+            }
+        };
+
+        let headers = String::from_utf8_lossy(&buffer[..header_end]).into_owned();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().expect("valid content length"))
+            })
+            .unwrap_or(0);
+
+        while buffer.len() - header_end < content_length {
+            let read = stream.read(&mut chunk).expect("read HTTP request body");
+            assert!(read > 0, "client closed connection before body");
+            buffer.extend_from_slice(&chunk[..read]);
+        }
+
+        let request_line = headers.lines().next().expect("request line");
+        let mut parts = request_line.split_whitespace();
+        let method = parts.next().expect("request method").to_string();
+        let target = parts.next().expect("request target").to_string();
+        let body = buffer[header_end..header_end + content_length].to_vec();
+
+        CapturedAdminRequest {
+            method,
+            target,
+            body,
+        }
+    }
+
+    fn start_admin_test_server(
+        response_status: &str,
+        response_body: &'static str,
+    ) -> (
+        String,
+        mpsc::Receiver<CapturedAdminRequest>,
+        thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+        let response_status = response_status.to_string();
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let request = read_admin_request(&mut stream);
+            sender.send(request).expect("send captured request");
+
+            let response = format!(
+                "HTTP/1.1 {response_status}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write HTTP response");
+        });
+
+        (endpoint, receiver, handle)
+    }
+
+    fn admin_client_for_endpoint(endpoint: &str) -> AdminClient {
+        let alias = Alias::new("test", endpoint, "access", "secret");
+        AdminClient::new(&alias).expect("admin client should build")
+    }
+
+    fn assert_heal_options_body(
+        body: &[u8],
+        scan_mode: u8,
+        remove: bool,
+        recreate: bool,
+        dry_run: bool,
+    ) {
+        let value: serde_json::Value =
+            serde_json::from_slice(body).expect("heal request body should be JSON");
+
+        assert_eq!(value["recursive"], false);
+        assert_eq!(value["dryRun"], dry_run);
+        assert_eq!(value["remove"], remove);
+        assert_eq!(value["recreate"], recreate);
+        assert_eq!(value["scanMode"], scan_mode);
+        assert_eq!(value["updateParity"], false);
+        assert_eq!(value["nolock"], false);
+    }
 
     #[test]
     fn test_admin_url_construction() {
@@ -1023,6 +1130,67 @@ mod tests {
         let error = client.map_error(StatusCode::BAD_REQUEST, "err request body parse");
         assert!(matches!(error, Error::General(_)));
         assert_eq!(error.to_string(), "Bad request: err request body parse");
+    }
+
+    #[tokio::test]
+    async fn test_heal_status_uses_background_heal_status_endpoint() {
+        let (endpoint, receiver, handle) =
+            start_admin_test_server("200 OK", r#"{"bitrotStartTime":"2026-04-19T10:00:00Z"}"#);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client.heal_status().await.expect("heal status request");
+
+        assert!(status.healing);
+        assert_eq!(status.started.as_deref(), Some("2026-04-19T10:00:00Z"));
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.target, "/rustfs/admin/v3/background-heal/status");
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_heal_start_posts_to_bucket_prefix_route_with_options_body() {
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = HealStartRequest {
+            bucket: Some("photos".to_string()),
+            prefix: Some("2026/raw".to_string()),
+            scan_mode: HealScanMode::Deep,
+            remove: true,
+            recreate: true,
+            dry_run: true,
+        };
+
+        let status = client
+            .heal_start(request)
+            .await
+            .expect("heal start request");
+
+        assert!(!status.healing);
+        assert!(status.heal_id.is_empty());
+        assert!(status.started.is_none());
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.target, "/rustfs/admin/v3/heal/photos/2026%2Fraw");
+        assert_heal_options_body(&request.body, 2, true, true, true);
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_heal_stop_posts_force_stop_to_root_heal_route() {
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let client = admin_client_for_endpoint(&endpoint);
+
+        client.heal_stop().await.expect("heal stop request");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.target, "/rustfs/admin/v3/heal/?forceStop=true");
+        assert_heal_options_body(&request.body, 1, false, false, false);
+        handle.join().expect("server thread should finish");
     }
 
     #[test]


### PR DESCRIPTION
## Related issue(s)

No linked issue. This follows the recurring test-gap detection pass for recent admin heal API changes.

## Background

The recent admin heal alignment changed the RustFS admin API contract used by the S3 adapter. The helper-level tests covered path/body builders, but the public `AdminApi` methods still lacked coverage for the actual HTTP method, route, query string, and serialized body they send.

## Root cause

The previous tests did not exercise `AdminClient::heal_status`, `AdminClient::heal_start`, or `AdminClient::heal_stop` against an HTTP boundary. A future regression could accidentally return to the old `/heal/status`, `/heal/start`, or `/heal/stop` endpoints while the helper tests remained green.

## Solution

Added focused `rc-s3` unit tests with a one-request local HTTP server that captures the signed request. The tests assert:

- `heal_status` posts to `/rustfs/admin/v3/background-heal/status` and maps `bitrotStartTime`.
- `heal_start` posts to the bucket/prefix heal route with the expected RustFS heal options body.
- `heal_stop` posts to `/rustfs/admin/v3/heal/?forceStop=true` with the default heal options body.

## Test status

- `cargo test -p rc-s3 admin::tests::test_heal -- --nocapture`
- `make pre-commit`
