### PR TITLE
fix(alias): report endpoint validation as usage errors

### DIFF
--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -135,7 +135,7 @@ async fn execute_set(args: SetArgs, manager: &AliasManager, formatter: &Formatte
     }
 
     if let Err(e) = validate_alias_endpoint(&args.endpoint) {
-        formatter.error(&alias_endpoint_error_message(e));
+        formatter.error_with_code(ExitCode::UsageError, &alias_endpoint_error_message(e));
         return ExitCode::UsageError;
     }
 

--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -125,30 +125,28 @@ pub async fn execute(cmd: AliasCommands, output_config: OutputConfig) -> ExitCod
 async fn execute_set(args: SetArgs, manager: &AliasManager, formatter: &Formatter) -> ExitCode {
     // Validate inputs
     if args.name.is_empty() {
-        formatter.error("Alias name cannot be empty");
-        return ExitCode::UsageError;
+        return formatter.fail(ExitCode::UsageError, "Alias name cannot be empty");
     }
 
     if args.endpoint.is_empty() {
-        formatter.error("Endpoint URL cannot be empty");
-        return ExitCode::UsageError;
+        return formatter.fail(ExitCode::UsageError, "Endpoint URL cannot be empty");
     }
 
     if let Err(e) = validate_alias_endpoint(&args.endpoint) {
-        formatter.error_with_code(ExitCode::UsageError, &alias_endpoint_error_message(e));
-        return ExitCode::UsageError;
+        return formatter.fail(ExitCode::UsageError, &alias_endpoint_error_message(e));
     }
 
     // Validate signature version
     if args.signature != "v4" && args.signature != "v2" {
-        formatter.error("Signature must be 'v4' or 'v2'");
-        return ExitCode::UsageError;
+        return formatter.fail(ExitCode::UsageError, "Signature must be 'v4' or 'v2'");
     }
 
     // Validate bucket lookup
     if args.bucket_lookup != "auto" && args.bucket_lookup != "path" && args.bucket_lookup != "dns" {
-        formatter.error("Bucket lookup must be 'auto', 'path', or 'dns'");
-        return ExitCode::UsageError;
+        return formatter.fail(
+            ExitCode::UsageError,
+            "Bucket lookup must be 'auto', 'path', or 'dns'",
+        );
     }
 
     // Create alias

--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -3,7 +3,7 @@
 //! These tests cover local validation paths that do not require a running S3
 //! backend but still need stable JSON error metadata.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 fn rc_binary() -> PathBuf {
@@ -29,6 +29,14 @@ fn rc_binary() -> PathBuf {
 fn run_rc(args: &[&str]) -> Output {
     Command::new(rc_binary())
         .args(args)
+        .output()
+        .expect("failed to execute rc")
+}
+
+fn run_rc_with_config(args: &[&str], config_dir: &Path) -> Output {
+    Command::new(rc_binary())
+        .args(args)
+        .env("RC_CONFIG_DIR", config_dir)
         .output()
         .expect("failed to execute rc")
 }
@@ -71,5 +79,61 @@ fn cp_local_to_local_json_error_reports_usage_metadata() {
     assert_eq!(
         json["details"]["suggestion"],
         "Use your local shell cp command when both paths are on the filesystem."
+    );
+}
+
+#[test]
+fn alias_set_json_error_rejects_embedded_endpoint_credentials() {
+    let config_dir = tempfile::tempdir().expect("create temp config dir");
+
+    let output = run_rc_with_config(
+        &[
+            "alias",
+            "set",
+            "bad",
+            "http://ACCESS_KEY:SECRET_KEY@localhost:9000",
+            "accesskey",
+            "secretkey",
+            "--json",
+        ],
+        config_dir.path(),
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stderr.contains("SECRET_KEY"));
+
+    let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
+    assert_eq!(
+        json["error"],
+        "Endpoint must not include credentials; pass access key and secret key as separate arguments"
+    );
+    assert_eq!(json["code"], 2);
+    assert_eq!(json["details"]["type"], "usage_error");
+    assert_eq!(json["details"]["retryable"], false);
+
+    let list_output = run_rc_with_config(&["alias", "list", "--json"], config_dir.path());
+    assert!(
+        list_output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&list_output.stderr)
+    );
+
+    let stdout = String::from_utf8(list_output.stdout).expect("stdout should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is valid JSON");
+    assert_eq!(
+        payload["aliases"].as_array().expect("aliases array").len(),
+        0
     );
 }

--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -26,15 +26,27 @@ fn rc_binary() -> PathBuf {
     workspace_root.join("target/release/rc")
 }
 
+fn rc_command() -> Command {
+    let mut command = Command::new(rc_binary());
+
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+
+    command
+}
+
 fn run_rc(args: &[&str]) -> Output {
-    Command::new(rc_binary())
+    rc_command()
         .args(args)
         .output()
         .expect("failed to execute rc")
 }
 
 fn run_rc_with_config(args: &[&str], config_dir: &Path) -> Output {
-    Command::new(rc_binary())
+    rc_command()
         .args(args)
         .env("RC_CONFIG_DIR", config_dir)
         .output()


### PR DESCRIPTION
## Related Issue

No linked issue. This follows recent alias endpoint validation work and adds a focused regression for a missed JSON error contract path.

## Background

`alias set` now rejects endpoint URLs that embed credentials, but JSON-mode validation errors should still be reported as usage errors with the same exit code metadata as the process exit status. Without an explicit usage code on this path, the JSON error payload can lose the `code: 2` field and be inferred from the word "credentials" instead of from the command's actual usage error result.

## Solution

Emit endpoint validation failures through `error_with_code(ExitCode::UsageError, ...)` so JSON error metadata matches the command's returned exit code. Add an integration regression that runs `alias set --json` with credentials embedded in the endpoint and verifies the alias is rejected without persisting or echoing the secret.

## Validation

- `cargo test -p rustfs-cli --test error_contract alias_set_json_error_rejects_embedded_endpoint_credentials -- --nocapture`
- `cargo test -p rustfs-cli --test error_contract`
- `make pre-commit`
