### PR TITLE
test(s3): keep XML test stream blocking

### DIFF
--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -2958,6 +2958,9 @@ mod tests {
                 }
             };
             stream
+                .set_nonblocking(false)
+                .expect("configure blocking request stream");
+            stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .expect("set stream read timeout");
             let request = read_xml_request(&mut stream);


### PR DESCRIPTION
## Related issue

No issue. Fixes a recent CI regression on `windows-latest`.

## Evidence / reproduction

The CI run for `fix(ci): align protected file checks (#208)` failed in `Test (windows-latest)` while running `cargo test --workspace`. The failing test was `client::tests::custom_headers_are_added_to_xml_requests_before_signing`, where the local XML test server hit a request-read failure and the client reported a send failure.

## Root cause

The XML test helper sets the listener to nonblocking while waiting for a request. On Windows, the accepted `TcpStream` can still behave as nonblocking, so the immediate request read can fail with `WouldBlock`.

## Fix

After accepting the request stream, explicitly switch it back to blocking mode before applying the read timeout and parsing the request.

## Validation

- `cargo test -p rc-s3 custom_headers_are_added_to_xml_requests_before_signing --lib`
- `cargo test -p rc-s3 --lib`
- `cargo fmt --all --check`
- `cargo clippy -p rc-s3 --all-targets -- -D warnings`
- `git diff --check`
- `make pre-commit`