### PR TITLE
test(sql): cover select error exit codes

### DIFF
--- a/crates/cli/src/commands/sql.rs
+++ b/crates/cli/src/commands/sql.rs
@@ -153,6 +153,7 @@ fn exit_code_from_error(error: &rc_core::Error) -> ExitCode {
 mod tests {
     use super::*;
     use crate::output::OutputConfig;
+    use rc_core::Error;
 
     #[tokio::test]
     async fn sql_empty_query_is_usage_error() {
@@ -178,5 +179,35 @@ mod tests {
         };
         let code = execute(args, OutputConfig::default()).await;
         assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[test]
+    fn sql_exit_code_from_backend_errors() {
+        let cases = [
+            (
+                Error::UnsupportedFeature("S3 Select is not supported".to_string()),
+                ExitCode::UnsupportedFeature,
+            ),
+            (
+                Error::NotFound("Object not found".to_string()),
+                ExitCode::NotFound,
+            ),
+            (
+                Error::Auth("Access denied".to_string()),
+                ExitCode::AuthError,
+            ),
+            (
+                Error::Network("Request timeout".to_string()),
+                ExitCode::NetworkError,
+            ),
+            (
+                Error::General("Query failed".to_string()),
+                ExitCode::GeneralError,
+            ),
+        ];
+
+        for (error, expected) in cases {
+            assert_eq!(exit_code_from_error(&error), expected);
+        }
     }
 }


### PR DESCRIPTION
## Related issue(s)

Automated test-gap detection for the recent S3 Select command work.

## Background

The S3 Select command recently added command-level handling for backend errors returned by the select adapter. Existing and open coverage now exercises parser wiring and S3 serialization shapes, but the SQL command's final mapping from rc-core errors to CLI exit codes was not directly covered.

## Root cause

`sql::execute` delegates backend failures through `exit_code_from_error`, so regressions in unsupported-feature, missing-object, auth, network, or generic error mappings could change automation-visible process outcomes without a focused command-layer test.

## Solution

Add a small unit test in `crates/cli/src/commands/sql.rs` that covers representative backend errors and their expected SQL command exit codes. This keeps the scope limited to the recent S3 Select command path and avoids duplicating the open parser and S3 serialization PRs.

## Test status

- `cargo test -p rustfs-cli commands::sql::tests::sql_exit_code_from_backend_errors --lib`
- `cargo fmt --all --check`
- `make pre-commit`
