### PR TITLE
test(s3): cover select no-such-key fallback

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -235,6 +235,12 @@ mod tests {
     }
 
     #[test]
+    fn classify_missing_code_maps_no_such_key_substring() {
+        let e = classify_aws_code(None, "Service error: ... NoSuchKey ...");
+        assert!(matches!(e, Error::NotFound(msg) if msg.contains("Object")));
+    }
+
+    #[test]
     fn classify_missing_code_maps_access_denied_substring() {
         let e = classify_aws_code(None, "Service error: ... AccessDenied ...");
         assert!(matches!(e, Error::Auth(msg) if msg.contains("Access denied")));


### PR DESCRIPTION
## Summary
This PR closes a remaining regression gap in the recent S3 Select fallback classification coverage.

When an S3-compatible backend fails to return structured error metadata, `crates/s3/src/select.rs` falls back to matching known error substrings in the response text. The `NoSuchKey` branch in that fallback logic is part of the current runtime behavior, but it was still untested after the recent Select coverage additions.

This patch adds one focused unit test for the metadata-missing `NoSuchKey` path. Runtime behavior is unchanged.

## Root Cause
Recent Select follow-up PRs covered serialization helpers, exit codes, `AccessDenied`, and `NotImplemented` fallback handling, but they did not exercise the `NoSuchKey` substring fallback that maps missing-object responses to `NotFound`.

## Validation
- `cargo test -p rc-s3 classify_missing_code_maps_no_such_key_substring --lib`
- `make pre-commit`
