### PR TITLE
test(cli): cover SQL Select parser options

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -544,6 +544,58 @@ mod tests {
     }
 
     #[test]
+    fn cli_accepts_sql_select_options() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "sql",
+            "local/reports/data.jsonl",
+            "--query",
+            "SELECT * FROM S3Object",
+            "--input-format",
+            "json",
+            "--output-format",
+            "json",
+            "--compression",
+            "gzip",
+        ])
+        .expect("parse sql command");
+
+        match cli.command {
+            Commands::Sql(arg) => {
+                assert_eq!(arg.path, "local/reports/data.jsonl");
+                assert_eq!(arg.query, "SELECT * FROM S3Object");
+                assert!(matches!(arg.input_format, sql::InputFormatArg::Json));
+                assert!(matches!(arg.output_format, sql::OutputFormatArg::Json));
+                assert!(matches!(arg.compression, sql::CompressionArg::Gzip));
+            }
+            other => panic!("expected sql command, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_sql_defaults() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "sql",
+            "local/reports/data.csv",
+            "--query",
+            "SELECT s._1 FROM S3Object s",
+        ])
+        .expect("parse sql command defaults");
+
+        match cli.command {
+            Commands::Sql(arg) => {
+                assert_eq!(arg.path, "local/reports/data.csv");
+                assert_eq!(arg.query, "SELECT s._1 FROM S3Object s");
+                assert!(matches!(arg.input_format, sql::InputFormatArg::Csv));
+                assert!(matches!(arg.output_format, sql::OutputFormatArg::Csv));
+                assert!(matches!(arg.compression, sql::CompressionArg::None));
+            }
+            other => panic!("expected sql command, got {:?}", other),
+        }
+    }
+
+    #[test]
     fn cli_accepts_object_list_alias() {
         let cli = Cli::try_parse_from(["rc", "object", "ls", "local/my-bucket/logs/"])
             .expect("parse object ls alias");


### PR DESCRIPTION
## Related issue

Automated test-gap detection for the recent S3 Select command work.

## Background

The recent SQL Select feature added a new top-level `rc sql` command with format and compression flags. Existing coverage included help output and early execution errors, while PR #147 covers S3 request serialization. The remaining gap was the root CLI parser path that binds user-provided SQL Select options into `SqlArgs`.

## Solution

Add focused parser coverage for `rc sql` with explicit JSON input/output and gzip compression, plus a defaults case for CSV input/output and no compression. This keeps the scope limited to command wiring and avoids duplicating the S3 serialization tests already covered elsewhere.

## Validation

- `cargo test -p rustfs-cli commands::tests::cli_accepts_sql --lib`
- `make pre-commit`
