### PR TITLE
test(alias): cover non-UTF8 RC_HOST credential decoding

### DIFF
--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -619,6 +619,17 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_rc_host_alias_rejects_non_utf8_percent_encoded_secret_key() {
+        let result = parse_env_alias("invalid", "https://ACCESS_KEY:SECRET%FF@rustfs.local");
+
+        assert!(result.is_err());
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("invalid percent-encoding in secret key"));
+        assert!(!error.contains("ACCESS_KEY"));
+        assert!(!error.contains("SECRET"));
+    }
+
+    #[test]
     fn test_parse_rc_host_alias_rejects_invalid_access_key_percent_encoding() {
         let result = parse_env_alias("invalid", "https://ACCESS%ZZKEY:SECRET_KEY@rustfs.local");
 


### PR DESCRIPTION
## Summary

- Add focused rc-core coverage for RC_HOST credentials that contain valid percent escapes but decode to invalid UTF-8.
- Assert the error is classified as invalid percent-encoding for the secret key and does not expose credential material.

## Background

Recent RC_HOST credential parsing changes added explicit malformed percent-encoding handling. The non-UTF-8 decode error branch remained uncovered, so this PR adds a narrow regression test around that path.

## Validation

- cargo test -p rc-core test_parse_rc_host_alias_rejects_non_utf8_percent_encoded_secret_key --lib
- cargo test -p rc-core alias::tests --lib
- make pre-commit
