### PR TITLE
test(s3): cover delete bucket NotFound fallback

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3705,6 +3705,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delete_bucket_maps_not_found_code_to_not_found() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NotFound")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NotFound</Code>
+  <Message>The specified bucket does not exist.</Message>
+</Error>"#,
+            ))
+            .expect("build not found bucket response");
+        let (client, _request_receiver) = test_s3_client(Some(response));
+
+        let result = client.delete_bucket("missing-bucket").await;
+
+        match result {
+            Err(Error::NotFound(message)) => {
+                assert_eq!(message, "Bucket not found: missing-bucket")
+            }
+            other => panic!("Expected NotFound for NotFound delete bucket error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn delete_bucket_maps_other_failures_to_network() {
         let response = http::Response::builder()
             .status(500)


### PR DESCRIPTION
## Related issue

This PR does not resolve a user-facing bug by itself. It closes a remaining test gap around the recent `delete_bucket` error-classification changes landed in #163 and #166.

## Background

`crates/s3/src/client.rs::delete_bucket` now has explicit classification for missing buckets, non-empty buckets, and generic backend failures. The existing tests already covered `NoSuchBucket`, `BucketNotEmpty`, and a generic `InternalError` path.

A nearby backend variant was still untested: some S3-compatible services return `NotFound` instead of `NoSuchBucket` for the same missing-bucket condition. The implementation already handles that code path, but the regression suite did not prove it.

## Root cause

The recent focused test additions around `delete_bucket` stopped one branch short of the sibling `NotFound` mapping path, leaving the same user-visible behavior dependent on unverified backend wording.

## Solution

Add one focused unit test that simulates a `404 NotFound` delete-bucket response and asserts that rc still maps it to `Error::NotFound("Bucket not found: <bucket>")`.

This keeps the scope limited to the changed helper and strengthens the recent error-mapping work without changing runtime behavior.

## Validation

- `cargo test -p rc-s3 delete_bucket_maps_ --lib`
- `make pre-commit`
