### PR TITLE
test(alias): cover RC_HOST alias resolution

### DIFF
--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -1,5 +1,6 @@
 #![cfg(not(windows))]
 
+use std::net::TcpListener;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -21,6 +22,13 @@ fn rc_binary() -> PathBuf {
     }
 
     workspace_root.join("target/release/rc")
+}
+
+fn unused_local_endpoint() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind local endpoint");
+    let address = listener.local_addr().expect("local endpoint address");
+    drop(listener);
+    format!("http://{address}")
 }
 
 #[test]
@@ -52,4 +60,37 @@ fn alias_list_includes_rc_host_alias_without_credentials() {
         payload["aliases"][0]["endpoint"],
         "https://rustfs.local:9000"
     );
+}
+
+#[test]
+fn ls_resolves_rc_host_alias_from_environment() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let endpoint = unused_local_endpoint();
+    let (_, endpoint_authority) = endpoint.split_once("://").expect("endpoint has scheme");
+    let env_alias = format!("http://ACCESS_KEY:SECRET_KEY@{endpoint_authority}");
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "ls", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", env_alias)
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(
+        output.status.code(),
+        Some(3),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("Failed to list buckets"),
+        "payload: {payload}"
+    );
+    assert_eq!(payload["details"]["type"], "network_error");
 }


### PR DESCRIPTION
## Related

Follow-up test-gap coverage for recent `RC_HOST_<ALIAS>` environment alias support.

## Background

PR #176 added temporary aliases through environment variables so users can run commands such as `rc ls myalias` without storing credentials in the config file. Existing coverage verified that `alias list --json` includes an environment alias and redacts credentials, but it did not exercise the primary command-resolution path that loads an alias through `AliasManager::get`.

## Solution

Add a focused CLI integration test for `rc --json ls myalias` with `RC_HOST_myalias` pointing at an unused local endpoint. The expected network-class failure proves the command resolved the environment alias and attempted to use its endpoint instead of returning `Alias 'myalias' not found`.

## Validation

- `cargo test -p rustfs-cli --test env_alias`
- `make pre-commit`
