### PR TITLE
test(alias): cover RC_HOST access-key percent errors

### DIFF
--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -134,6 +134,44 @@ fn alias_list_rejects_invalid_rc_host_percent_encoding_without_credentials() {
 }
 
 #[test]
+fn alias_list_rejects_invalid_rc_host_access_key_percent_encoding_without_credentials() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = Command::new(rc_binary())
+        .args(["alias", "list", "--json"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_badalias",
+            "https://ACCESS%ZZKEY:SECRET_KEY@rustfs.local:9000",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stderr.contains("ACCESS"));
+    assert!(!stderr.contains("SECRET_KEY"));
+
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("invalid percent-encoding in access key"),
+        "payload: {payload}"
+    );
+    assert_eq!(payload["code"], 2);
+    assert_eq!(payload["details"]["type"], "usage_error");
+}
+
+#[test]
 fn alias_list_rejects_invalid_rc_host_scheme_without_credentials() {
     let config_dir = tempfile::tempdir().expect("create config dir");
 

--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -619,6 +619,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_rc_host_alias_rejects_invalid_access_key_percent_encoding() {
+        let result = parse_env_alias("invalid", "https://ACCESS%ZZKEY:SECRET_KEY@rustfs.local");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("invalid percent-encoding in access key"));
+        assert!(!error.contains("ACCESS"));
+        assert!(!error.contains("SECRET_KEY"));
+    }
+
+    #[test]
     fn test_env_aliases_from_vars_filters_rc_host_prefix() {
         let aliases = env_aliases_from_vars(vec![
             (


### PR DESCRIPTION
## Related Issue

No direct issue. This follows up on recent RC_HOST credential parsing fixes.

## Background

Recent changes reject malformed percent-encoding in RC_HOST credentials and ensure JSON errors do not expose credentials. Existing tests covered the malformed secret-key path, but the access-key branch used the same decoder without direct coverage.

## Solution

Added a core parser regression test for malformed access-key percent-encoding. Added a CLI JSON-contract test that verifies alias list returns usage exit code 2, reports the access-key error, and redacts both access and secret values from stderr.

## Test Status

- cargo test -p rc-core test_parse_rc_host_alias_rejects_invalid_access_key_percent_encoding
- cargo test -p rustfs-cli --test env_alias alias_list_rejects_invalid_rc_host_access_key_percent_encoding_without_credentials
- make pre-commit
