### PR TITLE
fix(rm): preserve recursive purge semantics

### DIFF
--- a/crates/cli/src/commands/rm.rs
+++ b/crates/cli/src/commands/rm.rs
@@ -307,6 +307,28 @@ async fn delete_recursive(
             .collect());
     }
 
+    if args.purge {
+        let mut deleted = Vec::new();
+        let mut failed = Vec::new();
+        let mut first_error_code = None;
+
+        for key in keys_to_delete {
+            match delete_single(client, alias_name, bucket, &key, args, formatter).await {
+                Ok(paths) => deleted.extend(paths),
+                Err((code, paths)) => {
+                    first_error_code.get_or_insert(code);
+                    failed.extend(paths);
+                }
+            }
+        }
+
+        return if failed.is_empty() {
+            Ok(deleted)
+        } else {
+            Err((first_error_code.unwrap_or(ExitCode::GeneralError), failed))
+        };
+    }
+
     // Delete in batches (S3 allows up to 1000 per request)
     let mut deleted = Vec::new();
     let mut failed = Vec::new();

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -439,7 +439,7 @@ mod bucket_operations {
         assert_eq!(rules.len(), 1, "Expected one CORS rule from stdin input");
         assert_eq!(rules[0]["id"].as_str(), Some("stdin-rule"));
         assert_eq!(
-            rules[0]["allowed_methods"].as_array().map(|methods| methods
+            rules[0]["allowedMethods"].as_array().map(|methods| methods
                 .iter()
                 .filter_map(|method| method.as_str())
                 .collect::<Vec<_>>()),


### PR DESCRIPTION
## Summary
- Route recursive `rm --purge` through single-object delete requests so RustFS applies force-delete semantics to each object.
- Align the CORS stdin integration assertion with the existing camelCase JSON output contract.

## Evidence
- The scheduled Full Integration run on main failed in `bucket_operations::test_bucket_cors_set_accepts_stdin_source` and `version_operations::test_rm_recursive_purge_permanently_deletes_versioned_prefix`.
- Both failures reproduced locally against `rustfs/rustfs:latest` using an isolated RustFS container.
- Recursive purge reported deleted keys, but `version list` still showed delete markers and original versions because the batch delete path did not purge versions on latest RustFS.

## Safety
- Non-purge recursive deletion still uses the existing batch delete path.
- The purge path reuses the existing single-object delete behavior already validated by the single-object purge integration test.
- The CORS change only updates the test assertion to match the existing public JSON shape.

## Validation
- `cargo test --package rustfs-cli --test integration --features integration bucket_operations::test_bucket_cors_set_accepts_stdin_source -- --exact --test-threads=1`
- `cargo test --package rustfs-cli --test integration --features integration version_operations::test_rm_recursive_purge_permanently_deletes_versioned_prefix -- --exact --test-threads=1`
- `cargo test --package rustfs-cli --test integration --features integration -- --test-threads=1`
- `make pre-commit`