### PR TITLE
fix(ci): align protected file checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,15 +88,17 @@ jobs:
       - name: Check protected files
         run: |
           PROTECTED_FILES=(
-            "docs/SPEC.md"
+            "docs/reference/rc/"
             "schemas/output_v1.json"
             "crates/cli/src/exit_code.rs"
+            "crates/core/src/config.rs"
           )
 
           CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
 
           for file in "${PROTECTED_FILES[@]}"; do
-            if echo "$CHANGED_FILES" | grep -q "^$file$"; then
+            protected_path="${file%/}"
+            if echo "$CHANGED_FILES" | grep -Fxq "$protected_path" || echo "$CHANGED_FILES" | grep -q "^$protected_path/"; then
               echo "::warning::Protected file modified: $file"
               echo "This change requires the Breaking Change process. See AGENTS.md."
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ The following files require the Breaking Change process for modifications:
 
 | File | Description |
 |------|-------------|
-| `docs/SPEC.md` | CLI behavior contract |
+| `docs/reference/rc/` | CLI behavior contract |
 | `schemas/output_v1.json` | JSON output schema |
 | `crates/cli/src/exit_code.rs` | Exit code definitions |
 | `crates/core/src/config.rs` | Config schema_version related |
@@ -80,7 +80,7 @@ Modifying protected files requires:
 
 2. **Provide migration path**
    - Config migration: add `migrations/v{N}_to_v{N+1}.rs`
-   - Documentation update: update relevant SPEC.md sections
+   - Documentation update: update relevant command reference sections
 
 3. **PR marking**
    - Include `BREAKING` in PR title or description
@@ -367,7 +367,7 @@ Before submitting a PR, confirm all of the following:
 ### Phase 2+: Command Implementation
 - Follow command implementation template
 - Each command needs tests
-- Update SPEC.md (if needed)
+- Update the command reference (if needed)
 - Update Golden tests
 
 ### Git Commit Guidelines


### PR DESCRIPTION
## Summary
- replace the deleted docs/SPEC.md protected path with docs/reference/rc/
- add crates/core/src/config.rs to the CI protected-file list so it matches AGENTS.md
- remove stale SPEC.md wording from AGENTS.md

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'
- simulated protected-file matching for docs/reference/rc/, crates/core/src/config.rs, and schemas/output_v1.json.bak
- git diff --check