### PR TITLE
test(s3): cover select not-implemented fallbacks

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -247,9 +247,21 @@ mod tests {
     }
 
     #[test]
+    fn classify_unknown_code_with_not_implemented_text_maps_unsupported_feature() {
+        let e = classify_aws_code(Some("SlowDown"), "backend replied with NotImplemented");
+        assert!(matches!(e, Error::UnsupportedFeature(msg) if msg.contains("does not support")));
+    }
+
+    #[test]
     fn classify_missing_code_unknown_maps_general() {
         let e = classify_aws_code(None, "Service error: query parsing failed");
         assert!(matches!(e, Error::General(_)));
+    }
+
+    #[test]
+    fn classify_missing_code_maps_not_implemented_substring() {
+        let e = classify_aws_code(None, "Service error: backend returned NotImplemented");
+        assert!(matches!(e, Error::UnsupportedFeature(msg) if msg.contains("does not support")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR closes a remaining regression gap around the recent S3 Select error-classification work.

When an S3-compatible backend does not return stable error metadata, the client falls back to matching error text. The current code already treats `NotImplemented` as `UnsupportedFeature`, but the recent tests only covered the direct code-path and a few metadata-missing cases. Two fallback branches were still untested: one where AWS returns an unrelated service code but the response text still includes `NotImplemented`, and one where metadata is missing entirely and only the text can be inspected.

This patch adds focused unit coverage for those two fallback paths in `crates/s3/src/select.rs`. It does not change runtime behavior.

## Root Cause
The earlier S3 Select test additions covered the new `AccessDenied` fallback and the serialization helpers, but they did not exercise the `NotImplemented` substring fallbacks that protect compatibility with backends that surface incomplete or inconsistent error metadata.

## Validation
- `cargo test -p rc-s3 select::tests --lib`
- `cargo fmt --all --check`
- `make pre-commit`
