### PR TITLE
test(s3): cover empty-code no-such-key fallback

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -253,6 +253,12 @@ mod tests {
     }
 
     #[test]
+    fn classify_empty_code_maps_no_such_key_substring() {
+        let e = classify_aws_code(Some(""), "Service error: ... NoSuchKey ...");
+        assert!(matches!(e, Error::NotFound(msg) if msg.contains("Object")));
+    }
+
+    #[test]
     fn classify_maps_invalid_argument() {
         let e = classify_aws_code(Some("InvalidArgument"), "bad expr");
         assert!(matches!(e, Error::General(_)));


### PR DESCRIPTION
## Summary
This PR adds one focused regression test for the S3 Select error-classification path that treats an empty AWS error code the same as missing metadata.

The current test coverage already exercises `None` metadata for `NoSuchKey` and the empty-string fallback for `AccessDenied`, while open PR #158 covers the remaining empty-string `NoSuchBucket` and `NotImplemented` branches. One symmetric branch was still untested: if the SDK surfaces `Some("")` and the backend text contains `NoSuchKey`, the CLI should continue to classify the response as object-not-found instead of falling back to a generic error.

## Root cause
The implementation already normalizes empty error codes with `code.filter(|s| !s.is_empty())`, so the runtime behavior was correct. The gap was only in regression coverage for that final empty-code `NoSuchKey` path.

## Changes
- Add `classify_empty_code_maps_no_such_key_substring` in `crates/s3/src/select.rs`
- Keep runtime logic unchanged

## Validation
- `cargo test -p rc-s3 select::tests --lib`
- `make pre-commit`
