### PR TITLE
test(s3): cover select empty error-code fallback

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -241,6 +241,12 @@ mod tests {
     }
 
     #[test]
+    fn classify_empty_code_maps_access_denied_substring() {
+        let e = classify_aws_code(Some(""), "Service error: ... AccessDenied ...");
+        assert!(matches!(e, Error::Auth(msg) if msg.contains("Access denied")));
+    }
+
+    #[test]
     fn classify_maps_invalid_argument() {
         let e = classify_aws_code(Some("InvalidArgument"), "bad expr");
         assert!(matches!(e, Error::General(_)));


### PR DESCRIPTION
## Summary
This PR adds focused regression coverage for one remaining S3 Select error-classification fallback path.

Recent test-gap work around `classify_aws_code` already covered missing-metadata fallbacks such as `AccessDenied`, `NoSuchBucket`, `NotImplemented`, and `NoSuchKey`. One small branch was still untested: when the SDK surfaces an empty error code string instead of omitting the metadata entirely. The runtime code intentionally treats an empty code the same as missing metadata by filtering it out before substring-based fallback classification.

This patch adds a single unit test in `crates/s3/src/select.rs` to lock that behavior in place. It does not change runtime logic.

## Root Cause
The fallback logic uses `code.filter(|s| !s.is_empty())` before dispatching to the missing-metadata classifier, but the existing tests only exercised `None` metadata and did not cover the `Some("")` case. That left a small but real compatibility path unverified.

## Validation
- `cargo test -p rc-s3 classify_empty_code_maps_access_denied_substring --lib`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `make pre-commit`
