### PR TITLE
test(alias): cover missing RC_HOST credentials

### DIFF
--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -226,6 +226,44 @@ fn alias_list_rejects_empty_rc_host_alias_name_as_usage_error() {
 }
 
 #[test]
+fn alias_list_rejects_rc_host_missing_secret_key_as_usage_error() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = rc_command()
+        .args(["alias", "list", "--json"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_badalias", "https://ACCESS_KEY@rustfs.local:9000")
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stderr.contains("ACCESS_KEY"));
+
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("must include access key and secret key credentials"),
+        "payload: {payload}"
+    );
+    assert_eq!(payload["code"], 2);
+    assert_eq!(payload["details"]["type"], "usage_error");
+}
+
+#[test]
 fn alias_list_rejects_invalid_rc_host_scheme_without_credentials() {
     let config_dir = tempfile::tempdir().expect("create config dir");
 


### PR DESCRIPTION
## Related issue(s)

None.

## Background

Recent alias validation work changed malformed `RC_HOST_*` values to surface as usage errors with structured JSON metadata. Existing coverage exercises invalid percent encoding and invalid schemes, but the missing-secret-key credential shape was still only covered indirectly at the core parser level.

## Root cause

`RC_HOST_badalias=https://ACCESS_KEY@rustfs.local:9000` reaches the alias list command through the environment alias loader. Before the recent alias command error handling changes, this command path could report the parser failure through generic JSON error inference instead of the explicit usage-error exit code metadata.

## Solution

Add a focused subprocess regression in `crates/cli/tests/env_alias.rs` for a missing `RC_HOST_*` secret key. The test verifies that `rc alias list --json` exits with code 2, emits JSON on stderr, classifies the error as `usage_error`, and does not leak the provided access key.

## Validation

- `cargo test -p rustfs-cli --test env_alias alias_list_rejects_rc_host_missing_secret_key_as_usage_error`
- `make pre-commit`
