### PR TITLE
test(s3): cover list versions NotFound fallback

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3657,6 +3657,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_object_versions_page_maps_not_found_code_to_not_found() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NotFound")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NotFound</Code>
+  <Message>The specified bucket does not exist.</Message>
+</Error>"#,
+            ))
+            .expect("build not found bucket response");
+        let (client, _request_receiver) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "missing-bucket", "");
+
+        let result = client.list_object_versions_page(&path, Some(1000)).await;
+
+        match result {
+            Err(Error::NotFound(message)) => {
+                assert_eq!(message, "Bucket not found: missing-bucket")
+            }
+            other => panic!("Expected NotFound for NotFound list versions error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn delete_bucket_maps_bucket_not_empty_to_conflict() {
         let response = http::Response::builder()
             .status(409)


### PR DESCRIPTION
## Related issue

No external issue. This is a focused test-gap follow-up for the recently merged S3 version-listing error handling.

## Background

Recent changes made `list_object_versions_page` preserve backend error codes so missing buckets map to `Error::NotFound`. The existing regression coverage exercised `NoSuchBucket`, while the sibling `NotFound` fallback branch remained uncovered.

## Solution

Add a narrow rc-s3 unit test that feeds a 404 response with `x-amz-error-code: NotFound` into `list_object_versions_page` and asserts it returns `Error::NotFound` with the expected bucket message.

## Validation

- `cargo test -p rc-s3 list_object_versions_page_maps_not_found_code_to_not_found --lib`
- `make pre-commit`
