### PR TITLE
test(admin): cover pool and rebalance gaps

### DIFF
--- a/crates/cli/src/commands/admin/pool.rs
+++ b/crates/cli/src/commands/admin/pool.rs
@@ -224,6 +224,10 @@ mod tests {
     fn test_decommission_state() {
         assert_eq!(decommission_state(None), "not started");
         assert_eq!(
+            decommission_state(Some(&PoolDecommissionInfo::default())),
+            "not started"
+        );
+        assert_eq!(
             decommission_state(Some(&PoolDecommissionInfo {
                 start_time: Some("2026-05-06T00:00:00Z".to_string()),
                 ..Default::default()
@@ -237,12 +241,29 @@ mod tests {
             })),
             "complete"
         );
+        assert_eq!(
+            decommission_state(Some(&PoolDecommissionInfo {
+                failed: true,
+                ..Default::default()
+            })),
+            "failed"
+        );
+        assert_eq!(
+            decommission_state(Some(&PoolDecommissionInfo {
+                canceled: true,
+                ..Default::default()
+            })),
+            "canceled"
+        );
     }
 
     #[test]
     fn test_format_bytes() {
         assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(1536), "1.50 KiB");
         assert_eq!(format_bytes(1024), "1.00 KiB");
         assert_eq!(format_bytes(1024 * 1024), "1.00 MiB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00 GiB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024 * 1024), "1.00 TiB");
     }
 }

--- a/crates/cli/src/commands/admin/rebalance.rs
+++ b/crates/cli/src/commands/admin/rebalance.rs
@@ -258,18 +258,42 @@ fn format_bytes(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::output::OutputConfig;
 
     #[test]
     fn test_format_duration() {
         assert_eq!(format_duration(0), "0s");
+        assert_eq!(format_duration(59), "59s");
+        assert_eq!(format_duration(60), "1m 0s");
         assert_eq!(format_duration(65), "1m 5s");
+        assert_eq!(format_duration(3600), "1h 0m 0s");
         assert_eq!(format_duration(3661), "1h 1m 1s");
     }
 
     #[test]
     fn test_format_bytes() {
         assert_eq!(format_bytes(0), "0 B");
+        assert_eq!(format_bytes(1536), "1.50 KiB");
         assert_eq!(format_bytes(1024), "1.00 KiB");
         assert_eq!(format_bytes(1024 * 1024), "1.00 MiB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024), "1.00 GiB");
+        assert_eq!(format_bytes(1024 * 1024 * 1024 * 1024), "1.00 TiB");
+    }
+
+    #[test]
+    fn test_style_status_variants_without_color() {
+        let formatter = Formatter::new(OutputConfig {
+            no_color: true,
+            ..Default::default()
+        });
+
+        assert_eq!(style_status("Started", &formatter), "Started");
+        assert_eq!(style_status("running", &formatter), "running");
+        assert_eq!(style_status("Stopped", &formatter), "Stopped");
+        assert_eq!(style_status("stopped", &formatter), "stopped");
+        assert_eq!(style_status("Completed", &formatter), "Completed");
+        assert_eq!(style_status("complete", &formatter), "complete");
+        assert_eq!(style_status("idle", &formatter), "idle");
+        assert_eq!(style_status("Queued", &formatter), "Queued");
     }
 }

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -1274,6 +1274,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_pool_status_uses_command_line_query_without_by_id() {
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"id":2,"cmdline":"/data/pool2/disk{1...4}","lastUpdate":"2026-05-06T00:00:00Z","decommissionInfo":null}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client
+            .pool_status(PoolTarget {
+                pool: "/data/pool2/disk{1...4}".to_string(),
+                by_id: false,
+            })
+            .await
+            .expect("pool status request");
+
+        assert_eq!(status.id, 2);
+        assert_eq!(status.cmd_line, "/data/pool2/disk{1...4}");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/pools/status?pool=%2Fdata%2Fpool2%2Fdisk%7B1...4%7D"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
     async fn test_list_pools_uses_pool_list_route() {
         let (endpoint, receiver, handle) = start_admin_test_server(
             "200 OK",


### PR DESCRIPTION
## Related issue(s)

None. This is a focused test-gap follow-up for the recent admin pool, decommission, and rebalance command work.

## Background and impact

The new admin pool and rebalance commands already had parser and route coverage, but several local formatting and state branches were still only lightly exercised. Those branches decide how decommission terminal states, byte sizes, durations, and rebalance statuses are presented to users.

## Root cause

The initial coverage focused on command discovery and the primary S3 admin API routes. It did not cover the non-by-id pool status command-line query variant, failed and canceled decommission states, larger byte units, or the rebalance status styling branches.

## Solution

This adds focused tests for the uncovered admin paths without changing runtime behavior. The S3 admin test now asserts the command-line pool query path omits by-id and encodes the pool value correctly. The CLI tests now cover decommission terminal states, GiB and TiB byte formatting, duration boundaries, and rebalance status variants with color disabled for stable assertions.

## Validation

- cargo test -p rc-s3 test_pool_status_uses_command_line_query_without_by_id --lib
- cargo test -p rustfs-cli admin::pool::tests --lib
- cargo test -p rustfs-cli admin::rebalance::tests --lib
- make pre-commit
