### PR TITLE
test(admin): cover rebalance start and stop dispatch

### DIFF
--- a/crates/cli/tests/admin_rebalance.rs
+++ b/crates/cli/tests/admin_rebalance.rs
@@ -104,6 +104,40 @@ fn rc_host_alias(endpoint: &str) -> String {
 }
 
 #[test]
+fn rebalance_start_dispatches_to_rebalance_start_json() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(r#"{"id":"rebalance-123"}"#);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "rebalance", "start", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
+    assert_eq!(payload["success"], true);
+    assert_eq!(payload["message"], "Rebalance started successfully");
+    assert_eq!(payload["target"], "myalias");
+    assert_eq!(payload["id"], "rebalance-123");
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(request.target, "/rustfs/admin/v3/rebalance/start");
+
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
 fn rebalance_status_dispatches_to_rebalance_status_json() {
     let config_dir = tempfile::tempdir().expect("create config dir");
     let (endpoint, receiver, handle) = start_admin_test_server(
@@ -134,6 +168,40 @@ fn rebalance_status_dispatches_to_rebalance_status_json() {
         .expect("captured admin request");
     assert_eq!(request.method, "GET");
     assert_eq!(request.target, "/rustfs/admin/v3/rebalance/status");
+
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn rebalance_stop_dispatches_to_rebalance_stop_json() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server("");
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "rebalance", "stop", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
+    assert_eq!(payload["success"], true);
+    assert_eq!(payload["message"], "Rebalance stopped successfully");
+    assert_eq!(payload["target"], "myalias");
+    assert!(payload.get("id").is_none());
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(request.target, "/rustfs/admin/v3/rebalance/stop");
 
     handle.join().expect("admin test server finished");
 }


### PR DESCRIPTION
## Related Issue

No linked issue. This is a focused test-gap follow-up for the recent admin rebalance command work.

## Background

Recent changes added admin rebalance command support and then covered the direct status dispatch path. The start and stop CLI paths were still only covered indirectly through the expansion wrapper, leaving the user-facing `rc admin rebalance start` and `rc admin rebalance stop` JSON contracts without direct integration coverage.

## Solution

Add direct integration tests for `rc admin rebalance start` and `rc admin rebalance stop` using the existing loopback admin test server pattern. The tests assert the JSON messages, target alias, returned rebalance id behavior, HTTP method, and RustFS admin route.

## Tests

- `cargo test -p rustfs-cli --test admin_rebalance`
- `make pre-commit`
