### PR TITLE
feat(alias): support RC_HOST environment aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2328,6 +2328,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -1,0 +1,55 @@
+#![cfg(not(windows))]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn rc_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rc") {
+        return PathBuf::from(path);
+    }
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has parent directory")
+        .parent()
+        .expect("workspace root exists")
+        .to_path_buf();
+
+    let debug_binary = workspace_root.join("target/debug/rc");
+    if debug_binary.exists() {
+        return debug_binary;
+    }
+
+    workspace_root.join("target/release/rc")
+}
+
+#[test]
+fn alias_list_includes_rc_host_alias_without_credentials() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = Command::new(rc_binary())
+        .args(["alias", "list", "--json"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_myalias",
+            "https://ACCESS_KEY:SECRET_KEY@rustfs.local:9000",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(!stdout.contains("SECRET_KEY"));
+
+    let payload: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
+    assert_eq!(payload["aliases"][0]["name"], "myalias");
+    assert_eq!(
+        payload["aliases"][0]["endpoint"],
+        "https://rustfs.local:9000"
+    );
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -33,9 +33,9 @@ tracing.workspace = true
 dirs.workspace = true
 jiff.workspace = true
 url.workspace = true
+urlencoding.workspace = true
 humansize.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
 mockall.workspace = true
-

--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -3,10 +3,15 @@
 //! Aliases are named references to S3-compatible storage endpoints,
 //! including connection details and credentials.
 
+use std::env;
+
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 use crate::config::ConfigManager;
 use crate::error::{Error, Result};
+
+const RC_HOST_PREFIX: &str = "RC_HOST_";
 
 /// Retry configuration for an alias
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -165,6 +170,129 @@ impl Alias {
     }
 }
 
+fn env_alias_var_name(name: &str) -> String {
+    format!("{RC_HOST_PREFIX}{name}")
+}
+
+fn env_alias(name: &str) -> Result<Option<Alias>> {
+    let var_name = env_alias_var_name(name);
+    let Some(value) = env::var_os(&var_name) else {
+        return Ok(None);
+    };
+
+    let value = value
+        .into_string()
+        .map_err(|_| Error::Config(format!("{var_name} must be valid UTF-8")))?;
+    parse_env_alias(name, &value).map(Some)
+}
+
+fn env_aliases() -> Result<Vec<Alias>> {
+    let mut vars = Vec::new();
+
+    for (key, value) in env::vars_os() {
+        let Ok(key) = key.into_string() else {
+            continue;
+        };
+
+        if !key.starts_with(RC_HOST_PREFIX) {
+            continue;
+        }
+
+        let value = value
+            .into_string()
+            .map_err(|_| Error::Config(format!("{key} must be valid UTF-8")))?;
+        vars.push((key, value));
+    }
+
+    env_aliases_from_vars(vars)
+}
+
+fn env_aliases_from_vars<I, K, V>(vars: I) -> Result<Vec<Alias>>
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<str>,
+    V: AsRef<str>,
+{
+    let mut aliases = Vec::new();
+
+    for (key, value) in vars {
+        let key = key.as_ref();
+        let Some(alias_name) = key.strip_prefix(RC_HOST_PREFIX) else {
+            continue;
+        };
+
+        if alias_name.is_empty() {
+            return Err(Error::Config("RC_HOST_ must include an alias name".into()));
+        }
+
+        aliases.push(parse_env_alias(alias_name, value.as_ref())?);
+    }
+
+    aliases.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(aliases)
+}
+
+fn parse_env_alias(name: &str, value: &str) -> Result<Alias> {
+    let var_name = env_alias_var_name(name);
+    let mut url = Url::parse(value)
+        .map_err(|e| Error::Config(format!("{var_name} must be a valid URL: {e}")))?;
+
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(Error::Config(format!(
+            "{var_name} must use an http or https URL"
+        )));
+    }
+
+    if url.host_str().is_none() {
+        return Err(Error::Config(format!("{var_name} must include a host")));
+    }
+
+    let access_key = url.username();
+    let Some(secret_key) = url.password() else {
+        return Err(Error::Config(format!(
+            "{var_name} must include access key and secret key credentials"
+        )));
+    };
+
+    if access_key.is_empty() || secret_key.is_empty() {
+        return Err(Error::Config(format!(
+            "{var_name} must include non-empty access key and secret key credentials"
+        )));
+    }
+
+    let access_key = decode_env_alias_credential(access_key, &var_name, "access key")?;
+    let secret_key = decode_env_alias_credential(secret_key, &var_name, "secret key")?;
+
+    url.set_username("").map_err(|()| {
+        Error::Config(format!("{var_name} credentials cannot be removed from URL"))
+    })?;
+    url.set_password(None).map_err(|()| {
+        Error::Config(format!("{var_name} credentials cannot be removed from URL"))
+    })?;
+
+    let endpoint = url.as_str().trim_end_matches('/').to_string();
+    Ok(Alias::new(name, endpoint, access_key, secret_key))
+}
+
+fn decode_env_alias_credential(value: &str, var_name: &str, field: &str) -> Result<String> {
+    urlencoding::decode(value)
+        .map(|decoded| decoded.into_owned())
+        .map_err(|e| {
+            Error::Config(format!(
+                "{var_name} contains invalid percent-encoding in {field}: {e}"
+            ))
+        })
+}
+
+fn merge_env_aliases(mut aliases: Vec<Alias>, env_aliases: Vec<Alias>) -> Vec<Alias> {
+    for env_alias in env_aliases {
+        aliases.retain(|alias| alias.name != env_alias.name);
+        aliases.push(env_alias);
+    }
+
+    aliases
+}
+
 /// Manager for alias operations
 pub struct AliasManager {
     config_manager: ConfigManager,
@@ -185,11 +313,16 @@ impl AliasManager {
     /// List all configured aliases
     pub fn list(&self) -> Result<Vec<Alias>> {
         let config = self.config_manager.load()?;
-        Ok(config.aliases)
+        let env_aliases = env_aliases()?;
+        Ok(merge_env_aliases(config.aliases, env_aliases))
     }
 
     /// Get an alias by name
     pub fn get(&self, name: &str) -> Result<Alias> {
+        if let Some(alias) = env_alias(name)? {
+            return Ok(alias);
+        }
+
         let config = self.config_manager.load()?;
         config
             .aliases
@@ -225,6 +358,10 @@ impl AliasManager {
 
     /// Check if an alias exists
     pub fn exists(&self, name: &str) -> Result<bool> {
+        if env_alias(name)?.is_some() {
+            return Ok(true);
+        }
+
         let config = self.config_manager.load()?;
         Ok(config.aliases.iter().any(|a| a.name == name))
     }
@@ -326,5 +463,67 @@ mod tests {
         let aliases = manager.list().unwrap();
         assert_eq!(aliases.len(), 1);
         assert_eq!(aliases[0].endpoint, "http://new:9000");
+    }
+
+    #[test]
+    fn test_parse_rc_host_alias() {
+        let alias =
+            parse_env_alias("myalias", "https://ACCESS_KEY:SECRET_KEY@rustfs.local:9000").unwrap();
+
+        assert_eq!(alias.name, "myalias");
+        assert_eq!(alias.endpoint, "https://rustfs.local:9000");
+        assert_eq!(alias.access_key, "ACCESS_KEY");
+        assert_eq!(alias.secret_key, "SECRET_KEY");
+        assert_eq!(alias.region, "us-east-1");
+        assert_eq!(alias.bucket_lookup, "auto");
+    }
+
+    #[test]
+    fn test_parse_rc_host_alias_decodes_credentials() {
+        let alias =
+            parse_env_alias("encoded", "https://ACCESS%2FKEY:SECRET%40KEY@rustfs.local").unwrap();
+
+        assert_eq!(alias.access_key, "ACCESS/KEY");
+        assert_eq!(alias.secret_key, "SECRET@KEY");
+    }
+
+    #[test]
+    fn test_parse_rc_host_alias_requires_credentials() {
+        let result = parse_env_alias("missing", "https://rustfs.local");
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), Error::Config(_)));
+    }
+
+    #[test]
+    fn test_env_aliases_from_vars_filters_rc_host_prefix() {
+        let aliases = env_aliases_from_vars(vec![
+            (
+                "RC_HOST_second".to_string(),
+                "https://key2:secret2@second.local".to_string(),
+            ),
+            ("UNRELATED".to_string(), "ignored".to_string()),
+            (
+                "RC_HOST_first".to_string(),
+                "https://key1:secret1@first.local".to_string(),
+            ),
+        ])
+        .unwrap();
+
+        assert_eq!(aliases.len(), 2);
+        assert_eq!(aliases[0].name, "first");
+        assert_eq!(aliases[1].name, "second");
+    }
+
+    #[test]
+    fn test_merge_env_aliases_overrides_config_alias() {
+        let config_alias = Alias::new("local", "http://old:9000", "old", "old");
+        let env_alias = parse_env_alias("local", "https://new:secret@new.local").unwrap();
+
+        let aliases = merge_env_aliases(vec![config_alias], vec![env_alias]);
+
+        assert_eq!(aliases.len(), 1);
+        assert_eq!(aliases[0].endpoint, "https://new.local");
+        assert_eq!(aliases[0].access_key, "new");
     }
 }


### PR DESCRIPTION
## Related Issue
Closes #174

## Problem
Users requested temporary aliases through `RC_HOST_<ALIAS>`, similar to MinIO `MC_HOST_<ALIAS>`, so commands can run without a persisted config alias.

## Root Cause
`AliasManager` only resolved aliases from the config file, so `rc ls myalias` could not use credentials supplied through an environment variable.

## Solution
- Parse `RC_HOST_<alias>` URLs into temporary aliases.
- Strip credentials from the endpoint and percent-decode access key and secret key userinfo.
- Let environment aliases participate in `get`, `exists`, and `list`, overriding same-named config aliases for the current process.
- Add CLI coverage to ensure `alias list --json` sees an env alias without exposing credentials.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- Docker-backed check against `rustfs/rustfs:latest`: `RC_HOST_myalias=http://<access-key>:<secret-key>@127.0.0.1:<port> target/debug/rc ls myalias`
