### PR TITLE
test(s3): cover decommission start by-id query

### DIFF
--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -1347,6 +1347,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_decommission_start_posts_by_id_multi_pool_query() {
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let client = admin_client_for_endpoint(&endpoint);
+
+        client
+            .decommission_start(PoolTarget {
+                pool: "1,2".to_string(),
+                by_id: true,
+            })
+            .await
+            .expect("decommission start request");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/pools/decommission?pool=1%2C2&by-id=true"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
     async fn test_decommission_cancel_posts_pool_cancel_route_with_by_id_query() {
         let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
         let client = admin_client_for_endpoint(&endpoint);


### PR DESCRIPTION
## Related
- Follow-up test-gap coverage for recent admin pool/decommission routing changes.

## Background
Recent admin command work added decommission start support for pool command lines and `--by-id` pool identifiers. Existing route tests covered decommission start with a pool command line and decommission cancel with `--by-id`, but the start path did not directly assert the multi-pool `--by-id` query contract.

## Solution
Add a focused `rc-s3` admin client test that calls `decommission_start` with `PoolTarget { pool: "1,2", by_id: true }` and verifies the signed request uses `/rustfs/admin/v3/pools/decommission?pool=1%2C2&by-id=true` with an empty body.

## Tests
- `cargo test -p rc-s3 test_decommission_start_posts_by_id_multi_pool_query --lib`
- `cargo test -p rustfs-cli admin::tests --lib`
- `cargo test -p rc-s3 admin::tests --lib`
- `make pre-commit`
