### PR TITLE
test(alias): cover empty RC_HOST alias name

### DIFF
--- a/crates/cli/tests/env_alias.rs
+++ b/crates/cli/tests/env_alias.rs
@@ -24,6 +24,18 @@ fn rc_binary() -> PathBuf {
     workspace_root.join("target/release/rc")
 }
 
+fn rc_command() -> Command {
+    let mut command = Command::new(rc_binary());
+
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+
+    command
+}
+
 fn unused_local_endpoint() -> String {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind local endpoint");
     let address = listener.local_addr().expect("local endpoint address");
@@ -35,7 +47,7 @@ fn unused_local_endpoint() -> String {
 fn alias_list_includes_rc_host_alias_without_credentials() {
     let config_dir = tempfile::tempdir().expect("create config dir");
 
-    let output = Command::new(rc_binary())
+    let output = rc_command()
         .args(["alias", "list", "--json"])
         .env("RC_CONFIG_DIR", config_dir.path())
         .env(
@@ -69,7 +81,7 @@ fn ls_resolves_rc_host_alias_from_environment() {
     let (_, endpoint_authority) = endpoint.split_once("://").expect("endpoint has scheme");
     let env_alias = format!("http://ACCESS_KEY:SECRET_KEY@{endpoint_authority}");
 
-    let output = Command::new(rc_binary())
+    let output = rc_command()
         .args(["--json", "ls", "myalias"])
         .env("RC_CONFIG_DIR", config_dir.path())
         .env("RC_HOST_myalias", env_alias)
@@ -99,7 +111,7 @@ fn ls_resolves_rc_host_alias_from_environment() {
 fn alias_list_rejects_invalid_rc_host_percent_encoding_without_credentials() {
     let config_dir = tempfile::tempdir().expect("create config dir");
 
-    let output = Command::new(rc_binary())
+    let output = rc_command()
         .args(["alias", "list", "--json"])
         .env("RC_CONFIG_DIR", config_dir.path())
         .env(
@@ -137,7 +149,7 @@ fn alias_list_rejects_invalid_rc_host_percent_encoding_without_credentials() {
 fn alias_list_rejects_invalid_rc_host_access_key_percent_encoding_without_credentials() {
     let config_dir = tempfile::tempdir().expect("create config dir");
 
-    let output = Command::new(rc_binary())
+    let output = rc_command()
         .args(["alias", "list", "--json"])
         .env("RC_CONFIG_DIR", config_dir.path())
         .env(
@@ -172,10 +184,52 @@ fn alias_list_rejects_invalid_rc_host_access_key_percent_encoding_without_creden
 }
 
 #[test]
+fn alias_list_rejects_empty_rc_host_alias_name_as_usage_error() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = rc_command()
+        .args(["alias", "list", "--json"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_",
+            "https://ACCESS_KEY:SECRET_KEY@rustfs.local:9000",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(!stderr.contains("ACCESS_KEY"));
+    assert!(!stderr.contains("SECRET_KEY"));
+
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert!(
+        payload["error"]
+            .as_str()
+            .expect("error message")
+            .contains("RC_HOST_ must include an alias name"),
+        "payload: {payload}"
+    );
+    assert_eq!(payload["code"], 2);
+    assert_eq!(payload["details"]["type"], "usage_error");
+}
+
+#[test]
 fn alias_list_rejects_invalid_rc_host_scheme_without_credentials() {
     let config_dir = tempfile::tempdir().expect("create config dir");
 
-    let output = Command::new(rc_binary())
+    let output = rc_command()
         .args(["alias", "list", "--json"])
         .env("RC_CONFIG_DIR", config_dir.path())
         .env(


### PR DESCRIPTION
## Related issue(s)

None.

## Background

Recent alias error handling work changed malformed `RC_HOST_*` environment aliases to report structured usage errors from the alias list command. Existing subprocess coverage checks invalid schemes and malformed credential percent encoding, but the empty alias-name variable `RC_HOST_` was only covered indirectly by the core parser behavior.

## Root cause

`RC_HOST_` reaches `AliasManager::list()` through the environment alias loader and fails before any alias is built. Before the recent alias command error-code handling, this path could fall back to a generic alias-list error response instead of preserving the core `Config` usage-error exit code and JSON metadata.

## Solution

Add a focused `crates/cli/tests/env_alias.rs` subprocess regression for `rc alias list --json` with `RC_HOST_` set. The test verifies exit code 2, stderr JSON, `usage_error` metadata, and that credential material from the malformed environment value is not echoed.

## Validation

- `cargo test -p rustfs-cli --test env_alias alias_list_rejects_empty_rc_host_alias_name_as_usage_error`
- `cargo test -p rustfs-cli --test env_alias`
- `make pre-commit`
