### PR TITLE
test(s3): cover delete bucket network fallback

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3594,6 +3594,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_bucket_maps_other_failures_to_network() {
+        let response = http::Response::builder()
+            .status(500)
+            .header("x-amz-error-code", "InternalError")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>Something went wrong.</Message>
+</Error>"#,
+            ))
+            .expect("build delete bucket response");
+        let (client, _request_receiver) = test_s3_client(Some(response));
+
+        let result = client.delete_bucket("bucket").await;
+
+        match result {
+            Err(Error::Network(message)) => assert!(message.contains("InternalError")),
+            other => panic!("Expected Network for delete bucket failure, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn delete_objects_with_force_delete_sets_rustfs_header() {
         let response = http::Response::builder()
             .status(200)


### PR DESCRIPTION
## Related
This pull request adds focused regression coverage for the recent `delete_bucket` error mapping work in `#163`.

## Background
`delete_bucket()` now distinguishes `NoSuchBucket` and `BucketNotEmpty` from other backend failures. That behavior was covered for the two special-case branches, but the generic fallback path was still untested.

## Root Cause
The recent change introduced a third branch that maps all remaining SDK failures to `Error::Network`. Without a direct test, later edits could accidentally change that fallback classification or stop surfacing the backend error code.

## Solution
Add one narrow unit test beside the existing `delete_bucket` regression tests in `crates/s3/src/client.rs`. The new test drives a synthetic `InternalError` response and asserts that the client keeps classifying it as `Error::Network` while preserving the backend code in the message.

## Validation
I ran the focused seam first with `cargo test -p rc-s3 delete_bucket_maps_ --lib`, then the full repository gate with `make pre-commit`.
