### PR TITLE
test(cp): cover download progress edge cases

### DIFF
--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -834,6 +834,35 @@ mod tests {
     }
 
     #[test]
+    fn test_download_progress_skips_unknown_total_size() {
+        let output_config = OutputConfig::default();
+        let mut progress = None;
+
+        update_download_progress(&mut progress, &output_config, 1024, None);
+
+        assert!(progress.is_none());
+    }
+
+    #[test]
+    fn test_download_progress_respects_no_progress_config() {
+        let output_config = OutputConfig {
+            no_progress: true,
+            ..Default::default()
+        };
+        let mut progress = None;
+
+        update_download_progress(
+            &mut progress,
+            &output_config,
+            1024,
+            Some(DOWNLOAD_PROGRESS_THRESHOLD),
+        );
+
+        let progress = progress.expect("large download should create progress state");
+        assert!(!progress.is_visible());
+    }
+
+    #[test]
     fn test_parse_cp_path_prefers_existing_local_path_when_alias_missing() {
         let (alias_manager, temp_dir) = temp_alias_manager();
         let full = temp_dir.path().join("issue-2094-local").join("file.txt");


### PR DESCRIPTION
## Related Issue(s)

No linked issue. This is from the recurring test-gap detection pass.

## Background

Recent work added download progress reporting for large `rc cp` downloads. The existing tests covered the known-size threshold behavior, but two branches remained unasserted: downloads with unknown total size and output configurations that disable progress rendering.

## Root Cause

The helper intentionally avoids creating progress for unknown content length and relies on `OutputConfig` to suppress visible progress bars when `--no-progress` is active. Without focused tests, those branches could regress during future transfer UI changes.

## Solution

Added two focused unit tests for `update_download_progress`:

- unknown total size keeps progress unset
- `no_progress` creates state for a large transfer but keeps the progress bar hidden

## Test Status

- `cargo test -p rustfs-cli commands::cp::tests::test_download_progress`
- `cargo fmt --all --check`
- `make pre-commit`
