### PR TITLE
fix(alias): reject malformed RC_HOST credentials

### DIFF
--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -180,8 +180,9 @@ async fn execute_set(args: SetArgs, manager: &AliasManager, formatter: &Formatte
             ExitCode::Success
         }
         Err(e) => {
-            formatter.error(&e.to_string());
-            ExitCode::GeneralError
+            let code = exit_code_from_error(&e);
+            formatter.error_with_code(code, &e.to_string());
+            code
         }
     }
 }
@@ -218,8 +219,9 @@ async fn execute_list(args: ListArgs, manager: &AliasManager, formatter: &Format
             ExitCode::Success
         }
         Err(e) => {
-            formatter.error(&e.to_string());
-            ExitCode::GeneralError
+            let code = exit_code_from_error(&e);
+            formatter.error_with_code(code, &e.to_string());
+            code
         }
     }
 }
@@ -249,8 +251,9 @@ async fn execute_remove(
             ExitCode::NotFound
         }
         Err(e) => {
-            formatter.error(&e.to_string());
-            ExitCode::GeneralError
+            let code = exit_code_from_error(&e);
+            formatter.error_with_code(code, &e.to_string());
+            code
         }
     }
 }
@@ -260,6 +263,10 @@ fn alias_endpoint_error_message(error: rc_core::Error) -> String {
         rc_core::Error::Config(message) => message,
         other => format!("Invalid endpoint: {other}"),
     }
+}
+
+fn exit_code_from_error(error: &rc_core::Error) -> ExitCode {
+    ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -133,6 +133,8 @@ fn infer_error_metadata(message: &str) -> (&'static str, bool, Option<String>) {
     if normalized.contains("invalid")
         || normalized.contains("cannot be empty")
         || normalized.contains("must be")
+        || normalized.contains("must use")
+        || normalized.contains("must include")
         || normalized.contains("must specify")
         || normalized.contains("expected:")
         || normalized.contains("use -r/--recursive")

--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -94,3 +94,77 @@ fn ls_resolves_rc_host_alias_from_environment() {
     );
     assert_eq!(payload["details"]["type"], "network_error");
 }
+
+#[test]
+fn alias_list_rejects_invalid_rc_host_percent_encoding_without_credentials() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = Command::new(rc_binary())
+        .args(["alias", "list", "--json"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_badalias",
+            "https://ACCESS_KEY:SECRET%ZZ@rustfs.local:9000",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stderr.contains("ACCESS_KEY"));
+    assert!(!stderr.contains("SECRET"));
+
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("invalid percent-encoding in secret key"),
+        "payload: {payload}"
+    );
+    assert_eq!(payload["details"]["type"], "usage_error");
+}
+
+#[test]
+fn alias_list_rejects_invalid_rc_host_scheme_without_credentials() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = Command::new(rc_binary())
+        .args(["alias", "list", "--json"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_badalias",
+            "ftp://ACCESS_KEY:SECRET_KEY@rustfs.local:9000",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stderr.contains("ACCESS_KEY"));
+    assert!(!stderr.contains("SECRET_KEY"));
+
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("must use an http or https URL"),
+        "payload: {payload}"
+    );
+    assert_eq!(payload["details"]["type"], "usage_error");
+}

--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -111,7 +111,7 @@ fn alias_list_rejects_invalid_rc_host_percent_encoding_without_credentials() {
 
     assert_eq!(
         output.status.code(),
-        Some(1),
+        Some(2),
         "stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
@@ -129,6 +129,7 @@ fn alias_list_rejects_invalid_rc_host_percent_encoding_without_credentials() {
             .contains("invalid percent-encoding in secret key"),
         "payload: {payload}"
     );
+    assert_eq!(payload["code"], 2);
     assert_eq!(payload["details"]["type"], "usage_error");
 }
 
@@ -148,7 +149,7 @@ fn alias_list_rejects_invalid_rc_host_scheme_without_credentials() {
 
     assert_eq!(
         output.status.code(),
-        Some(1),
+        Some(2),
         "stdout: {}\nstderr: {}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
@@ -166,5 +167,6 @@ fn alias_list_rejects_invalid_rc_host_scheme_without_credentials() {
             .contains("must use an http or https URL"),
         "payload: {payload}"
     );
+    assert_eq!(payload["code"], 2);
     assert_eq!(payload["details"]["type"], "usage_error");
 }

--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -301,6 +301,12 @@ fn validate_http_endpoint_url(url: &Url, label: &str) -> Result<()> {
 }
 
 fn decode_env_alias_credential(value: &str, var_name: &str, field: &str) -> Result<String> {
+    if has_invalid_percent_encoding(value) {
+        return Err(Error::Config(format!(
+            "{var_name} contains invalid percent-encoding in {field}"
+        )));
+    }
+
     urlencoding::decode(value)
         .map(|decoded| decoded.into_owned())
         .map_err(|e| {
@@ -308,6 +314,29 @@ fn decode_env_alias_credential(value: &str, var_name: &str, field: &str) -> Resu
                 "{var_name} contains invalid percent-encoding in {field}: {e}"
             ))
         })
+}
+
+fn has_invalid_percent_encoding(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] != b'%' {
+            index += 1;
+            continue;
+        }
+
+        if index + 2 >= bytes.len()
+            || !bytes[index + 1].is_ascii_hexdigit()
+            || !bytes[index + 2].is_ascii_hexdigit()
+        {
+            return true;
+        }
+
+        index += 3;
+    }
+
+    false
 }
 
 fn merge_env_aliases(mut aliases: Vec<Alias>, env_aliases: Vec<Alias>) -> Vec<Alias> {
@@ -577,6 +606,16 @@ mod tests {
 
         assert!(result.is_err());
         assert!(matches!(result.unwrap_err(), Error::Config(_)));
+    }
+
+    #[test]
+    fn test_parse_rc_host_alias_rejects_invalid_percent_encoding() {
+        let result = parse_env_alias("invalid", "https://ACCESS_KEY:SECRET%ZZ@rustfs.local");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("invalid percent-encoding in secret key"));
+        assert!(!error.contains("SECRET"));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issue(s)

None.

## Problem Background and User Impact

Recent RC_HOST_* environment alias support lets users configure aliases without writing credentials to disk. The happy path was covered, but malformed environment alias values could still regress without a user-facing test. In particular, invalid percent escapes inside credentials were accepted as literal secret text, and some validation messages were classified as generic JSON errors instead of usage errors.

## Root Cause Summary

The credential decoder delegated directly to urlencoding::decode, which tolerates malformed percent triplets such as %ZZ. The JSON error metadata inference also did not treat messages using “must use” or “must include” as usage errors.

## Solution Overview

This PR adds strict percent-triplet validation before decoding RC_HOST credentials and keeps invalid credential values out of errors. It also broadens JSON error metadata inference for validation messages that say a value must use or include something. The CLI integration tests now cover malformed RC_HOST percent encoding and unsupported schemes while asserting credentials are not echoed.

## Test Status

- `cargo test -p rc-core test_parse_rc_host_alias_rejects_invalid_percent_encoding --lib`
- `cargo test -p rustfs-cli --test env_alias`
- `cargo fmt --all --check`
- `git diff --check`
- `make pre-commit`
