### PR TITLE
chore(release): bump version to 0.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "rc-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2333,7 +2333,7 @@ dependencies = [
 
 [[package]]
 name = "rc-s3"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "rustfs-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/cli", "crates/core", "crates/s3"]
 
 [workspace.package]
-version = "0.1.15"
+version = "0.1.16"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -15,9 +15,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # RustFS Internal Crates
-rc-core = { path = "./crates/core", version = "0.1.15" }
-rc-s3 = { path = "./crates/s3", version = "0.1.15" }
-rustfs-cli = { path = "./crates/cli", version = "0.1.15" }
+rc-core = { path = "./crates/core", version = "0.1.16" }
+rc-s3 = { path = "./crates/s3", version = "0.1.16" }
+rustfs-cli = { path = "./crates/cli", version = "0.1.16" }
 
 # Async runtime
 tokio = { version = "1.49", features = ["full"] }


### PR DESCRIPTION
## Summary
- Bump workspace package version to 0.1.16
- Update internal workspace dependency versions and lockfile package versions

## Validation
- cargo fmt --all --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace