### PR TITLE
test(s3): cover select empty-code metadata fallbacks

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -253,6 +253,18 @@ mod tests {
     }
 
     #[test]
+    fn classify_empty_code_maps_no_such_bucket_substring() {
+        let e = classify_aws_code(Some(""), "Service error: ... NoSuchBucket ...");
+        assert!(matches!(e, Error::NotFound(msg) if msg.contains("Bucket")));
+    }
+
+    #[test]
+    fn classify_empty_code_maps_not_implemented_substring() {
+        let e = classify_aws_code(Some(""), "Service error: backend returned NotImplemented");
+        assert!(matches!(e, Error::UnsupportedFeature(msg) if msg.contains("does not support")));
+    }
+
+    #[test]
     fn classify_maps_invalid_argument() {
         let e = classify_aws_code(Some("InvalidArgument"), "bad expr");
         assert!(matches!(e, Error::General(_)));


### PR DESCRIPTION
## Summary
This PR adds focused regression coverage for the S3 Select error-classification path that treats an empty AWS error code the same as missing metadata.

Recent follow-up PRs covered the `None` metadata path and one `Some("")` case for `AccessDenied`, but two symmetric empty-code branches were still untested. If the SDK surfaces `Some("")` and the backend text contains `NoSuchBucket` or `NotImplemented`, the CLI should continue to classify those responses as not found and unsupported feature rather than falling back to a generic error.

## Root cause
The implementation already normalizes empty error codes with `code.filter(|s| !s.is_empty())`, so behavior was correct. The remaining gap was test coverage: those two empty-code fallback branches were not asserted explicitly, which left room for future regressions in the shared classifier.

## Changes
This PR adds two unit tests in `crates/s3/src/select.rs`:
- `classify_empty_code_maps_no_such_bucket_substring`
- `classify_empty_code_maps_not_implemented_substring`

The runtime logic is unchanged.

## Validation
- `cargo test -p rc-s3 select::tests --lib`
- `make pre-commit`
