### PR TITLE
fix(ls): classify version listing backend failures as network

### DIFF
--- a/crates/cli/src/commands/ls.rs
+++ b/crates/cli/src/commands/ls.rs
@@ -237,6 +237,7 @@ fn ls_version_output(result: ObjectVersionListResult, summarize: bool) -> LsVers
 fn exit_code_from_version_listing_error(error: &Error) -> ExitCode {
     match error {
         Error::NotFound(_) => ExitCode::NotFound,
+        Error::Network(_) => ExitCode::NetworkError,
         _ => {
             let error_text = error.to_string();
             if error_text.contains("NotFound") || error_text.contains("NoSuchBucket") {
@@ -721,6 +722,14 @@ mod tests {
                 "list_object_versions: timeout".to_string()
             )),
             ExitCode::GeneralError
+        );
+    }
+
+    #[test]
+    fn test_version_listing_network_errors_use_network_exit_code() {
+        assert_eq!(
+            exit_code_from_version_listing_error(&Error::Network("timeout".to_string())),
+            ExitCode::NetworkError
         );
     }
 }

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -765,7 +765,7 @@ impl S3Client {
             if err_str.contains("NotFound") || err_str.contains("NoSuchBucket") {
                 Error::NotFound(format!("Bucket not found: {}", path.bucket))
             } else {
-                Error::General(format!("list_object_versions: {e}"))
+                Error::Network(err_str)
             }
         })?;
 
@@ -3679,6 +3679,30 @@ mod tests {
                 assert_eq!(message, "Bucket not found: missing-bucket")
             }
             other => panic!("Expected NotFound for NotFound list versions error, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn list_object_versions_page_maps_other_failures_to_network() {
+        let response = http::Response::builder()
+            .status(500)
+            .header("x-amz-error-code", "InternalError")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>Something went wrong.</Message>
+</Error>"#,
+            ))
+            .expect("build internal error response");
+        let (client, _request_receiver) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "bucket", "");
+
+        let result = client.list_object_versions_page(&path, Some(1000)).await;
+
+        match result {
+            Err(Error::Network(message)) => assert!(message.contains("InternalError")),
+            other => panic!("Expected Network for list versions failure, got: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Background

Recent changes tightened `rc ls --versions` behavior around missing buckets, but the adjacent generic backend-failure path was still untested.

## Root Cause

`S3Client::list_object_versions_page` converted non-NotFound service failures into `Error::General`, and the `ls --versions` exit-code helper did not preserve `Error::Network` as a network exit code. That made retryable backend failures look like generic CLI failures.

## Solution

Return `Error::Network` for non-missing-bucket list-version service failures and preserve that classification in `rc ls --versions` exit-code mapping.

## Tests

- `cargo test -p rc-s3 list_object_versions_page --lib`
- `cargo test -p rustfs-cli ls::tests --lib`
- `make pre-commit`
