### PR TITLE
fix(alias): validate endpoint URLs before saving

### DIFF
--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -135,7 +135,7 @@ async fn execute_set(args: SetArgs, manager: &AliasManager, formatter: &Formatte
     }
 
     if let Err(e) = validate_alias_endpoint(&args.endpoint) {
-        formatter.error(&e.to_string());
+        formatter.error(&alias_endpoint_error_message(e));
         return ExitCode::UsageError;
     }
 
@@ -255,6 +255,13 @@ async fn execute_remove(
     }
 }
 
+fn alias_endpoint_error_message(error: rc_core::Error) -> String {
+    match error {
+        rc_core::Error::Config(message) => message,
+        other => format!("Invalid endpoint: {other}"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -311,5 +318,14 @@ mod tests {
 
         assert_eq!(exit_code, ExitCode::UsageError);
         assert!(manager.get("rustfs").is_err());
+    }
+
+    #[test]
+    fn test_alias_endpoint_error_message_omits_config_prefix() {
+        let message = alias_endpoint_error_message(rc_core::Error::Config(
+            "Endpoint must include a host".to_string(),
+        ));
+
+        assert_eq!(message, "Endpoint must include a host");
     }
 }

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::exit_code::ExitCode;
 use crate::output::{Formatter, OutputConfig};
-use rc_core::{Alias, AliasManager};
+use rc_core::{Alias, AliasManager, validate_alias_endpoint};
 
 /// Alias subcommands for managing storage service connections
 #[derive(Subcommand, Debug)]
@@ -131,6 +131,11 @@ async fn execute_set(args: SetArgs, manager: &AliasManager, formatter: &Formatte
 
     if args.endpoint.is_empty() {
         formatter.error("Endpoint URL cannot be empty");
+        return ExitCode::UsageError;
+    }
+
+    if let Err(e) = validate_alias_endpoint(&args.endpoint) {
+        formatter.error(&e.to_string());
         return ExitCode::UsageError;
     }
 
@@ -282,5 +287,29 @@ mod tests {
         assert_eq!(info.name, "test");
         assert_eq!(info.endpoint, "http://localhost:9000");
         assert_eq!(info.region, "us-east-1");
+    }
+
+    #[tokio::test]
+    async fn test_execute_set_rejects_invalid_endpoint_url() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let manager = AliasManager::with_config_manager(rc_core::ConfigManager::with_path(
+            temp_dir.path().join("config.toml"),
+        ));
+        let formatter = Formatter::new(OutputConfig::default());
+        let args = SetArgs {
+            name: "rustfs".to_string(),
+            endpoint: "http://rustfs-node{1...32}:9000".to_string(),
+            access_key: "accesskey".to_string(),
+            secret_key: "secretkey".to_string(),
+            region: "us-east-1".to_string(),
+            signature: "v4".to_string(),
+            bucket_lookup: "auto".to_string(),
+            insecure: false,
+        };
+
+        let exit_code = execute_set(args, &manager, &formatter).await;
+
+        assert_eq!(exit_code, ExitCode::UsageError);
+        assert!(manager.get("rustfs").is_err());
     }
 }

--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -135,6 +135,12 @@ pub fn validate_alias_endpoint(value: &str) -> Result<()> {
     let url = Url::parse(value)
         .map_err(|e| Error::Config(format!("Endpoint must be a valid URL: {e}")))?;
 
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(Error::Config(
+            "Endpoint must not include credentials; pass access key and secret key as separate arguments".into(),
+        ));
+    }
+
     validate_http_endpoint_url(&url, "Endpoint")
 }
 
@@ -534,6 +540,19 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("Endpoint must use an http or https URL")
+        );
+    }
+
+    #[test]
+    fn test_validate_alias_endpoint_rejects_embedded_credentials() {
+        let result = validate_alias_endpoint("http://access:secret@localhost:9000");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Endpoint must not include credentials")
         );
     }
 

--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -124,6 +124,20 @@ pub struct Alias {
     pub timeout: Option<TimeoutConfig>,
 }
 
+/// Validate that an alias endpoint is a usable HTTP(S) URL.
+pub fn validate_alias_endpoint(value: &str) -> Result<()> {
+    if value.contains('{') || value.contains('}') {
+        return Err(Error::Config(
+            "Endpoint must be a single S3 service URL; RustFS volume expansion patterns are not supported".into(),
+        ));
+    }
+
+    let url = Url::parse(value)
+        .map_err(|e| Error::Config(format!("Endpoint must be a valid URL: {e}")))?;
+
+    validate_http_endpoint_url(&url, "Endpoint")
+}
+
 fn default_region() -> String {
     "us-east-1".to_string()
 }
@@ -237,15 +251,7 @@ fn parse_env_alias(name: &str, value: &str) -> Result<Alias> {
     let mut url = Url::parse(value)
         .map_err(|e| Error::Config(format!("{var_name} must be a valid URL: {e}")))?;
 
-    if !matches!(url.scheme(), "http" | "https") {
-        return Err(Error::Config(format!(
-            "{var_name} must use an http or https URL"
-        )));
-    }
-
-    if url.host_str().is_none() {
-        return Err(Error::Config(format!("{var_name} must include a host")));
-    }
+    validate_http_endpoint_url(&url, &var_name)?;
 
     let access_key = url.username();
     let Some(secret_key) = url.password() else {
@@ -272,6 +278,20 @@ fn parse_env_alias(name: &str, value: &str) -> Result<Alias> {
 
     let endpoint = url.as_str().trim_end_matches('/').to_string();
     Ok(Alias::new(name, endpoint, access_key, secret_key))
+}
+
+fn validate_http_endpoint_url(url: &Url, label: &str) -> Result<()> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(Error::Config(format!(
+            "{label} must use an http or https URL"
+        )));
+    }
+
+    if url.host_str().is_none() {
+        return Err(Error::Config(format!("{label} must include a host")));
+    }
+
+    Ok(())
 }
 
 fn decode_env_alias_credential(value: &str, var_name: &str, field: &str) -> Result<String> {
@@ -476,6 +496,51 @@ mod tests {
         assert_eq!(alias.secret_key, "SECRET_KEY");
         assert_eq!(alias.region, "us-east-1");
         assert_eq!(alias.bucket_lookup, "auto");
+    }
+
+    #[test]
+    fn test_validate_alias_endpoint_rejects_volume_expansion_endpoint() {
+        let result = validate_alias_endpoint("http://rustfs-node{1...32}:9000");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("RustFS volume expansion patterns are not supported")
+        );
+    }
+
+    #[test]
+    fn test_validate_alias_endpoint_rejects_missing_scheme() {
+        let result = validate_alias_endpoint("localhost:9000");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Endpoint must use an http or https URL")
+        );
+    }
+
+    #[test]
+    fn test_validate_alias_endpoint_rejects_non_http_scheme() {
+        let result = validate_alias_endpoint("ftp://localhost:9000");
+
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Endpoint must use an http or https URL")
+        );
+    }
+
+    #[test]
+    fn test_validate_alias_endpoint_accepts_http_url_with_host() {
+        validate_alias_endpoint("http://localhost:9000").unwrap();
+        validate_alias_endpoint("https://s3.amazonaws.com").unwrap();
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,7 +21,7 @@ pub mod retry;
 pub mod select;
 pub mod traits;
 
-pub use alias::{Alias, AliasManager};
+pub use alias::{Alias, AliasManager, validate_alias_endpoint};
 pub use config::{Config, ConfigManager};
 pub use cors::{CorsConfiguration, CorsRule};
 pub use error::{Error, Result};


### PR DESCRIPTION
## Related Issue

Closes #181

## Background

Issue #181 reports configuring an alias with `http://rustfs-node{1...32}:9000`, then seeing `rc ls rustfs` fail with `Network error: dispatch failure`.

That endpoint is RustFS server volume expansion syntax, not a single S3 service endpoint. `rc alias set` only rejected empty endpoints, so the invalid endpoint could be saved and fail later during the S3 request.

## Solution

- Add shared alias endpoint validation in `rc-core`.
- Require HTTP(S) URLs with a host.
- Reject RustFS volume expansion patterns before saving aliases.
- Return a usage error from `rc alias set` when the endpoint is invalid.

## Tests

- `cargo test -p rc-core validate_alias_endpoint --lib`
- `cargo test -p rustfs-cli commands::alias::tests --lib`
- `RC_CONFIG_DIR=<tmp> cargo run -q -p rustfs-cli -- alias set rustfs 'http://rustfs-node{1...32}:9000' xxx xxx` returns exit code 2
- `make pre-commit`
