### PR TITLE
test(s3): cover select access denied fallback

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -197,6 +197,9 @@ fn classify_aws_code_missing_metadata(text: &str) -> Error {
     if text.contains("NoSuchBucket") {
         return Error::NotFound("Bucket not found".to_string());
     }
+    if text.contains("AccessDenied") {
+        return Error::Auth("Access denied".to_string());
+    }
     Error::General(text.to_string())
 }
 
@@ -229,6 +232,12 @@ mod tests {
     fn classify_missing_code_maps_no_such_bucket_substring() {
         let e = classify_aws_code(None, "Service error: ... NoSuchBucket ...");
         assert!(matches!(e, Error::NotFound(msg) if msg.contains("Bucket")));
+    }
+
+    #[test]
+    fn classify_missing_code_maps_access_denied_substring() {
+        let e = classify_aws_code(None, "Service error: ... AccessDenied ...");
+        assert!(matches!(e, Error::Auth(msg) if msg.contains("Access denied")));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issue(s)

None. This is focused test-gap coverage from recent S3 Select work.

## Background

Recent S3 Select support added error classification for backend failures. The mapper already handled explicit AccessDenied metadata, but the fallback path used when SDK metadata is missing did not preserve the auth classification.

## Root Cause

classify_aws_code_missing_metadata only searched fallback error text for NotImplemented, NoSuchKey, and NoSuchBucket. AccessDenied text therefore fell through to a general error.

## Solution

Add a focused fallback branch that maps AccessDenied text to rc_core::Error::Auth, plus a unit test covering the missing-metadata path.

## Tests

- cargo test -p rc-s3 select::tests::classify_missing_code_maps_access_denied_substring --lib
- make pre-commit
