### PR TITLE
test(s3): cover Aliyun bucket lookup fallbacks

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -2817,6 +2817,25 @@ mod tests {
     }
 
     #[test]
+    fn auto_bucket_lookup_keeps_path_style_for_non_oss_aliyun_endpoint() {
+        let alias = Alias::new(
+            "aliyun",
+            "https://ecs-cn-hangzhou.aliyuncs.com",
+            "access-key",
+            "secret-key",
+        );
+
+        assert!(force_path_style_for_alias(&alias));
+    }
+
+    #[test]
+    fn auto_bucket_lookup_keeps_path_style_for_invalid_endpoint() {
+        let alias = Alias::new("broken", "not a valid endpoint", "access-key", "secret-key");
+
+        assert!(force_path_style_for_alias(&alias));
+    }
+
+    #[test]
     fn explicit_bucket_lookup_overrides_auto_detection() {
         let mut path_alias = Alias::new(
             "aliyun",
@@ -2832,6 +2851,19 @@ mod tests {
 
         assert!(force_path_style_for_alias(&path_alias));
         assert!(!force_path_style_for_alias(&dns_alias));
+    }
+
+    #[test]
+    fn unknown_bucket_lookup_keeps_path_style() {
+        let mut alias = Alias::new(
+            "aliyun",
+            "https://oss-cn-hangzhou.aliyuncs.com",
+            "access-key",
+            "secret-key",
+        );
+        alias.bucket_lookup = "unexpected".to_string();
+
+        assert!(force_path_style_for_alias(&alias));
     }
 
     #[test]


### PR DESCRIPTION
## Related issue(s)

None. This is automation-driven test gap coverage for the recent Aliyun OSS bucket lookup change.

## Background

PR #151 changed the S3 client so `bucket_lookup = auto` keeps path-style addressing for most S3-compatible endpoints, but switches to virtual-hosted style for Aliyun OSS service endpoints. The merged change covered the main Aliyun and custom-endpoint paths, but a few fallback branches remained untested.

## Solution

Add focused `rc-s3` unit coverage for the new bucket lookup helper:

- Non-OSS `aliyuncs.com` services keep path-style addressing.
- Invalid endpoint strings keep path-style addressing.
- Unknown `bucket_lookup` values keep the conservative path-style fallback.

## Test status

- `cargo test -p rc-s3 bucket_lookup --lib`
- `make pre-commit`
