### PR TITLE
feat(admin): add expansion workflow command

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,9 @@ rc admin heal stop local
 # Pool expansion and decommission workflows
 rc admin pool list local
 rc admin pool status local 1 --by-id
+rc admin expand start local
+rc admin expand status local
+rc admin expand stop local
 rc admin decommission start local '/data/pool1/disk{1...4}'
 rc admin decommission status local '/data/pool1/disk{1...4}'
 rc admin decommission cancel local 1 --by-id
@@ -304,6 +307,7 @@ rc admin rebalance status local --json
 | `admin info`            | Display cluster information (cluster, server, disk)                                   |
 | `admin heal`            | Manage cluster healing operations (status, start, stop)                               |
 | `admin pool`            | List pools and inspect expansion/decommission status                                  |
+| `admin expand`          | Manage post-expansion data rebalancing (start, status, stop)                          |
 | `admin decommission`    | Manage server pool decommissioning (start, status, cancel)                            |
 | `admin rebalance`       | Manage post-expansion rebalancing (start, status, stop)                               |
 

--- a/crates/cli/src/commands/admin/expand.rs
+++ b/crates/cli/src/commands/admin/expand.rs
@@ -1,0 +1,56 @@
+//! Expansion workflow commands for post-expansion data rebalancing.
+
+use clap::Subcommand;
+
+use super::rebalance;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+const EXPAND_AFTER_HELP: &str = "\
+Examples:
+  rc admin expand start local
+  rc admin expand status local
+  rc admin expand stop local
+
+Notes:
+  Add server pools by updating the RustFS service configuration and restarting
+  the deployment first. This command manages the post-expansion rebalance step.";
+
+/// Expansion workflow subcommands
+#[derive(Subcommand, Debug)]
+#[command(after_help = EXPAND_AFTER_HELP)]
+pub enum ExpandCommands {
+    /// Start post-expansion data rebalancing
+    Start(rebalance::StartArgs),
+
+    /// Show post-expansion rebalance status
+    Status(rebalance::StatusArgs),
+
+    /// Stop a running post-expansion rebalance
+    Stop(rebalance::StopArgs),
+}
+
+/// Execute an expansion workflow subcommand
+pub async fn execute(cmd: ExpandCommands, formatter: &Formatter) -> ExitCode {
+    match cmd {
+        ExpandCommands::Start(args) => {
+            rebalance::execute_start_with_messages(
+                args,
+                formatter,
+                "Expansion rebalance started successfully",
+                "Failed to start expansion rebalance",
+            )
+            .await
+        }
+        ExpandCommands::Status(args) => rebalance::execute_status(args, formatter).await,
+        ExpandCommands::Stop(args) => {
+            rebalance::execute_stop_with_messages(
+                args,
+                formatter,
+                "Expansion rebalance stopped successfully",
+                "Failed to stop expansion rebalance",
+            )
+            .await
+        }
+    }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -4,6 +4,7 @@
 //! service accounts, and cluster operations on RustFS/MinIO-compatible servers.
 
 mod decommission;
+mod expand;
 mod group;
 mod heal;
 mod info;
@@ -34,6 +35,10 @@ pub enum AdminCommands {
     /// Manage server pools and expansion status
     #[command(subcommand)]
     Pool(pool::PoolCommands),
+
+    /// Manage post-expansion data rebalancing
+    #[command(alias = "scale", subcommand)]
+    Expand(expand::ExpandCommands),
 
     /// Manage server pool decommissioning
     #[command(alias = "decom", subcommand)]
@@ -68,6 +73,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
         AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,
+        AdminCommands::Expand(expand_cmd) => expand::execute(expand_cmd, &formatter).await,
         AdminCommands::Decommission(decommission_cmd) => {
             decommission::execute(decommission_cmd, &formatter).await
         }
@@ -212,6 +218,48 @@ mod tests {
                 assert_eq!(args.alias, "local");
                 assert!(args.pool.is_none());
                 assert!(!args.by_id);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_expand_commands() {
+        let cli = TestCli::parse_from(["rc", "expand", "start", "local"]);
+
+        match cli.command {
+            AdminCommands::Expand(expand::ExpandCommands::Start(args)) => {
+                assert_eq!(args.alias, "local");
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+
+        let cli = TestCli::parse_from(["rc", "expand", "status", "local"]);
+
+        match cli.command {
+            AdminCommands::Expand(expand::ExpandCommands::Status(args)) => {
+                assert_eq!(args.alias, "local");
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+
+        let cli = TestCli::parse_from(["rc", "expand", "stop", "local"]);
+
+        match cli.command {
+            AdminCommands::Expand(expand::ExpandCommands::Stop(args)) => {
+                assert_eq!(args.alias, "local");
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_expand_alias() {
+        let cli = TestCli::parse_from(["rc", "scale", "status", "local"]);
+
+        match cli.command {
+            AdminCommands::Expand(expand::ExpandCommands::Status(args)) => {
+                assert_eq!(args.alias, "local");
             }
             _ => panic!("Unexpected command parsing result"),
         }

--- a/crates/cli/src/commands/admin/rebalance.rs
+++ b/crates/cli/src/commands/admin/rebalance.rs
@@ -59,6 +59,21 @@ pub async fn execute(cmd: RebalanceCommands, formatter: &Formatter) -> ExitCode 
 }
 
 async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
+    execute_start_with_messages(
+        args,
+        formatter,
+        "Rebalance started successfully",
+        "Failed to start rebalance",
+    )
+    .await
+}
+
+pub(super) async fn execute_start_with_messages(
+    args: StartArgs,
+    formatter: &Formatter,
+    success_message: &str,
+    failure_prefix: &str,
+) -> ExitCode {
     let client = match get_admin_client(&args.alias, formatter) {
         Ok(c) => c,
         Err(code) => return code,
@@ -69,12 +84,12 @@ async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
             if formatter.is_json() {
                 formatter.json(&RebalanceOperationOutput {
                     success: true,
-                    message: "Rebalance started successfully".to_string(),
+                    message: success_message.to_string(),
                     target: args.alias,
                     id: Some(result.id),
                 });
             } else {
-                formatter.success("Rebalance started successfully.");
+                formatter.success(&format!("{success_message}."));
                 if !result.id.is_empty() {
                     formatter.println(&format!("  ID: {}", result.id));
                 }
@@ -82,13 +97,13 @@ async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
             ExitCode::Success
         }
         Err(e) => {
-            formatter.error(&format!("Failed to start rebalance: {e}"));
+            formatter.error(&format!("{failure_prefix}: {e}"));
             ExitCode::GeneralError
         }
     }
 }
 
-async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
+pub(super) async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
     let client = match get_admin_client(&args.alias, formatter) {
         Ok(c) => c,
         Err(code) => return code,
@@ -111,6 +126,21 @@ async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
 }
 
 async fn execute_stop(args: StopArgs, formatter: &Formatter) -> ExitCode {
+    execute_stop_with_messages(
+        args,
+        formatter,
+        "Rebalance stopped successfully",
+        "Failed to stop rebalance",
+    )
+    .await
+}
+
+pub(super) async fn execute_stop_with_messages(
+    args: StopArgs,
+    formatter: &Formatter,
+    success_message: &str,
+    failure_prefix: &str,
+) -> ExitCode {
     let client = match get_admin_client(&args.alias, formatter) {
         Ok(c) => c,
         Err(code) => return code,
@@ -121,17 +151,17 @@ async fn execute_stop(args: StopArgs, formatter: &Formatter) -> ExitCode {
             if formatter.is_json() {
                 formatter.json(&RebalanceOperationOutput {
                     success: true,
-                    message: "Rebalance stopped successfully".to_string(),
+                    message: success_message.to_string(),
                     target: args.alias,
                     id: None,
                 });
             } else {
-                formatter.success("Rebalance stopped successfully.");
+                formatter.success(&format!("{success_message}."));
             }
             ExitCode::Success
         }
         Err(e) => {
-            formatter.error(&format!("Failed to stop rebalance: {e}"));
+            formatter.error(&format!("{failure_prefix}: {e}"));
             ExitCode::GeneralError
         }
     }

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -158,6 +158,7 @@ fn top_level_command_help_contract() {
                 "info",
                 "heal",
                 "pool",
+                "expand",
                 "decommission",
                 "rebalance",
                 "user",
@@ -456,6 +457,32 @@ fn nested_subcommand_help_contract() {
             args: &["admin", "pool", "status"],
             usage: "Usage: rc admin pool status [OPTIONS] <ALIAS> [POOL]",
             expected_tokens: &["--by-id"],
+        },
+        HelpCase {
+            args: &["admin", "expand"],
+            usage: "Usage: rc admin expand [OPTIONS] <COMMAND>",
+            expected_tokens: &[
+                "start",
+                "status",
+                "stop",
+                "Examples:",
+                "rc admin expand start local",
+            ],
+        },
+        HelpCase {
+            args: &["admin", "expand", "start"],
+            usage: "Usage: rc admin expand start [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "expand", "status"],
+            usage: "Usage: rc admin expand status [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "expand", "stop"],
+            usage: "Usage: rc admin expand stop [OPTIONS] <ALIAS>",
+            expected_tokens: &[],
         },
         HelpCase {
             args: &["admin", "decommission", "start"],

--- a/schemas/output_v2.json
+++ b/schemas/output_v2.json
@@ -755,6 +755,36 @@
       }
     },
     {
+      "title": "admin expand status",
+      "description": "Post-expansion rebalance status output",
+      "$ref": "#/definitions/rebalanceStatus"
+    },
+    {
+      "title": "admin expand operation",
+      "description": "Post-expansion rebalance start/stop output",
+      "type": "object",
+      "required": [
+        "success",
+        "message",
+        "target"
+      ],
+      "properties": {
+        "success": {
+          "type": "boolean"
+        },
+        "message": {
+          "type": "string"
+        },
+        "target": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string",
+          "description": "Rebalance operation ID returned by start"
+        }
+      }
+    },
+    {
       "title": "error",
       "description": "Error response",
       "$ref": "#/definitions/errorResponse"


### PR DESCRIPTION
## Related Issue(s)

None.

## Problem Background and User Impact

RustFS expansion requires operators to add server pools in the deployment configuration first, then run a post-expansion rebalance. The CLI exposed pool inspection and rebalance commands separately, but did not provide an expansion-oriented command path.

## Root Cause Summary

The existing admin command set had the backend rebalance API integration, but no dedicated command that matches the expansion workflow language users expect.

## Solution Overview

- Add `rc admin expand start|status|stop` for post-expansion rebalancing.
- Add `scale` as a convenience alias for the same command group.
- Reuse the existing rebalance Admin API implementation instead of inventing unsupported online pool-add behavior.
- Update help contract coverage, README examples, and the v2 output schema entries.

## Test Status

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
