### PR TITLE
feat(admin): add pool decommission and rebalance commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,22 @@ rc admin heal start local --bucket mybucket --scan-mode deep
 rc admin heal start local --dry-run
 rc admin heal stop local
 
+# Pool expansion and decommission workflows
+rc admin pool list local
+rc admin pool status local 1 --by-id
+rc admin decommission start local '/data/pool1/disk{1...4}'
+rc admin decommission status local '/data/pool1/disk{1...4}'
+rc admin decommission cancel local 1 --by-id
+
+# Rebalance data after adding server pools
+rc admin rebalance start local
+rc admin rebalance status local
+rc admin rebalance stop local
+
 # JSON output
 rc admin info cluster local --json
 rc admin heal status local --json
+rc admin rebalance status local --json
 ```
 
 ## Command Overview
@@ -290,6 +303,9 @@ rc admin heal status local --json
 | `admin service-account` | Manage service accounts (create, remove, list, info)                                  |
 | `admin info`            | Display cluster information (cluster, server, disk)                                   |
 | `admin heal`            | Manage cluster healing operations (status, start, stop)                               |
+| `admin pool`            | List pools and inspect expansion/decommission status                                  |
+| `admin decommission`    | Manage server pool decommissioning (start, status, cancel)                            |
+| `admin rebalance`       | Manage post-expansion rebalancing (start, status, stop)                               |
 
 ### ILM Subcommands
 

--- a/crates/cli/src/commands/admin/decommission.rs
+++ b/crates/cli/src/commands/admin/decommission.rs
@@ -1,0 +1,193 @@
+//! Decommission commands for retiring server pools.
+
+use clap::Subcommand;
+use serde::Serialize;
+
+use super::{get_admin_client, pool};
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+use rc_core::admin::{AdminApi, PoolStatus, PoolTarget};
+
+/// Decommission subcommands
+#[derive(Subcommand, Debug)]
+pub enum DecommissionCommands {
+    /// Start decommissioning a pool
+    Start(StartArgs),
+
+    /// Show decommissioning status
+    Status(StatusArgs),
+
+    /// Cancel decommissioning a pool
+    Cancel(CancelArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StartArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Pool command line, comma-separated pool command lines, or zero-based pool ID with --by-id
+    pub pool: String,
+
+    /// Interpret POOL as zero-based pool ID values
+    #[arg(long)]
+    pub by_id: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StatusArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Pool command line, or zero-based pool ID with --by-id
+    pub pool: Option<String>,
+
+    /// Interpret POOL as a zero-based pool ID
+    #[arg(long)]
+    pub by_id: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct CancelArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Pool command line, or zero-based pool ID with --by-id
+    pub pool: String,
+
+    /// Interpret POOL as a zero-based pool ID
+    #[arg(long)]
+    pub by_id: bool,
+}
+
+#[derive(Serialize)]
+struct DecommissionOperationOutput {
+    success: bool,
+    message: String,
+    pool: String,
+}
+
+#[derive(Serialize)]
+struct DecommissionStatusListOutput {
+    pools: Vec<PoolStatus>,
+}
+
+/// Execute a decommission subcommand
+pub async fn execute(cmd: DecommissionCommands, formatter: &Formatter) -> ExitCode {
+    match cmd {
+        DecommissionCommands::Start(args) => execute_start(args, formatter).await,
+        DecommissionCommands::Status(args) => execute_status(args, formatter).await,
+        DecommissionCommands::Cancel(args) => execute_cancel(args, formatter).await,
+    }
+}
+
+async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    let target = PoolTarget {
+        pool: args.pool,
+        by_id: args.by_id,
+    };
+
+    match client.decommission_start(target.clone()).await {
+        Ok(()) => {
+            if formatter.is_json() {
+                formatter.json(&DecommissionOperationOutput {
+                    success: true,
+                    message: "Decommission started successfully".to_string(),
+                    pool: target.pool,
+                });
+            } else {
+                formatter.success(&format!(
+                    "Decommission started successfully for `{}`.",
+                    target.pool
+                ));
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to start decommission: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}
+
+async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    if let Some(pool_name) = args.pool {
+        let target = PoolTarget {
+            pool: pool_name,
+            by_id: args.by_id,
+        };
+        match client.pool_status(target).await {
+            Ok(status) => {
+                if formatter.is_json() {
+                    formatter.json(&status);
+                } else {
+                    pool::print_pool_status(&status, formatter);
+                }
+                ExitCode::Success
+            }
+            Err(e) => {
+                formatter.error(&format!("Failed to get decommission status: {e}"));
+                ExitCode::GeneralError
+            }
+        }
+    } else {
+        match client.list_pools().await {
+            Ok(pools) => {
+                if formatter.is_json() {
+                    formatter.json(&DecommissionStatusListOutput { pools });
+                } else {
+                    pool::print_pool_list(&pools, formatter);
+                }
+                ExitCode::Success
+            }
+            Err(e) => {
+                formatter.error(&format!("Failed to get decommission status: {e}"));
+                ExitCode::GeneralError
+            }
+        }
+    }
+}
+
+async fn execute_cancel(args: CancelArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    let target = PoolTarget {
+        pool: args.pool,
+        by_id: args.by_id,
+    };
+
+    match client.decommission_cancel(target.clone()).await {
+        Ok(()) => {
+            if formatter.is_json() {
+                formatter.json(&DecommissionOperationOutput {
+                    success: true,
+                    message: "Decommission canceled successfully".to_string(),
+                    pool: target.pool,
+                });
+            } else {
+                formatter.success(&format!(
+                    "Decommission canceled successfully for `{}`.",
+                    target.pool
+                ));
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to cancel decommission: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -3,10 +3,13 @@
 //! This module provides commands for managing users, policies, groups,
 //! service accounts, and cluster operations on RustFS/MinIO-compatible servers.
 
+mod decommission;
 mod group;
 mod heal;
 mod info;
 mod policy;
+mod pool;
+mod rebalance;
 mod service_account;
 mod user;
 
@@ -27,6 +30,18 @@ pub enum AdminCommands {
     /// Manage cluster healing operations
     #[command(subcommand)]
     Heal(heal::HealCommands),
+
+    /// Manage server pools and expansion status
+    #[command(subcommand)]
+    Pool(pool::PoolCommands),
+
+    /// Manage server pool decommissioning
+    #[command(alias = "decom", subcommand)]
+    Decommission(decommission::DecommissionCommands),
+
+    /// Manage post-expansion rebalancing
+    #[command(subcommand)]
+    Rebalance(rebalance::RebalanceCommands),
 
     /// Manage IAM users
     #[command(subcommand)]
@@ -52,6 +67,13 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
     match cmd {
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
+        AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,
+        AdminCommands::Decommission(decommission_cmd) => {
+            decommission::execute(decommission_cmd, &formatter).await
+        }
+        AdminCommands::Rebalance(rebalance_cmd) => {
+            rebalance::execute(rebalance_cmd, &formatter).await
+        }
         AdminCommands::User(user_cmd) => user::execute(user_cmd, &formatter).await,
         AdminCommands::Policy(policy_cmd) => policy::execute(policy_cmd, &formatter).await,
         AdminCommands::Group(group_cmd) => group::execute(group_cmd, &formatter).await,
@@ -153,6 +175,60 @@ mod tests {
                 assert!(args.remove);
                 assert!(args.recreate);
                 assert!(args.dry_run);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_pool_status_by_id() {
+        let cli = TestCli::parse_from(["rc", "pool", "status", "local", "1", "--by-id"]);
+
+        match cli.command {
+            AdminCommands::Pool(pool::PoolCommands::Status(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.pool.as_deref(), Some("1"));
+                assert!(args.by_id);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_decommission_start_by_id() {
+        let cli = TestCli::parse_from(["rc", "decommission", "start", "local", "1", "--by-id"]);
+
+        match cli.command {
+            AdminCommands::Decommission(decommission::DecommissionCommands::Start(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.pool, "1");
+                assert!(args.by_id);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_decommission_alias() {
+        let cli = TestCli::parse_from(["rc", "decom", "cancel", "local", "1", "--by-id"]);
+
+        match cli.command {
+            AdminCommands::Decommission(decommission::DecommissionCommands::Cancel(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.pool, "1");
+                assert!(args.by_id);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_rebalance_start() {
+        let cli = TestCli::parse_from(["rc", "rebalance", "start", "local"]);
+
+        match cli.command {
+            AdminCommands::Rebalance(rebalance::RebalanceCommands::Start(args)) => {
+                assert_eq!(args.alias, "local");
             }
             _ => panic!("Unexpected command parsing result"),
         }

--- a/crates/cli/src/commands/admin/pool.rs
+++ b/crates/cli/src/commands/admin/pool.rs
@@ -1,0 +1,248 @@
+//! Pool commands for cluster expansion and pool status.
+
+use clap::Subcommand;
+use serde::Serialize;
+
+use super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+use rc_core::admin::{AdminApi, PoolDecommissionInfo, PoolStatus, PoolTarget};
+
+/// Pool subcommands
+#[derive(Subcommand, Debug)]
+pub enum PoolCommands {
+    /// List server pools
+    List(ListArgs),
+
+    /// Show server pool status
+    Status(StatusArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct ListArgs {
+    /// Alias name of the server
+    pub alias: String,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StatusArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Pool command line, or zero-based pool ID with --by-id
+    pub pool: Option<String>,
+
+    /// Interpret POOL as a zero-based pool ID
+    #[arg(long)]
+    pub by_id: bool,
+}
+
+#[derive(Serialize)]
+struct PoolListOutput {
+    pools: Vec<PoolStatus>,
+}
+
+/// Execute a pool subcommand
+pub async fn execute(cmd: PoolCommands, formatter: &Formatter) -> ExitCode {
+    match cmd {
+        PoolCommands::List(args) => execute_list(args, formatter).await,
+        PoolCommands::Status(args) => execute_status(args, formatter).await,
+    }
+}
+
+async fn execute_list(args: ListArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    match client.list_pools().await {
+        Ok(pools) => {
+            if formatter.is_json() {
+                formatter.json(&PoolListOutput { pools });
+            } else {
+                print_pool_list(&pools, formatter);
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to list pools: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}
+
+async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    if let Some(pool) = args.pool {
+        let target = PoolTarget {
+            pool,
+            by_id: args.by_id,
+        };
+        match client.pool_status(target).await {
+            Ok(status) => {
+                if formatter.is_json() {
+                    formatter.json(&status);
+                } else {
+                    print_pool_status(&status, formatter);
+                }
+                ExitCode::Success
+            }
+            Err(e) => {
+                formatter.error(&format!("Failed to get pool status: {e}"));
+                ExitCode::GeneralError
+            }
+        }
+    } else {
+        match client.list_pools().await {
+            Ok(pools) => {
+                if formatter.is_json() {
+                    formatter.json(&PoolListOutput { pools });
+                } else {
+                    print_pool_list(&pools, formatter);
+                }
+                ExitCode::Success
+            }
+            Err(e) => {
+                formatter.error(&format!("Failed to get pool status: {e}"));
+                ExitCode::GeneralError
+            }
+        }
+    }
+}
+
+pub(super) fn print_pool_list(pools: &[PoolStatus], formatter: &Formatter) {
+    formatter.println(&formatter.style_name("Pools:"));
+    if pools.is_empty() {
+        formatter.println("  No pools found.");
+        return;
+    }
+
+    for pool in pools {
+        print_pool_status(pool, formatter);
+    }
+}
+
+pub(super) fn print_pool_status(pool: &PoolStatus, formatter: &Formatter) {
+    let decommission = pool.decommission.as_ref();
+    let state = decommission_state(decommission);
+    let used = decommission
+        .map(|info| info.total_size.saturating_sub(info.current_size))
+        .unwrap_or_default();
+    let total = decommission.map(|info| info.total_size).unwrap_or_default();
+
+    formatter.println(&format!(
+        "  Pool {}: {}",
+        pool.id,
+        formatter.style_url(&pool.cmd_line)
+    ));
+    formatter.println(&format!(
+        "    Decommission: {}",
+        style_state(state, formatter)
+    ));
+
+    if total > 0 {
+        formatter.println(&format!(
+            "    Usage:        {} / {}",
+            formatter.style_size(&format_bytes(used)),
+            format_bytes(total)
+        ));
+    }
+
+    if let Some(info) = decommission
+        && (info.objects_decommissioned > 0
+            || info.objects_decommissioned_failed > 0
+            || info.bytes_decommissioned > 0
+            || info.bytes_decommissioned_failed > 0)
+    {
+        formatter.println(&format!(
+            "    Progress:     {}, {} failed; {}, {} failed bytes",
+            info.objects_decommissioned,
+            info.objects_decommissioned_failed,
+            format_bytes(info.bytes_decommissioned),
+            format_bytes(info.bytes_decommissioned_failed)
+        ));
+    }
+}
+
+fn decommission_state(decommission: Option<&PoolDecommissionInfo>) -> &'static str {
+    let Some(info) = decommission else {
+        return "not started";
+    };
+
+    if info.complete {
+        "complete"
+    } else if info.failed {
+        "failed"
+    } else if info.canceled {
+        "canceled"
+    } else if info.start_time.is_some() {
+        "running"
+    } else {
+        "not started"
+    }
+}
+
+fn style_state(state: &str, formatter: &Formatter) -> String {
+    match state {
+        "complete" => formatter.style_size(state),
+        "failed" => formatter.theme().error.apply_to(state).to_string(),
+        "canceled" => formatter.theme().warning.apply_to(state).to_string(),
+        "running" => formatter.style_name(state),
+        _ => formatter.style_date(state),
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    const TB: u64 = GB * 1024;
+
+    if bytes >= TB {
+        format!("{:.2} TiB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.2} GiB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MiB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KiB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_decommission_state() {
+        assert_eq!(decommission_state(None), "not started");
+        assert_eq!(
+            decommission_state(Some(&PoolDecommissionInfo {
+                start_time: Some("2026-05-06T00:00:00Z".to_string()),
+                ..Default::default()
+            })),
+            "running"
+        );
+        assert_eq!(
+            decommission_state(Some(&PoolDecommissionInfo {
+                complete: true,
+                ..Default::default()
+            })),
+            "complete"
+        );
+    }
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(1024), "1.00 KiB");
+        assert_eq!(format_bytes(1024 * 1024), "1.00 MiB");
+    }
+}

--- a/crates/cli/src/commands/admin/rebalance.rs
+++ b/crates/cli/src/commands/admin/rebalance.rs
@@ -1,0 +1,275 @@
+//! Rebalance commands for post-expansion data movement.
+
+use clap::Subcommand;
+use serde::Serialize;
+
+use super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+use rc_core::admin::{AdminApi, RebalancePoolStatus, RebalanceStatus};
+
+/// Rebalance subcommands
+#[derive(Subcommand, Debug)]
+pub enum RebalanceCommands {
+    /// Start a rebalance operation
+    Start(StartArgs),
+
+    /// Show rebalance status
+    Status(StatusArgs),
+
+    /// Stop a running rebalance operation
+    Stop(StopArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StartArgs {
+    /// Alias name of the server
+    pub alias: String,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StatusArgs {
+    /// Alias name of the server
+    pub alias: String,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct StopArgs {
+    /// Alias name of the server
+    pub alias: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RebalanceOperationOutput {
+    success: bool,
+    message: String,
+    target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    id: Option<String>,
+}
+
+/// Execute a rebalance subcommand
+pub async fn execute(cmd: RebalanceCommands, formatter: &Formatter) -> ExitCode {
+    match cmd {
+        RebalanceCommands::Start(args) => execute_start(args, formatter).await,
+        RebalanceCommands::Status(args) => execute_status(args, formatter).await,
+        RebalanceCommands::Stop(args) => execute_stop(args, formatter).await,
+    }
+}
+
+async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    match client.rebalance_start().await {
+        Ok(result) => {
+            if formatter.is_json() {
+                formatter.json(&RebalanceOperationOutput {
+                    success: true,
+                    message: "Rebalance started successfully".to_string(),
+                    target: args.alias,
+                    id: Some(result.id),
+                });
+            } else {
+                formatter.success("Rebalance started successfully.");
+                if !result.id.is_empty() {
+                    formatter.println(&format!("  ID: {}", result.id));
+                }
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to start rebalance: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}
+
+async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    match client.rebalance_status().await {
+        Ok(status) => {
+            if formatter.is_json() {
+                formatter.json(&status);
+            } else {
+                print_rebalance_status(&status, formatter);
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to get rebalance status: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}
+
+async fn execute_stop(args: StopArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    match client.rebalance_stop().await {
+        Ok(()) => {
+            if formatter.is_json() {
+                formatter.json(&RebalanceOperationOutput {
+                    success: true,
+                    message: "Rebalance stopped successfully".to_string(),
+                    target: args.alias,
+                    id: None,
+                });
+            } else {
+                formatter.success("Rebalance stopped successfully.");
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to stop rebalance: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}
+
+fn print_rebalance_status(status: &RebalanceStatus, formatter: &Formatter) {
+    formatter.println(&format!(
+        "{} {}",
+        formatter.style_name("Rebalance:"),
+        if status.id.is_empty() {
+            formatter.style_date("not started")
+        } else {
+            formatter.style_size("configured")
+        }
+    ));
+
+    if !status.id.is_empty() {
+        formatter.println(&format!("  ID: {}", status.id));
+    }
+    if let Some(stopped_at) = &status.stopped_at {
+        formatter.println(&format!("  Stopped: {}", stopped_at));
+    }
+
+    if status.pools.is_empty() {
+        formatter.println("  No pool status found.");
+        return;
+    }
+
+    formatter.println("");
+    formatter.println(&formatter.style_name("Per-pool usage:"));
+    for pool in &status.pools {
+        print_rebalance_pool(pool, formatter);
+    }
+}
+
+fn print_rebalance_pool(pool: &RebalancePoolStatus, formatter: &Formatter) {
+    let status = if pool.status.is_empty() {
+        "idle"
+    } else {
+        pool.status.as_str()
+    };
+
+    formatter.println(&format!(
+        "  Pool {}: {:.2}% used ({})",
+        pool.id,
+        pool.used * 100.0,
+        style_status(status, formatter)
+    ));
+
+    if let Some(error) = &pool.last_error
+        && !error.is_empty()
+    {
+        formatter.println(&format!("    Last error: {error}"));
+    }
+
+    if let Some(progress) = &pool.progress {
+        formatter.println(&format!(
+            "    Progress:   {} moved, {} objects, {} versions",
+            format_bytes(progress.bytes),
+            progress.num_objects,
+            progress.num_versions
+        ));
+        formatter.println(&format!(
+            "    Remaining:  {} buckets, ETA {}",
+            progress.remaining_buckets,
+            format_duration(progress.eta)
+        ));
+        if !progress.bucket.is_empty() {
+            formatter.println(&format!(
+                "    Current:    {}/{}",
+                progress.bucket, progress.object
+            ));
+        }
+        formatter.println(&format!(
+            "    Elapsed:    {}",
+            format_duration(progress.elapsed)
+        ));
+    }
+}
+
+fn style_status(status: &str, formatter: &Formatter) -> String {
+    match status {
+        "Started" | "running" => formatter.style_name(status),
+        "Stopped" | "stopped" => formatter.theme().warning.apply_to(status).to_string(),
+        "Completed" | "complete" => formatter.style_size(status),
+        "idle" => formatter.style_date(status),
+        _ => status.to_string(),
+    }
+}
+
+fn format_duration(seconds: u64) -> String {
+    let hours = seconds / 3600;
+    let minutes = (seconds % 3600) / 60;
+    let secs = seconds % 60;
+
+    if hours > 0 {
+        format!("{hours}h {minutes}m {secs}s")
+    } else if minutes > 0 {
+        format!("{minutes}m {secs}s")
+    } else {
+        format!("{secs}s")
+    }
+}
+
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = KB * 1024;
+    const GB: u64 = MB * 1024;
+    const TB: u64 = GB * 1024;
+
+    if bytes >= TB {
+        format!("{:.2} TiB", bytes as f64 / TB as f64)
+    } else if bytes >= GB {
+        format!("{:.2} GiB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MiB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.2} KiB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_duration() {
+        assert_eq!(format_duration(0), "0s");
+        assert_eq!(format_duration(65), "1m 5s");
+        assert_eq!(format_duration(3661), "1h 1m 1s");
+    }
+
+    #[test]
+    fn test_format_bytes() {
+        assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(1024), "1.00 KiB");
+        assert_eq!(format_bytes(1024 * 1024), "1.00 MiB");
+    }
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -154,7 +154,17 @@ fn top_level_command_help_contract() {
         HelpCase {
             args: &["admin"],
             usage: "Usage: rc admin [OPTIONS] <COMMAND>",
-            expected_tokens: &["info", "heal", "user", "policy", "group", "service-account"],
+            expected_tokens: &[
+                "info",
+                "heal",
+                "pool",
+                "decommission",
+                "rebalance",
+                "user",
+                "policy",
+                "group",
+                "service-account",
+            ],
         },
         HelpCase {
             args: &["bucket"],
@@ -435,6 +445,46 @@ fn nested_subcommand_help_contract() {
         HelpCase {
             args: &["admin", "heal", "stop"],
             usage: "Usage: rc admin heal stop [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "pool", "list"],
+            usage: "Usage: rc admin pool list [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "pool", "status"],
+            usage: "Usage: rc admin pool status [OPTIONS] <ALIAS> [POOL]",
+            expected_tokens: &["--by-id"],
+        },
+        HelpCase {
+            args: &["admin", "decommission", "start"],
+            usage: "Usage: rc admin decommission start [OPTIONS] <ALIAS> <POOL>",
+            expected_tokens: &["--by-id"],
+        },
+        HelpCase {
+            args: &["admin", "decommission", "status"],
+            usage: "Usage: rc admin decommission status [OPTIONS] <ALIAS> [POOL]",
+            expected_tokens: &["--by-id"],
+        },
+        HelpCase {
+            args: &["admin", "decommission", "cancel"],
+            usage: "Usage: rc admin decommission cancel [OPTIONS] <ALIAS> <POOL>",
+            expected_tokens: &["--by-id"],
+        },
+        HelpCase {
+            args: &["admin", "rebalance", "start"],
+            usage: "Usage: rc admin rebalance start [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "rebalance", "status"],
+            usage: "Usage: rc admin rebalance status [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "rebalance", "stop"],
+            usage: "Usage: rc admin rebalance stop [OPTIONS] <ALIAS>",
             expected_tokens: &[],
         },
         HelpCase {

--- a/crates/core/src/admin/cluster.rs
+++ b/crates/core/src/admin/cluster.rs
@@ -566,6 +566,170 @@ pub struct HealStatus {
     pub last_update: Option<String>,
 }
 
+/// Request targeting a storage pool by command line or numeric ID.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct PoolTarget {
+    /// Pool command line, or zero-based pool ID when `by_id` is true.
+    pub pool: String,
+
+    /// Interpret `pool` as a zero-based pool ID.
+    #[serde(default)]
+    pub by_id: bool,
+}
+
+/// Status of a server pool.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PoolStatus {
+    /// Zero-based pool ID.
+    #[serde(default)]
+    pub id: usize,
+
+    /// Pool command line used by the server process.
+    #[serde(default, rename = "cmdline")]
+    pub cmd_line: String,
+
+    /// Last pool metadata update timestamp.
+    #[serde(default, rename = "lastUpdate")]
+    pub last_update: String,
+
+    /// Decommission status and progress for this pool.
+    #[serde(default, rename = "decommissionInfo")]
+    pub decommission: Option<PoolDecommissionInfo>,
+}
+
+/// Decommission state and progress for a server pool.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PoolDecommissionInfo {
+    /// Decommission start timestamp.
+    #[serde(default, rename = "startTime")]
+    pub start_time: Option<String>,
+
+    /// Free bytes when decommission started.
+    #[serde(default, rename = "startSize")]
+    pub start_size: u64,
+
+    /// Total pool size in bytes.
+    #[serde(default, rename = "totalSize")]
+    pub total_size: u64,
+
+    /// Current free size in bytes.
+    #[serde(default, rename = "currentSize")]
+    pub current_size: u64,
+
+    /// Whether decommission completed.
+    #[serde(default)]
+    pub complete: bool,
+
+    /// Whether decommission failed.
+    #[serde(default)]
+    pub failed: bool,
+
+    /// Whether decommission was canceled.
+    #[serde(default)]
+    pub canceled: bool,
+
+    /// Number of successfully decommissioned objects.
+    #[serde(default, rename = "objectsDecommissioned")]
+    pub objects_decommissioned: u64,
+
+    /// Number of objects that failed to decommission.
+    #[serde(default, rename = "objectsDecommissionedFailed")]
+    pub objects_decommissioned_failed: u64,
+
+    /// Bytes successfully moved off the pool.
+    #[serde(default, rename = "bytesDecommissioned")]
+    pub bytes_decommissioned: u64,
+
+    /// Bytes that failed to move off the pool.
+    #[serde(default, rename = "bytesDecommissionedFailed")]
+    pub bytes_decommissioned_failed: u64,
+}
+
+/// Response from starting a rebalance operation.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RebalanceStartResult {
+    /// Rebalance operation ID.
+    #[serde(default)]
+    pub id: String,
+}
+
+/// Cluster-wide rebalance status.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RebalanceStatus {
+    /// Rebalance operation ID.
+    #[serde(default)]
+    pub id: String,
+
+    /// Per-pool rebalance status.
+    #[serde(default)]
+    pub pools: Vec<RebalancePoolStatus>,
+
+    /// Timestamp when rebalance was stopped.
+    #[serde(default, rename = "stoppedAt")]
+    pub stopped_at: Option<String>,
+}
+
+/// Rebalance status for a single pool.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RebalancePoolStatus {
+    /// Zero-based pool ID.
+    #[serde(default)]
+    pub id: usize,
+
+    /// Rebalance status for this pool.
+    #[serde(default)]
+    pub status: String,
+
+    /// Used capacity ratio in the range 0.0..=1.0.
+    #[serde(default)]
+    pub used: f64,
+
+    /// Last rebalance error, if any.
+    #[serde(default, rename = "lastError")]
+    pub last_error: Option<String>,
+
+    /// Rebalance progress, if this pool is active.
+    #[serde(default)]
+    pub progress: Option<RebalancePoolProgress>,
+}
+
+/// Rebalance progress for a single pool.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct RebalancePoolProgress {
+    /// Number of objects moved.
+    #[serde(default, rename = "objects")]
+    pub num_objects: u64,
+
+    /// Number of object versions moved.
+    #[serde(default, rename = "versions")]
+    pub num_versions: u64,
+
+    /// Number of bytes moved.
+    #[serde(default)]
+    pub bytes: u64,
+
+    /// Number of buckets remaining.
+    #[serde(default, rename = "remainingBuckets")]
+    pub remaining_buckets: usize,
+
+    /// Current bucket.
+    #[serde(default)]
+    pub bucket: String,
+
+    /// Current object.
+    #[serde(default)]
+    pub object: String,
+
+    /// Elapsed seconds.
+    #[serde(default)]
+    pub elapsed: u64,
+
+    /// Estimated seconds remaining.
+    #[serde(default)]
+    pub eta: u64,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -686,6 +850,36 @@ mod tests {
         assert!(status.heal_id.is_empty());
         assert!(!status.healing);
         assert_eq!(status.items_scanned, 0);
+    }
+
+    #[test]
+    fn test_pool_status_deserialization() {
+        let json = r#"{"id":1,"cmdline":"/data/pool1/disk{1...4}","lastUpdate":"2026-05-06T00:00:00Z","decommissionInfo":{"startTime":"2026-05-06T00:00:01Z","startSize":100,"totalSize":1000,"currentSize":600,"complete":false,"failed":false,"canceled":false,"objectsDecommissioned":2,"objectsDecommissionedFailed":1,"bytesDecommissioned":128,"bytesDecommissionedFailed":64}}"#;
+
+        let status: PoolStatus = serde_json::from_str(json).unwrap();
+
+        assert_eq!(status.id, 1);
+        assert_eq!(status.cmd_line, "/data/pool1/disk{1...4}");
+        let info = status.decommission.expect("decommission info exists");
+        assert_eq!(info.objects_decommissioned, 2);
+        assert_eq!(info.bytes_decommissioned_failed, 64);
+    }
+
+    #[test]
+    fn test_rebalance_status_deserialization() {
+        let json = r#"{"id":"rebalance-1","pools":[{"id":0,"status":"Started","used":0.5,"lastError":null,"progress":{"objects":3,"versions":4,"bytes":1024,"remainingBuckets":2,"bucket":"bucket","object":"object","elapsed":10,"eta":20}}],"stoppedAt":null}"#;
+
+        let status: RebalanceStatus = serde_json::from_str(json).unwrap();
+
+        assert_eq!(status.id, "rebalance-1");
+        assert_eq!(status.pools.len(), 1);
+        assert_eq!(status.pools[0].used, 0.5);
+        let progress = status.pools[0]
+            .progress
+            .as_ref()
+            .expect("progress should exist");
+        assert_eq!(progress.num_objects, 3);
+        assert_eq!(progress.remaining_buckets, 2);
     }
 
     #[test]

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -10,7 +10,8 @@ mod types;
 pub use cluster::{
     BackendInfo, BackendType, BucketsInfo, ClusterInfo, DiskInfo, HealDriveInfo, HealDriveInfos,
     HealResultItem, HealScanMode, HealStartRequest, HealStatus, HealingDiskInfo, MemStats,
-    ObjectsInfo, ServerInfo, UsageInfo,
+    ObjectsInfo, PoolDecommissionInfo, PoolStatus, PoolTarget, RebalancePoolProgress,
+    RebalancePoolStatus, RebalanceStartResult, RebalanceStatus, ServerInfo, UsageInfo,
 };
 pub use tier::{
     TierAliyun, TierAzure, TierConfig, TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2,
@@ -46,6 +47,27 @@ pub trait AdminApi: Send + Sync {
 
     /// Stop a running heal operation
     async fn heal_stop(&self) -> Result<()>;
+
+    /// List storage pools
+    async fn list_pools(&self) -> Result<Vec<PoolStatus>>;
+
+    /// Get storage pool status
+    async fn pool_status(&self, target: PoolTarget) -> Result<PoolStatus>;
+
+    /// Start decommissioning one or more storage pools
+    async fn decommission_start(&self, target: PoolTarget) -> Result<()>;
+
+    /// Cancel decommissioning a storage pool
+    async fn decommission_cancel(&self, target: PoolTarget) -> Result<()>;
+
+    /// Start a rebalance operation
+    async fn rebalance_start(&self) -> Result<RebalanceStartResult>;
+
+    /// Get rebalance status
+    async fn rebalance_status(&self) -> Result<RebalanceStatus>;
+
+    /// Stop a running rebalance operation
+    async fn rebalance_stop(&self) -> Result<()>;
 
     // ==================== User Operations ====================
 

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -11,7 +11,8 @@ use aws_sigv4::http_request::{
 use aws_sigv4::sign::v4;
 use rc_core::admin::{
     AdminApi, BucketQuota, ClusterInfo, CreateServiceAccountRequest, Group, GroupStatus,
-    HealScanMode, HealStartRequest, HealStatus, Policy, PolicyEntity, PolicyInfo, ServiceAccount,
+    HealScanMode, HealStartRequest, HealStatus, Policy, PolicyEntity, PolicyInfo, PoolStatus,
+    PoolTarget, RebalanceStartResult, RebalanceStatus, ServiceAccount,
     ServiceAccountCreateResponse, UpdateGroupMembersRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
@@ -442,6 +443,14 @@ fn rustfs_heal_body(request: &HealStartRequest) -> Result<Vec<u8>> {
     serde_json::to_vec(&RustfsHealOptions::from(request)).map_err(Error::Json)
 }
 
+fn pool_target_query(target: &PoolTarget) -> Vec<(&str, &str)> {
+    let mut query = vec![("pool", target.pool.as_str())];
+    if target.by_id {
+        query.push(("by-id", "true"));
+    }
+    query
+}
+
 /// Request body for setting bucket quota
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -482,6 +491,43 @@ impl AdminApi for AdminClient {
             Some(&body),
         )
         .await
+    }
+
+    async fn list_pools(&self) -> Result<Vec<PoolStatus>> {
+        self.request(Method::GET, "/pools/list", None, None).await
+    }
+
+    async fn pool_status(&self, target: PoolTarget) -> Result<PoolStatus> {
+        let query = pool_target_query(&target);
+        self.request(Method::GET, "/pools/status", Some(&query), None)
+            .await
+    }
+
+    async fn decommission_start(&self, target: PoolTarget) -> Result<()> {
+        let query = pool_target_query(&target);
+        self.request_no_response(Method::POST, "/pools/decommission", Some(&query), None)
+            .await
+    }
+
+    async fn decommission_cancel(&self, target: PoolTarget) -> Result<()> {
+        let query = pool_target_query(&target);
+        self.request_no_response(Method::POST, "/pools/cancel", Some(&query), None)
+            .await
+    }
+
+    async fn rebalance_start(&self) -> Result<RebalanceStartResult> {
+        self.request(Method::POST, "/rebalance/start", None, None)
+            .await
+    }
+
+    async fn rebalance_status(&self) -> Result<RebalanceStatus> {
+        self.request(Method::GET, "/rebalance/status", None, None)
+            .await
+    }
+
+    async fn rebalance_stop(&self) -> Result<()> {
+        self.request_no_response(Method::POST, "/rebalance/stop", None, None)
+            .await
     }
 
     // ==================== User Operations ====================
@@ -1195,6 +1241,78 @@ mod tests {
         assert_eq!(request.method, "POST");
         assert_eq!(request.target, "/rustfs/admin/v3/heal/?forceStop=true");
         assert_heal_options_body(&request.body, 1, false, false, false);
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_pool_status_uses_pool_status_route_with_by_id_query() {
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"id":1,"cmdline":"/data/pool1/disk{1...4}","lastUpdate":"2026-05-06T00:00:00Z","decommissionInfo":null}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client
+            .pool_status(PoolTarget {
+                pool: "1".to_string(),
+                by_id: true,
+            })
+            .await
+            .expect("pool status request");
+
+        assert_eq!(status.id, 1);
+        assert_eq!(status.cmd_line, "/data/pool1/disk{1...4}");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/pools/status?pool=1&by-id=true"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_decommission_start_posts_pool_query() {
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let client = admin_client_for_endpoint(&endpoint);
+
+        client
+            .decommission_start(PoolTarget {
+                pool: "/data/pool1/disk{1...4}".to_string(),
+                by_id: false,
+            })
+            .await
+            .expect("decommission start request");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/pools/decommission?pool=%2Fdata%2Fpool1%2Fdisk%7B1...4%7D"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_rebalance_start_posts_rebalance_start_route() {
+        let (endpoint, receiver, handle) =
+            start_admin_test_server("200 OK", r#"{"id":"rebalance-123"}"#);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let result = client
+            .rebalance_start()
+            .await
+            .expect("rebalance start request");
+
+        assert_eq!(result.id, "rebalance-123");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.target, "/rustfs/admin/v3/rebalance/start");
+        assert!(request.body.is_empty());
         handle.join().expect("server thread should finish");
     }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -228,6 +228,85 @@ rc admin heal stop <ALIAS>
 
 **Exit Codes:** 0, 2 (invalid input), 4 (auth error), 5 (alias not found)
 
+#### admin pool
+
+List server pools and inspect pool status. This is the CLI entry point for
+post-expansion verification: RustFS expansion is performed by starting the
+deployment with additional pools, then using these commands to verify that the
+new pool is visible.
+
+```
+rc admin pool list <ALIAS>
+rc admin pool status <ALIAS> [POOL] [OPTIONS]
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| ALIAS | Alias name of the server |
+| POOL | Pool command line, or zero-based pool ID with `--by-id` |
+
+**Options (status):**
+| Option | Default | Description |
+|--------|---------|-------------|
+| --by-id | false | Interpret `POOL` as a zero-based pool ID |
+
+**Output (--json):**
+- `admin pool list`: See `schemas/output_v2.json#admin-pool-list`
+- `admin pool status`: See `schemas/output_v2.json#admin-pool-status`
+
+**Exit Codes:** 0, 4 (auth error), 5 (alias not found)
+
+#### admin decommission
+
+Manage server pool decommissioning.
+
+```
+rc admin decommission start <ALIAS> <POOL> [OPTIONS]
+rc admin decommission status <ALIAS> [POOL] [OPTIONS]
+rc admin decommission cancel <ALIAS> <POOL> [OPTIONS]
+```
+
+Alias: `rc admin decom`
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| ALIAS | Alias name of the server |
+| POOL | Pool command line, comma-separated pool command lines for `start`, or zero-based pool ID with `--by-id` |
+
+**Options:**
+| Option | Default | Description |
+|--------|---------|-------------|
+| --by-id | false | Interpret `POOL` as zero-based pool ID values |
+
+**Output (--json):**
+- `admin decommission status`: See `schemas/output_v2.json#admin-pool-status` or `schemas/output_v2.json#admin-pool-list`
+- `admin decommission start/cancel`: See `schemas/output_v2.json#admin-decommission-operation`
+
+**Exit Codes:** 0, 4 (auth error), 5 (alias not found)
+
+#### admin rebalance
+
+Manage data rebalancing after server pool expansion.
+
+```
+rc admin rebalance start <ALIAS>
+rc admin rebalance status <ALIAS>
+rc admin rebalance stop <ALIAS>
+```
+
+**Arguments:**
+| Argument | Description |
+|----------|-------------|
+| ALIAS | Alias name of the server |
+
+**Output (--json):**
+- `admin rebalance status`: See `schemas/output_v2.json#admin-rebalance-status`
+- `admin rebalance start/stop`: See `schemas/output_v2.json#admin-rebalance-operation`
+
+**Exit Codes:** 0, 4 (auth error), 5 (alias not found)
+
 ---
 
 ### ls - List Objects

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -253,7 +253,8 @@ rc admin pool status <ALIAS> [POOL] [OPTIONS]
 
 **Output (--json):**
 - `admin pool list`: See `schemas/output_v2.json#admin-pool-list`
-- `admin pool status`: See `schemas/output_v2.json#admin-pool-status`
+- `admin pool status <ALIAS> <POOL>`: See `schemas/output_v2.json#admin-pool-status`
+- `admin pool status <ALIAS>`: See `schemas/output_v2.json#admin-pool-list`
 
 **Exit Codes:** 0, 4 (auth error), 5 (alias not found)
 

--- a/schemas/output_v2.json
+++ b/schemas/output_v2.json
@@ -302,9 +302,13 @@
       "type": "object",
       "properties": {
         "startTime": {
-          "type": [
-            "string",
-            "null"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/timestamp"
+            },
+            {
+              "type": "null"
+            }
           ],
           "description": "Decommission start timestamp"
         },
@@ -368,7 +372,7 @@
           "description": "Pool command line used by the server process"
         },
         "lastUpdate": {
-          "type": "string",
+          "$ref": "#/definitions/timestamp",
           "description": "Last pool metadata update timestamp"
         },
         "decommissionInfo": {
@@ -492,9 +496,13 @@
           }
         },
         "stoppedAt": {
-          "type": [
-            "string",
-            "null"
+          "oneOf": [
+            {
+              "$ref": "#/definitions/timestamp"
+            },
+            {
+              "type": "null"
+            }
           ],
           "description": "Timestamp when rebalance was stopped"
         }

--- a/schemas/output_v2.json
+++ b/schemas/output_v2.json
@@ -298,6 +298,208 @@
         }
       }
     },
+    "poolDecommissionInfo": {
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Decommission start timestamp"
+        },
+        "startSize": {
+          "type": "integer",
+          "description": "Free bytes when decommission started"
+        },
+        "totalSize": {
+          "type": "integer",
+          "description": "Total pool size in bytes"
+        },
+        "currentSize": {
+          "type": "integer",
+          "description": "Current free bytes in the pool"
+        },
+        "complete": {
+          "type": "boolean",
+          "description": "Whether decommission completed"
+        },
+        "failed": {
+          "type": "boolean",
+          "description": "Whether decommission failed"
+        },
+        "canceled": {
+          "type": "boolean",
+          "description": "Whether decommission was canceled"
+        },
+        "objectsDecommissioned": {
+          "type": "integer",
+          "description": "Objects successfully moved off the pool"
+        },
+        "objectsDecommissionedFailed": {
+          "type": "integer",
+          "description": "Objects that failed to move off the pool"
+        },
+        "bytesDecommissioned": {
+          "type": "integer",
+          "description": "Bytes successfully moved off the pool"
+        },
+        "bytesDecommissionedFailed": {
+          "type": "integer",
+          "description": "Bytes that failed to move off the pool"
+        }
+      }
+    },
+    "poolStatus": {
+      "type": "object",
+      "required": [
+        "id",
+        "cmdline",
+        "lastUpdate",
+        "decommissionInfo"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Zero-based pool ID"
+        },
+        "cmdline": {
+          "type": "string",
+          "description": "Pool command line used by the server process"
+        },
+        "lastUpdate": {
+          "type": "string",
+          "description": "Last pool metadata update timestamp"
+        },
+        "decommissionInfo": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/poolDecommissionInfo"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Decommission state and progress for this pool"
+        }
+      }
+    },
+    "rebalancePoolProgress": {
+      "type": "object",
+      "required": [
+        "objects",
+        "versions",
+        "bytes",
+        "remainingBuckets",
+        "bucket",
+        "object",
+        "elapsed",
+        "eta"
+      ],
+      "properties": {
+        "objects": {
+          "type": "integer",
+          "description": "Objects moved"
+        },
+        "versions": {
+          "type": "integer",
+          "description": "Object versions moved"
+        },
+        "bytes": {
+          "type": "integer",
+          "description": "Bytes moved"
+        },
+        "remainingBuckets": {
+          "type": "integer",
+          "description": "Buckets remaining"
+        },
+        "bucket": {
+          "type": "string",
+          "description": "Current bucket"
+        },
+        "object": {
+          "type": "string",
+          "description": "Current object"
+        },
+        "elapsed": {
+          "type": "integer",
+          "description": "Elapsed seconds"
+        },
+        "eta": {
+          "type": "integer",
+          "description": "Estimated seconds remaining"
+        }
+      }
+    },
+    "rebalancePoolStatus": {
+      "type": "object",
+      "required": [
+        "id",
+        "status",
+        "used",
+        "lastError",
+        "progress"
+      ],
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Zero-based pool ID"
+        },
+        "status": {
+          "type": "string",
+          "description": "Pool rebalance status"
+        },
+        "used": {
+          "type": "number",
+          "description": "Used capacity ratio in the range 0.0..=1.0"
+        },
+        "lastError": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Last rebalance error for this pool"
+        },
+        "progress": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/rebalancePoolProgress"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Rebalance progress for this pool"
+        }
+      }
+    },
+    "rebalanceStatus": {
+      "type": "object",
+      "required": [
+        "id",
+        "pools",
+        "stoppedAt"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Rebalance operation ID"
+        },
+        "pools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/rebalancePoolStatus"
+          }
+        },
+        "stoppedAt": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "description": "Timestamp when rebalance was stopped"
+        }
+      }
+    },
     "errorResponse": {
       "type": "object",
       "required": [
@@ -469,6 +671,78 @@
         },
         "status": {
           "$ref": "#/definitions/healStatus"
+        }
+      }
+    },
+    {
+      "title": "admin pool list",
+      "description": "Server pool list output",
+      "type": "object",
+      "required": [
+        "pools"
+      ],
+      "properties": {
+        "pools": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/poolStatus"
+          }
+        }
+      }
+    },
+    {
+      "title": "admin pool status",
+      "description": "Server pool status output",
+      "$ref": "#/definitions/poolStatus"
+    },
+    {
+      "title": "admin decommission operation",
+      "description": "Decommission start/cancel output",
+      "type": "object",
+      "required": [
+        "success",
+        "message",
+        "pool"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "pool": {
+          "type": "string"
+        }
+      }
+    },
+    {
+      "title": "admin rebalance status",
+      "description": "Rebalance status output",
+      "$ref": "#/definitions/rebalanceStatus"
+    },
+    {
+      "title": "admin rebalance operation",
+      "description": "Rebalance start/stop output",
+      "type": "object",
+      "required": [
+        "success",
+        "message",
+        "target"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "description": "Rebalance operation ID returned by start"
         }
       }
     },


### PR DESCRIPTION
## Related issues

None specified.

## Background

RustFS exposes admin APIs for pool listing/status, decommission, and rebalance workflows, but rc did not provide matching CLI coverage.

## Protected contract note

BREAKING: Protected contract files were updated. The SPEC and output_v2 schema changes are additive for new admin pool, decommission, and rebalance command outputs; no existing command output shape is changed.

## Solution

Add admin pool, decommission, and rebalance command groups backed by the RustFS admin API. Document the new command contract in SPEC.md, extend output_v2 JSON schema, add help/parse/unit/endpoint coverage, and update README examples. Expansion is represented as the RustFS server workflow of starting with additional pools and then using rc to verify pools and run rebalance.

## Validation

- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- jq empty schemas/output_v2.json
- git diff --check
- Docker smoke validation against rustfs/rustfs:latest, including pool list/status, decommission start/status/cancel, rebalance start/status, and expansion-style single-pool to two-pool restart verification. Rebalance stop reached the real service error path but not the success path because the local rebalance completed too quickly.