### PR TITLE
feat(cli): add bucket encryption and SSE workflows

### DIFF
--- a/crates/cli/src/commands/bucket.rs
+++ b/crates/cli/src/commands/bucket.rs
@@ -8,7 +8,7 @@ use clap::{Args, Subcommand};
 use crate::exit_code::ExitCode;
 use crate::output::OutputConfig;
 
-use super::{anonymous, cors, event, ilm, ls, mb, quota, rb, replicate, version};
+use super::{anonymous, cors, encryption, event, ilm, ls, mb, quota, rb, replicate, version};
 
 const BUCKET_AFTER_HELP: &str = "\
 Examples:
@@ -17,6 +17,7 @@ Examples:
   rc bucket remove local/my-bucket
   rc bucket event list local/my-bucket
   rc bucket cors list local/my-bucket
+  rc bucket encryption info local/my-bucket
   rc bucket replication status local/my-bucket";
 
 /// Manage bucket-oriented workflows
@@ -46,6 +47,9 @@ pub enum BucketCommands {
     /// Manage bucket CORS rules
     #[command(subcommand)]
     Cors(cors::CorsCommands),
+
+    /// Manage bucket default encryption
+    Encryption(encryption::EncryptionArgs),
 
     /// Manage bucket versioning
     #[command(subcommand)]
@@ -80,6 +84,7 @@ pub async fn execute(args: BucketArgs, output_config: OutputConfig) -> ExitCode 
         BucketCommands::Cors(cmd) => {
             cors::execute(cors::CorsArgs { command: cmd }, output_config).await
         }
+        BucketCommands::Encryption(args) => encryption::execute(args, output_config).await,
         BucketCommands::Version(cmd) => {
             version::execute(version::VersionArgs { command: cmd }, output_config).await
         }

--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -64,7 +64,7 @@ pub struct CpArgs {
     #[arg(long = "enc-s3")]
     pub enc_s3: Vec<String>,
 
-    /// Apply SSE-KMS to the remote destination path as <TARGET>=<KMS_KEY_ID>
+    /// Apply SSE-KMS to the remote destination path as TARGET=KMS_KEY_ID
     #[arg(long = "enc-kms")]
     pub enc_kms: Vec<String>,
 }
@@ -779,10 +779,10 @@ async fn copy_s3_to_s3(
 fn parse_kms_target(value: &str) -> Result<(String, String), String> {
     let (target, key_id) = value
         .split_once('=')
-        .ok_or_else(|| "Expected <TARGET>=<KMS_KEY_ID> for --enc-kms".to_string())?;
+        .ok_or_else(|| "Expected TARGET=KMS_KEY_ID for --enc-kms".to_string())?;
 
     if target.is_empty() || key_id.is_empty() {
-        return Err("Expected <TARGET>=<KMS_KEY_ID> for --enc-kms".to_string());
+        return Err("Expected TARGET=KMS_KEY_ID for --enc-kms".to_string());
     }
 
     Ok((target.to_string(), key_id.to_string()))
@@ -806,19 +806,34 @@ pub(crate) fn parse_destination_encryption(
 
     let target_display = remote.to_string();
     let s3_matches = enc_s3.iter().any(|value| value == &target_display);
-    let kms_match = enc_kms
+    let kms_targets = enc_kms
         .iter()
         .map(|value| parse_kms_target(value))
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+    let kms_match = kms_targets
+        .iter()
         .find(|(candidate, _)| candidate == &target_display);
+
+    if !enc_s3.is_empty() && !s3_matches {
+        return Err(format!(
+            "--enc-s3 target must exactly match the remote destination: {target_display}"
+        ));
+    }
+
+    if !enc_kms.is_empty() && kms_match.is_none() {
+        return Err(format!(
+            "--enc-kms target must exactly match the remote destination: {target_display}"
+        ));
+    }
 
     match (s3_matches, kms_match) {
         (true, Some(_)) => Err(format!(
             "--enc-s3 and --enc-kms cannot target the same destination: {target_display}"
         )),
         (true, None) => Ok(Some(ObjectEncryptionRequest::SseS3)),
-        (false, Some((_, key_id))) => Ok(Some(ObjectEncryptionRequest::SseKms { key_id })),
+        (false, Some((_, key_id))) => Ok(Some(ObjectEncryptionRequest::SseKms {
+            key_id: key_id.clone(),
+        })),
         (false, None) => Ok(None),
     }
 }
@@ -1045,7 +1060,7 @@ mod tests {
     #[test]
     fn parse_enc_kms_target_requires_equals_separator() {
         let error = parse_kms_target("local/bucket/file.txt").expect_err("missing key separator");
-        assert!(error.contains("Expected <TARGET>=<KMS_KEY_ID>"));
+        assert!(error.contains("Expected TARGET=KMS_KEY_ID"));
     }
 
     #[test]
@@ -1071,6 +1086,29 @@ mod tests {
         .expect_err("same target conflict should fail");
 
         assert!(error.contains("cannot target the same destination"));
+    }
+
+    #[test]
+    fn destination_encryption_rejects_unmatched_s3_target() {
+        let target = ParsedPath::Remote(RemotePath::new("local", "bucket", "file.txt"));
+        let error =
+            parse_destination_encryption(&[String::from("local/bucket/typo.txt")], &[], &target)
+                .expect_err("unmatched s3 target should fail");
+
+        assert!(error.contains("must exactly match the remote destination"));
+    }
+
+    #[test]
+    fn destination_encryption_rejects_unmatched_kms_target() {
+        let target = ParsedPath::Remote(RemotePath::new("local", "bucket", "file.txt"));
+        let error = parse_destination_encryption(
+            &[],
+            &[String::from("local/bucket/typo.txt=kms-key")],
+            &target,
+        )
+        .expect_err("unmatched kms target should fail");
+
+        assert!(error.contains("must exactly match the remote destination"));
     }
 
     #[test]

--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -3,7 +3,9 @@
 //! Copies objects between local filesystem and S3, or between S3 locations.
 
 use clap::Args;
-use rc_core::{AliasManager, ObjectStore as _, ParsedPath, RemotePath, parse_path};
+use rc_core::{
+    AliasManager, ObjectEncryptionRequest, ObjectStore as _, ParsedPath, RemotePath, parse_path,
+};
 use rc_s3::S3Client;
 use serde::Serialize;
 use std::path::{Path, PathBuf};
@@ -57,6 +59,14 @@ pub struct CpArgs {
     /// Content type for uploaded files
     #[arg(long)]
     pub content_type: Option<String>,
+
+    /// Apply SSE-S3 to the remote destination path
+    #[arg(long = "enc-s3")]
+    pub enc_s3: Vec<String>,
+
+    /// Apply SSE-KMS to the remote destination path as <TARGET>=<KMS_KEY_ID>
+    #[arg(long = "enc-kms")]
+    pub enc_kms: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -146,6 +156,14 @@ async fn copy_local_to_s3(
     args: &CpArgs,
     formatter: &Formatter,
 ) -> ExitCode {
+    let target = ParsedPath::Remote(dst.clone());
+    let encryption = match parse_destination_encryption(&args.enc_s3, &args.enc_kms, &target) {
+        Ok(encryption) => encryption,
+        Err(error) => {
+            return formatter.fail(ExitCode::UsageError, &error);
+        }
+    };
+
     // Check if source exists
     if !src.exists() {
         return formatter.fail_with_suggestion(
@@ -196,10 +214,10 @@ async fn copy_local_to_s3(
 
     if src.is_file() {
         // Single file upload
-        upload_file(&client, src, dst, args, formatter).await
+        upload_file(&client, src, dst, args, formatter, encryption.as_ref()).await
     } else {
         // Directory upload
-        upload_directory(&client, src, dst, args, formatter).await
+        upload_directory(&client, src, dst, args, formatter, encryption.as_ref()).await
     }
 }
 
@@ -256,6 +274,7 @@ async fn upload_file(
     dst: &RemotePath,
     args: &CpArgs,
     formatter: &Formatter,
+    encryption: Option<&ObjectEncryptionRequest>,
 ) -> ExitCode {
     // Determine destination key
     let dst_key = if dst.key.is_empty() || dst.key.ends_with('/') {
@@ -313,7 +332,7 @@ async fn upload_file(
 
     // Upload
     match client
-        .put_object_from_path(&target, src, content_type, |bytes_sent| {
+        .put_object_from_path(&target, src, content_type, encryption, |bytes_sent| {
             if let Some(ref pb) = progress {
                 pb.set_position(bytes_sent);
             }
@@ -357,6 +376,7 @@ async fn upload_directory(
     dst: &RemotePath,
     args: &CpArgs,
     formatter: &Formatter,
+    encryption: Option<&ObjectEncryptionRequest>,
 ) -> ExitCode {
     use std::fs;
 
@@ -402,7 +422,7 @@ async fn upload_directory(
 
         let target = RemotePath::new(&dst.alias, &dst.bucket, &dst_key);
 
-        let result = upload_file(client, &file_path, &target, args, formatter).await;
+        let result = upload_file(client, &file_path, &target, args, formatter, encryption).await;
 
         if result == ExitCode::Success {
             success_count += 1;
@@ -665,6 +685,14 @@ async fn copy_s3_to_s3(
     args: &CpArgs,
     formatter: &Formatter,
 ) -> ExitCode {
+    let target = ParsedPath::Remote(dst.clone());
+    let encryption = match parse_destination_encryption(&args.enc_s3, &args.enc_kms, &target) {
+        Ok(encryption) => encryption,
+        Err(error) => {
+            return formatter.fail(ExitCode::UsageError, &error);
+        }
+    };
+
     // For S3-to-S3, we need to handle same or different aliases
     let alias_manager = match AliasManager::new() {
         Ok(am) => am,
@@ -714,7 +742,7 @@ async fn copy_s3_to_s3(
         return ExitCode::Success;
     }
 
-    match client.copy_object(src, dst).await {
+    match client.copy_object(src, dst, encryption.as_ref()).await {
         Ok(info) => {
             if formatter.is_json() {
                 let output = CpOutput {
@@ -745,6 +773,53 @@ async fn copy_s3_to_s3(
                 formatter.fail(ExitCode::NetworkError, &format!("Failed to copy: {e}"))
             }
         }
+    }
+}
+
+fn parse_kms_target(value: &str) -> Result<(String, String), String> {
+    let (target, key_id) = value
+        .split_once('=')
+        .ok_or_else(|| "Expected <TARGET>=<KMS_KEY_ID> for --enc-kms".to_string())?;
+
+    if target.is_empty() || key_id.is_empty() {
+        return Err("Expected <TARGET>=<KMS_KEY_ID> for --enc-kms".to_string());
+    }
+
+    Ok((target.to_string(), key_id.to_string()))
+}
+
+pub(crate) fn parse_destination_encryption(
+    enc_s3: &[String],
+    enc_kms: &[String],
+    target: &ParsedPath,
+) -> Result<Option<ObjectEncryptionRequest>, String> {
+    if enc_s3.is_empty() && enc_kms.is_empty() {
+        return Ok(None);
+    }
+
+    let remote = match target {
+        ParsedPath::Remote(remote) => remote,
+        ParsedPath::Local(_) => {
+            return Err("Destination encryption flags must reference a remote destination".into());
+        }
+    };
+
+    let target_display = remote.to_string();
+    let s3_matches = enc_s3.iter().any(|value| value == &target_display);
+    let kms_match = enc_kms
+        .iter()
+        .map(|value| parse_kms_target(value))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .find(|(candidate, _)| candidate == &target_display);
+
+    match (s3_matches, kms_match) {
+        (true, Some(_)) => Err(format!(
+            "--enc-s3 and --enc-kms cannot target the same destination: {target_display}"
+        )),
+        (true, None) => Ok(Some(ObjectEncryptionRequest::SseS3)),
+        (false, Some((_, key_id))) => Ok(Some(ObjectEncryptionRequest::SseKms { key_id })),
+        (false, None) => Ok(None),
     }
 }
 
@@ -959,10 +1034,43 @@ mod tests {
             dry_run: false,
             storage_class: None,
             content_type: None,
+            enc_s3: Vec::new(),
+            enc_kms: Vec::new(),
         };
         assert!(args.overwrite);
         assert!(!args.recursive);
         assert!(!args.dry_run);
+    }
+
+    #[test]
+    fn parse_enc_kms_target_requires_equals_separator() {
+        let error = parse_kms_target("local/bucket/file.txt").expect_err("missing key separator");
+        assert!(error.contains("Expected <TARGET>=<KMS_KEY_ID>"));
+    }
+
+    #[test]
+    fn destination_encryption_rejects_local_targets() {
+        let error = parse_destination_encryption(
+            &[String::from("./local.txt")],
+            &[],
+            &ParsedPath::Local(std::path::PathBuf::from("./local.txt")),
+        )
+        .expect_err("local target should be rejected");
+
+        assert!(error.contains("must reference a remote destination"));
+    }
+
+    #[test]
+    fn destination_encryption_detects_conflicting_flags_for_same_target() {
+        let target = ParsedPath::Remote(RemotePath::new("local", "bucket", "file.txt"));
+        let error = parse_destination_encryption(
+            &[String::from("local/bucket/file.txt")],
+            &[String::from("local/bucket/file.txt=kms-key")],
+            &target,
+        )
+        .expect_err("same target conflict should fail");
+
+        assert!(error.contains("cannot target the same destination"));
     }
 
     #[test]

--- a/crates/cli/src/commands/encryption.rs
+++ b/crates/cli/src/commands/encryption.rs
@@ -171,7 +171,7 @@ fn validate_set_encryption_args(
             "--key-id is only valid with --mode sse-kms",
         )),
         (EncryptionMode::SseKms, Some(key_id)) => Ok(BucketEncryption::SseKms {
-            key_id: key_id.to_string(),
+            key_id: Some(key_id.to_string()),
         }),
         (EncryptionMode::SseKms, None) => Err(formatter.fail(
             ExitCode::UsageError,
@@ -351,7 +351,7 @@ fn output_for_encryption(
             bucket,
             status: "Configured".to_string(),
             mode: Some("SSE-KMS".to_string()),
-            kms_key_id: Some(key_id),
+            kms_key_id: key_id,
         },
         None => BucketEncryptionOutput {
             bucket,

--- a/crates/cli/src/commands/encryption.rs
+++ b/crates/cli/src/commands/encryption.rs
@@ -1,0 +1,447 @@
+//! encryption command - Manage bucket default encryption.
+//!
+//! Set, inspect, or clear bucket default encryption for a bucket path.
+
+use clap::{Args, Subcommand, ValueEnum};
+use rc_core::{AliasManager, BucketEncryption, ObjectStore as _};
+use rc_s3::S3Client;
+use serde::Serialize;
+
+use crate::exit_code::ExitCode;
+use crate::output::{Formatter, OutputConfig};
+
+const ENCRYPTION_AFTER_HELP: &str = "\
+Examples:
+  rc bucket encryption set local/my-bucket --mode sse-s3
+  rc bucket encryption set local/my-bucket --mode sse-kms --key-id alias/my-key
+  rc bucket encryption info local/my-bucket
+  rc bucket encryption clear local/my-bucket";
+
+const SET_AFTER_HELP: &str = "\
+Examples:
+  rc bucket encryption set local/my-bucket --mode sse-s3
+  rc bucket encryption set local/my-bucket --mode sse-kms --key-id alias/my-key";
+
+const INFO_AFTER_HELP: &str = "\
+Examples:
+  rc bucket encryption info local/my-bucket";
+
+const CLEAR_AFTER_HELP: &str = "\
+Examples:
+  rc bucket encryption clear local/my-bucket";
+
+/// Manage bucket default encryption
+#[derive(Args, Debug)]
+#[command(after_help = ENCRYPTION_AFTER_HELP)]
+pub struct EncryptionArgs {
+    #[command(subcommand)]
+    pub command: EncryptionCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum EncryptionCommands {
+    /// Set bucket default encryption
+    Set(SetEncryptionArgs),
+
+    /// Show bucket default encryption
+    Info(InfoEncryptionArgs),
+
+    /// Clear bucket default encryption
+    Clear(ClearEncryptionArgs),
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, ValueEnum)]
+pub enum EncryptionMode {
+    SseS3,
+    SseKms,
+}
+
+#[derive(Args, Debug)]
+#[command(after_help = SET_AFTER_HELP)]
+pub struct SetEncryptionArgs {
+    /// Path to the bucket (alias/bucket)
+    pub path: String,
+
+    /// Default encryption mode
+    #[arg(long)]
+    pub mode: EncryptionMode,
+
+    /// KMS key id for sse-kms mode
+    #[arg(long)]
+    pub key_id: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct BucketArg {
+    /// Path to the bucket (alias/bucket)
+    pub path: String,
+}
+
+#[derive(Args, Debug)]
+#[command(after_help = INFO_AFTER_HELP)]
+pub struct InfoEncryptionArgs {
+    #[command(flatten)]
+    pub bucket: BucketArg,
+}
+
+#[derive(Args, Debug)]
+#[command(after_help = CLEAR_AFTER_HELP)]
+pub struct ClearEncryptionArgs {
+    #[command(flatten)]
+    pub bucket: BucketArg,
+}
+
+#[derive(Debug, Serialize)]
+struct BucketEncryptionOutput {
+    bucket: String,
+    status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mode: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kms_key_id: Option<String>,
+}
+
+/// Execute the encryption command
+pub async fn execute(args: EncryptionArgs, output_config: OutputConfig) -> ExitCode {
+    match args.command {
+        EncryptionCommands::Set(args) => execute_set(args, output_config).await,
+        EncryptionCommands::Info(args) => execute_info(args, output_config).await,
+        EncryptionCommands::Clear(args) => execute_clear(args, output_config).await,
+    }
+}
+
+async fn execute_set(args: SetEncryptionArgs, output_config: OutputConfig) -> ExitCode {
+    let formatter = Formatter::new(output_config);
+    let (alias_name, bucket) = match parse_bucket_path(&args.path) {
+        Ok(parts) => parts,
+        Err(error) => {
+            return formatter.fail_with_suggestion(
+                ExitCode::UsageError,
+                &error,
+                "Use a bucket path in the form alias/bucket before retrying the encryption command.",
+            );
+        }
+    };
+
+    let encryption = match validate_set_encryption_args(&args, &formatter) {
+        Ok(encryption) => encryption,
+        Err(code) => return code,
+    };
+
+    let client = match setup_client(&alias_name, &bucket, &formatter).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    match client
+        .set_bucket_encryption(&bucket, encryption.clone())
+        .await
+    {
+        Ok(()) => {
+            let output = output_for_encryption(bucket, Some(encryption), "Not configured");
+            if formatter.is_json() {
+                formatter.json(&output);
+            } else {
+                formatter.println(&format!("Bucket: {}", output.bucket));
+                formatter.println(&format!("Encryption: {}", output.status));
+                if let Some(mode) = output.mode {
+                    formatter.println(&format!("Mode: {mode}"));
+                }
+                if let Some(key_id) = output.kms_key_id {
+                    formatter.println(&format!("KMS Key ID: {key_id}"));
+                }
+            }
+            ExitCode::Success
+        }
+        Err(error) => formatter.fail(
+            exit_code_from_error(&error),
+            &format!("Failed to set bucket encryption: {error}"),
+        ),
+    }
+}
+
+fn validate_set_encryption_args(
+    args: &SetEncryptionArgs,
+    formatter: &Formatter,
+) -> Result<BucketEncryption, ExitCode> {
+    match (args.mode, args.key_id.as_deref()) {
+        (EncryptionMode::SseS3, None) => Ok(BucketEncryption::SseS3),
+        (EncryptionMode::SseS3, Some(_)) => Err(formatter.fail(
+            ExitCode::UsageError,
+            "--key-id is only valid with --mode sse-kms",
+        )),
+        (EncryptionMode::SseKms, Some(key_id)) => Ok(BucketEncryption::SseKms {
+            key_id: key_id.to_string(),
+        }),
+        (EncryptionMode::SseKms, None) => Err(formatter.fail(
+            ExitCode::UsageError,
+            "--key-id is required with --mode sse-kms",
+        )),
+    }
+}
+
+async fn execute_info(args: InfoEncryptionArgs, output_config: OutputConfig) -> ExitCode {
+    let formatter = Formatter::new(output_config);
+    let (alias_name, bucket) = match parse_bucket_path(&args.bucket.path) {
+        Ok(parts) => parts,
+        Err(error) => {
+            return formatter.fail_with_suggestion(
+                ExitCode::UsageError,
+                &error,
+                "Use a bucket path in the form alias/bucket before retrying the encryption command.",
+            );
+        }
+    };
+
+    let client = match setup_client(&alias_name, &bucket, &formatter).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    match client.get_bucket_encryption(&bucket).await {
+        Ok(encryption) => {
+            let output = output_for_encryption(bucket, encryption, "Not configured");
+            if formatter.is_json() {
+                formatter.json(&output);
+            } else {
+                formatter.println(&format!("Bucket: {}", output.bucket));
+                formatter.println(&format!("Encryption: {}", output.status));
+                if let Some(mode) = output.mode {
+                    formatter.println(&format!("Mode: {mode}"));
+                }
+                if let Some(key_id) = output.kms_key_id {
+                    formatter.println(&format!("KMS Key ID: {key_id}"));
+                }
+            }
+            ExitCode::Success
+        }
+        Err(error) => formatter.fail(
+            exit_code_from_error(&error),
+            &format!("Failed to get bucket encryption: {error}"),
+        ),
+    }
+}
+
+async fn execute_clear(args: ClearEncryptionArgs, output_config: OutputConfig) -> ExitCode {
+    let formatter = Formatter::new(output_config);
+    let (alias_name, bucket) = match parse_bucket_path(&args.bucket.path) {
+        Ok(parts) => parts,
+        Err(error) => {
+            return formatter.fail_with_suggestion(
+                ExitCode::UsageError,
+                &error,
+                "Use a bucket path in the form alias/bucket before retrying the encryption command.",
+            );
+        }
+    };
+
+    let client = match setup_client(&alias_name, &bucket, &formatter).await {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    match client.delete_bucket_encryption(&bucket).await {
+        Ok(()) => {
+            if formatter.is_json() {
+                formatter.json(&BucketEncryptionOutput {
+                    bucket,
+                    status: "Cleared".to_string(),
+                    mode: None,
+                    kms_key_id: None,
+                });
+            } else {
+                formatter.success("Bucket encryption configuration cleared successfully.");
+            }
+            ExitCode::Success
+        }
+        Err(error) => formatter.fail(
+            exit_code_from_error(&error),
+            &format!("Failed to clear bucket encryption: {error}"),
+        ),
+    }
+}
+
+async fn setup_client(
+    alias_name: &str,
+    bucket: &str,
+    formatter: &Formatter,
+) -> Result<S3Client, ExitCode> {
+    let alias_manager = match AliasManager::new() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return Err(formatter.fail(
+                ExitCode::GeneralError,
+                &format!("Failed to load aliases: {error}"),
+            ));
+        }
+    };
+
+    let alias = match alias_manager.get(alias_name) {
+        Ok(alias) => alias,
+        Err(_) => {
+            return Err(formatter.fail_with_suggestion(
+                ExitCode::NotFound,
+                &format!("Alias '{alias_name}' not found"),
+                "Run `rc alias list` to inspect configured aliases or add one with `rc alias set ...`.",
+            ));
+        }
+    };
+
+    let client = match S3Client::new(alias).await {
+        Ok(client) => client,
+        Err(error) => {
+            return Err(formatter.fail(
+                ExitCode::NetworkError,
+                &format!("Failed to create S3 client: {error}"),
+            ));
+        }
+    };
+
+    match client.bucket_exists(bucket).await {
+        Ok(true) => {}
+        Ok(false) => {
+            return Err(formatter.fail_with_suggestion(
+                ExitCode::NotFound,
+                &format!("Bucket '{bucket}' does not exist"),
+                "Check the bucket path and retry the encryption command.",
+            ));
+        }
+        Err(error) => {
+            return Err(formatter.fail(
+                ExitCode::NetworkError,
+                &format!("Failed to check bucket: {error}"),
+            ));
+        }
+    }
+
+    Ok(client)
+}
+
+fn parse_bucket_path(path: &str) -> Result<(String, String), String> {
+    if path.is_empty() {
+        return Err("Bucket path must be in format alias/bucket".to_string());
+    }
+
+    let parts: Vec<&str> = path.splitn(2, '/').collect();
+    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+        return Err("Bucket path must be in format alias/bucket".to_string());
+    }
+
+    let bucket = parts[1].trim_end_matches('/');
+    if bucket.is_empty() || bucket.contains('/') {
+        return Err("Bucket path must be in format alias/bucket".to_string());
+    }
+
+    Ok((parts[0].to_string(), bucket.to_string()))
+}
+
+fn output_for_encryption(
+    bucket: String,
+    encryption: Option<BucketEncryption>,
+    empty_status: &str,
+) -> BucketEncryptionOutput {
+    match encryption {
+        Some(BucketEncryption::SseS3) => BucketEncryptionOutput {
+            bucket,
+            status: "Configured".to_string(),
+            mode: Some("SSE-S3".to_string()),
+            kms_key_id: None,
+        },
+        Some(BucketEncryption::SseKms { key_id }) => BucketEncryptionOutput {
+            bucket,
+            status: "Configured".to_string(),
+            mode: Some("SSE-KMS".to_string()),
+            kms_key_id: Some(key_id),
+        },
+        None => BucketEncryptionOutput {
+            bucket,
+            status: empty_status.to_string(),
+            mode: None,
+            kms_key_id: None,
+        },
+    }
+}
+
+fn exit_code_from_error(error: &rc_core::Error) -> ExitCode {
+    ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_bucket_path_rejects_object_paths() {
+        assert!(parse_bucket_path("local/bucket/object.txt").is_err());
+    }
+
+    #[tokio::test]
+    async fn execute_set_kms_without_key_id_returns_usage_error() {
+        let args = EncryptionArgs {
+            command: EncryptionCommands::Set(SetEncryptionArgs {
+                path: "local/my-bucket".to_string(),
+                mode: EncryptionMode::SseKms,
+                key_id: None,
+            }),
+        };
+
+        let code = execute(args, OutputConfig::default()).await;
+        assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn execute_set_invalid_bucket_path_returns_usage_error() {
+        let args = EncryptionArgs {
+            command: EncryptionCommands::Set(SetEncryptionArgs {
+                path: "local/my-bucket/object.txt".to_string(),
+                mode: EncryptionMode::SseS3,
+                key_id: None,
+            }),
+        };
+
+        let code = execute(args, OutputConfig::default()).await;
+        assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn execute_set_sse_s3_with_key_id_returns_usage_error() {
+        let args = EncryptionArgs {
+            command: EncryptionCommands::Set(SetEncryptionArgs {
+                path: "local/my-bucket".to_string(),
+                mode: EncryptionMode::SseS3,
+                key_id: Some("kms-key".to_string()),
+            }),
+        };
+
+        let code = execute(args, OutputConfig::default()).await;
+        assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn execute_info_invalid_bucket_path_returns_usage_error() {
+        let args = EncryptionArgs {
+            command: EncryptionCommands::Info(InfoEncryptionArgs {
+                bucket: BucketArg {
+                    path: "local/my-bucket/object.txt".to_string(),
+                },
+            }),
+        };
+
+        let code = execute(args, OutputConfig::default()).await;
+        assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn execute_clear_invalid_bucket_path_returns_usage_error() {
+        let args = EncryptionArgs {
+            command: EncryptionCommands::Clear(ClearEncryptionArgs {
+                bucket: BucketArg {
+                    path: "local/my-bucket/object.txt".to_string(),
+                },
+            }),
+        };
+
+        let code = execute(args, OutputConfig::default()).await;
+        assert_eq!(code, ExitCode::UsageError);
+    }
+}

--- a/crates/cli/src/commands/mirror.rs
+++ b/crates/cli/src/commands/mirror.rs
@@ -102,7 +102,7 @@ impl MirrorCopyTarget for S3Client {
         data: Vec<u8>,
         content_type: Option<&str>,
     ) -> rc_core::Result<rc_core::ObjectInfo> {
-        rc_core::ObjectStore::put_object(self, path, data, content_type).await
+        rc_core::ObjectStore::put_object(self, path, data, content_type, None).await
     }
 }
 

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -21,6 +21,7 @@ mod completions;
 mod cors;
 pub mod cp;
 pub mod diff;
+mod encryption;
 mod event;
 mod find;
 mod head;

--- a/crates/cli/src/commands/mv.rs
+++ b/crates/cli/src/commands/mv.rs
@@ -36,7 +36,7 @@ pub struct MvArgs {
     #[arg(long = "enc-s3")]
     pub enc_s3: Vec<String>,
 
-    /// Apply SSE-KMS to the remote destination path as <TARGET>=<KMS_KEY_ID>
+    /// Apply SSE-KMS to the remote destination path as TARGET=KMS_KEY_ID
     #[arg(long = "enc-kms")]
     pub enc_kms: Vec<String>,
 }

--- a/crates/cli/src/commands/mv.rs
+++ b/crates/cli/src/commands/mv.rs
@@ -31,6 +31,14 @@ pub struct MvArgs {
     /// Only show what would be moved (dry run)
     #[arg(long)]
     pub dry_run: bool,
+
+    /// Apply SSE-S3 to the remote destination path
+    #[arg(long = "enc-s3")]
+    pub enc_s3: Vec<String>,
+
+    /// Apply SSE-KMS to the remote destination path as <TARGET>=<KMS_KEY_ID>
+    #[arg(long = "enc-kms")]
+    pub enc_kms: Vec<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -124,6 +132,8 @@ async fn move_local_to_s3(
         dry_run: args.dry_run,
         storage_class: None,
         content_type: None,
+        enc_s3: args.enc_s3.clone(),
+        enc_kms: args.enc_kms.clone(),
     };
 
     let cp_result = cp::execute(
@@ -178,6 +188,8 @@ async fn move_s3_to_local(
         dry_run: args.dry_run,
         storage_class: None,
         content_type: None,
+        enc_s3: args.enc_s3.clone(),
+        enc_kms: args.enc_kms.clone(),
     };
 
     let cp_result = cp::execute(
@@ -235,6 +247,16 @@ async fn move_s3_to_s3(
     args: &MvArgs,
     formatter: &Formatter,
 ) -> ExitCode {
+    let target = ParsedPath::Remote(dst.clone());
+    let encryption = match crate::commands::cp::parse_destination_encryption(
+        &args.enc_s3,
+        &args.enc_kms,
+        &target,
+    ) {
+        Ok(encryption) => encryption,
+        Err(error) => return formatter.fail(ExitCode::UsageError, &error),
+    };
+
     // For S3-to-S3, we need same alias for server-side copy
     if src.alias != dst.alias {
         formatter.error("Cross-alias S3-to-S3 move not yet supported.");
@@ -321,7 +343,10 @@ async fn move_s3_to_s3(
                 let src_obj_display = src_obj.to_string();
                 let dst_obj_display = dst_obj.to_string();
 
-                match client.copy_object(&src_obj, &dst_obj).await {
+                match client
+                    .copy_object(&src_obj, &dst_obj, encryption.as_ref())
+                    .await
+                {
                     Ok(_) => match client.delete_object(&src_obj).await {
                         Ok(()) => {
                             moved_count += 1;
@@ -402,7 +427,7 @@ async fn move_s3_to_s3(
         }
     } else {
         // Copy
-        match client.copy_object(src, dst).await {
+        match client.copy_object(src, dst, encryption.as_ref()).await {
             Ok(info) => {
                 // Delete source
                 if let Err(e) = client.delete_object(src).await {
@@ -535,10 +560,28 @@ mod tests {
             recursive: false,
             continue_on_error: false,
             dry_run: false,
+            enc_s3: Vec::new(),
+            enc_kms: Vec::new(),
         };
         assert!(!args.recursive);
         assert!(!args.dry_run);
         assert!(!args.continue_on_error);
+    }
+
+    #[test]
+    fn test_mv_args_store_encryption_flags() {
+        let args = MvArgs {
+            source: "src".to_string(),
+            target: "dst".to_string(),
+            recursive: false,
+            continue_on_error: false,
+            dry_run: false,
+            enc_s3: vec!["local/bucket/dst.txt".to_string()],
+            enc_kms: vec!["local/bucket/dst.txt=kms-key".to_string()],
+        };
+
+        assert_eq!(args.enc_s3.len(), 1);
+        assert_eq!(args.enc_kms.len(), 1);
     }
 
     #[test]

--- a/crates/cli/src/commands/pipe.rs
+++ b/crates/cli/src/commands/pipe.rs
@@ -3,7 +3,7 @@
 //! Reads from stdin and uploads to S3. Useful for piping output from other commands.
 
 use clap::Args;
-use rc_core::{AliasManager, ObjectStore as _, RemotePath};
+use rc_core::{AliasManager, ObjectEncryptionRequest, ObjectStore as _, RemotePath};
 use rc_s3::S3Client;
 use serde::Serialize;
 use std::io::Read;
@@ -24,6 +24,14 @@ pub struct PipeArgs {
     /// Storage class for the object
     #[arg(long)]
     pub storage_class: Option<String>,
+
+    /// Apply SSE-S3 to the upload target
+    #[arg(long = "enc-s3", default_value = "false")]
+    pub enc_s3: bool,
+
+    /// Apply SSE-KMS to the upload target
+    #[arg(long = "enc-kms")]
+    pub enc_kms: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -39,6 +47,19 @@ struct PipeOutput {
 /// Execute the pipe command
 pub async fn execute(args: PipeArgs, output_config: OutputConfig) -> ExitCode {
     let formatter = Formatter::new(output_config);
+    let encryption = match (args.enc_s3, args.enc_kms.as_deref()) {
+        (true, None) => Some(ObjectEncryptionRequest::SseS3),
+        (false, Some(key_id)) => Some(ObjectEncryptionRequest::SseKms {
+            key_id: key_id.to_string(),
+        }),
+        (false, None) => None,
+        (true, Some(_)) => {
+            return formatter.fail(
+                ExitCode::UsageError,
+                "--enc-s3 and --enc-kms cannot be used together",
+            );
+        }
+    };
 
     // Parse the target path
     let (alias_name, bucket, key) = match parse_pipe_path(&args.target) {
@@ -93,7 +114,12 @@ pub async fn execute(args: PipeArgs, output_config: OutputConfig) -> ExitCode {
 
     // Upload
     match client
-        .put_object(&target, buffer, Some(&args.content_type))
+        .put_object(
+            &target,
+            buffer,
+            Some(&args.content_type),
+            encryption.as_ref(),
+        )
         .await
     {
         Ok(info) => {
@@ -178,5 +204,19 @@ mod tests {
     #[test]
     fn test_parse_pipe_path_empty() {
         assert!(parse_pipe_path("").is_err());
+    }
+
+    #[tokio::test]
+    async fn pipe_conflicting_encryption_flags_return_usage_error() {
+        let args = PipeArgs {
+            target: "local/bucket/file.txt".to_string(),
+            content_type: "application/octet-stream".to_string(),
+            storage_class: None,
+            enc_s3: true,
+            enc_kms: Some("kms-key".to_string()),
+        };
+
+        let code = execute(args, OutputConfig::default()).await;
+        assert_eq!(code, ExitCode::UsageError);
     }
 }

--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -231,6 +231,80 @@ fn alias_set_json_error_rejects_invalid_signature() {
 }
 
 #[test]
+fn bucket_encryption_set_json_error_requires_key_id_for_sse_kms() {
+    let output = run_rc(&[
+        "bucket",
+        "encryption",
+        "set",
+        "local/my-bucket",
+        "--mode",
+        "sse-kms",
+        "--json",
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
+    assert_eq!(json["error"], "--key-id is required with --mode sse-kms");
+    assert_eq!(json["code"], 2);
+    assert_eq!(json["details"]["type"], "usage_error");
+    assert_eq!(json["details"]["retryable"], false);
+    assert_eq!(
+        json["details"]["suggestion"],
+        "Run the command with --help to review the expected arguments and flags."
+    );
+}
+
+#[test]
+fn bucket_encryption_set_json_error_rejects_key_id_for_sse_s3() {
+    let output = run_rc(&[
+        "bucket",
+        "encryption",
+        "set",
+        "local/my-bucket",
+        "--mode",
+        "sse-s3",
+        "--key-id",
+        "alias/my-key",
+        "--json",
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
+    assert_eq!(json["error"], "--key-id is only valid with --mode sse-kms");
+    assert_eq!(json["code"], 2);
+    assert_eq!(json["details"]["type"], "usage_error");
+    assert_eq!(json["details"]["retryable"], false);
+    assert_eq!(
+        json["details"]["suggestion"],
+        "Run the command with --help to review the expected arguments and flags."
+    );
+}
+
+#[test]
 #[cfg(not(windows))]
 fn alias_set_json_error_rejects_invalid_credentials_without_saving_alias() {
     let config_dir = tempfile::tempdir().expect("create temp config dir");

--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -305,6 +305,44 @@ fn bucket_encryption_set_json_error_rejects_key_id_for_sse_s3() {
 }
 
 #[test]
+fn cp_json_error_rejects_unmatched_encryption_target() {
+    let temp_dir = tempfile::tempdir().expect("create temp dir");
+    let source = temp_dir.path().join("source.txt");
+    std::fs::write(&source, b"source").expect("write source file");
+
+    let output = run_rc(&[
+        "cp",
+        source.to_str().expect("source path is valid utf-8"),
+        "local/archive/report.json",
+        "--enc-s3",
+        "local/archive/typo.json",
+        "--json",
+    ]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "usage JSON errors should be emitted on stderr"
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
+    assert_eq!(
+        json["error"],
+        "--enc-s3 target must exactly match the remote destination: local/archive/report.json"
+    );
+    assert_eq!(json["code"], 2);
+    assert_eq!(json["details"]["type"], "usage_error");
+    assert_eq!(json["details"]["retryable"], false);
+}
+
+#[test]
 #[cfg(not(windows))]
 fn alias_set_json_error_rejects_invalid_credentials_without_saving_alias() {
     let config_dir = tempfile::tempdir().expect("create temp config dir");

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -176,6 +176,8 @@ fn top_level_command_help_contract() {
                 "create",
                 "remove",
                 "event",
+                "cors",
+                "encryption",
                 "version",
                 "quota",
                 "anonymous",
@@ -184,6 +186,32 @@ fn top_level_command_help_contract() {
                 "Examples:",
                 "rc bucket list local/",
             ],
+        },
+        HelpCase {
+            args: &["bucket", "encryption"],
+            usage: "Usage: rc bucket encryption [OPTIONS] <COMMAND>",
+            expected_tokens: &["set", "info", "clear", "Examples:"],
+        },
+        HelpCase {
+            args: &["bucket", "encryption", "set"],
+            usage: "Usage: rc bucket encryption set [OPTIONS] --mode <MODE> <PATH>",
+            expected_tokens: &[
+                "--mode",
+                "--key-id",
+                "Examples:",
+                "rc bucket encryption set local/my-bucket --mode sse-s3",
+                "rc bucket encryption set local/my-bucket --mode sse-kms --key-id alias/my-key",
+            ],
+        },
+        HelpCase {
+            args: &["bucket", "encryption", "info"],
+            usage: "Usage: rc bucket encryption info [OPTIONS] <PATH>",
+            expected_tokens: &["Examples:", "rc bucket encryption info local/my-bucket"],
+        },
+        HelpCase {
+            args: &["bucket", "encryption", "clear"],
+            usage: "Usage: rc bucket encryption clear [OPTIONS] <PATH>",
+            expected_tokens: &["Examples:", "rc bucket encryption clear local/my-bucket"],
         },
         HelpCase {
             args: &["object"],
@@ -266,6 +294,8 @@ fn top_level_command_help_contract() {
                 "--dry-run",
                 "--storage-class",
                 "--content-type",
+                "--enc-s3",
+                "--enc-kms",
                 "Examples:",
                 "rc object copy ./report.json local/my-bucket/reports/",
             ],
@@ -273,7 +303,13 @@ fn top_level_command_help_contract() {
         HelpCase {
             args: &["mv"],
             usage: "Usage: rc mv [OPTIONS] <SOURCE> <TARGET>",
-            expected_tokens: &["--recursive", "--continue-on-error", "--dry-run"],
+            expected_tokens: &[
+                "--recursive",
+                "--continue-on-error",
+                "--dry-run",
+                "--enc-s3",
+                "--enc-kms",
+            ],
         },
         HelpCase {
             args: &["rm"],
@@ -293,7 +329,7 @@ fn top_level_command_help_contract() {
         HelpCase {
             args: &["pipe"],
             usage: "Usage: rc pipe [OPTIONS] <TARGET>",
-            expected_tokens: &["--content-type", "--storage-class"],
+            expected_tokens: &["--content-type", "--storage-class", "--enc-s3", "--enc-kms"],
         },
         HelpCase {
             args: &["find"],

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -3284,6 +3284,261 @@ mod alias_operations {
     }
 }
 
+mod encryption_operations {
+    use super::*;
+
+    fn upload_text_object(config_dir: &std::path::Path, bucket: &str, key: &str, content: &str) {
+        let temp_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
+        std::fs::write(temp_file.path(), content).expect("Failed to write");
+
+        let output = run_rc(
+            &[
+                "cp",
+                temp_file
+                    .path()
+                    .to_str()
+                    .expect("temp file path is valid utf-8"),
+                &format!("test/{}/{}", bucket, key),
+            ],
+            config_dir,
+        );
+        assert!(
+            output.status.success(),
+            "Failed to upload {}: {}",
+            key,
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    #[test]
+    fn test_bucket_encryption_set_info_clear() {
+        let (config_dir, bucket_name) = match setup_with_alias("encryption") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        let output = run_rc(
+            &[
+                "bucket",
+                "encryption",
+                "set",
+                &format!("test/{}", bucket_name),
+                "--mode",
+                "sse-s3",
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            output.status.success(),
+            "Failed to set bucket encryption: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON output");
+        assert_eq!(json["bucket"], bucket_name);
+        assert_eq!(json["status"], "Configured");
+        assert_eq!(json["mode"], "SSE-S3");
+
+        let output = run_rc(
+            &[
+                "bucket",
+                "encryption",
+                "info",
+                &format!("test/{}", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            output.status.success(),
+            "Failed to get bucket encryption: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON output");
+        assert_eq!(json["bucket"], bucket_name);
+        assert_eq!(json["status"], "Configured");
+        assert_eq!(json["mode"], "SSE-S3");
+
+        let output = run_rc(
+            &[
+                "bucket",
+                "encryption",
+                "clear",
+                &format!("test/{}", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            output.status.success(),
+            "Failed to clear bucket encryption: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON output");
+        assert_eq!(json["bucket"], bucket_name);
+        assert_eq!(json["status"], "Cleared");
+
+        let output = run_rc(
+            &[
+                "bucket",
+                "encryption",
+                "info",
+                &format!("test/{}", bucket_name),
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            output.status.success(),
+            "Failed to verify cleared bucket encryption: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let json: serde_json::Value = serde_json::from_str(&stdout).expect("Invalid JSON output");
+        assert_eq!(json["bucket"], bucket_name);
+        assert_eq!(json["status"], "Not configured");
+        assert!(
+            json.get("mode").is_none(),
+            "mode should be omitted after clear"
+        );
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
+
+    #[test]
+    fn test_cp_enc_s3_upload() {
+        let (config_dir, bucket_name) = match setup_with_alias("cpencs3") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        let temp_file = tempfile::NamedTempFile::new().expect("Failed to create temp file");
+        std::fs::write(temp_file.path(), "encrypted cp payload").expect("Failed to write");
+
+        let target = format!("test/{}/cp-sse-s3.txt", bucket_name);
+        let output = run_rc(
+            &[
+                "cp",
+                temp_file
+                    .path()
+                    .to_str()
+                    .expect("temp file path is valid utf-8"),
+                &target,
+                "--enc-s3",
+                &target,
+                "--json",
+            ],
+            config_dir.path(),
+        );
+        assert!(
+            output.status.success(),
+            "Failed to upload via cp --enc-s3: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let output = run_rc(&["cat", &target], config_dir.path());
+        assert!(output.status.success(), "Failed to read cp --enc-s3 object");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout, "encrypted cp payload");
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
+
+    #[test]
+    fn test_mv_enc_s3_remote_copy() {
+        let (config_dir, bucket_name) = match setup_with_alias("mvencs3") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        upload_text_object(
+            config_dir.path(),
+            &bucket_name,
+            "source.txt",
+            "encrypted mv payload",
+        );
+
+        let source = format!("test/{}/source.txt", bucket_name);
+        let target = format!("test/{}/dest.txt", bucket_name);
+        let output = run_rc(
+            &["mv", &source, &target, "--enc-s3", &target, "--json"],
+            config_dir.path(),
+        );
+        assert!(
+            output.status.success(),
+            "Failed to move via mv --enc-s3: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let output = run_rc(
+            &["ls", &format!("test/{}/", bucket_name), "--json"],
+            config_dir.path(),
+        );
+        assert!(output.status.success(), "Failed to list moved objects");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            !stdout.contains("source.txt"),
+            "source object should be removed"
+        );
+        assert!(
+            stdout.contains("dest.txt"),
+            "destination object should exist"
+        );
+
+        let output = run_rc(&["cat", &target], config_dir.path());
+        assert!(output.status.success(), "Failed to read mv --enc-s3 object");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout, "encrypted mv payload");
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
+
+    #[test]
+    fn test_pipe_enc_s3_upload() {
+        let (config_dir, bucket_name) = match setup_with_alias("pipeencs3") {
+            Some(v) => v,
+            None => {
+                eprintln!("Skipping: S3 test config not available");
+                return;
+            }
+        };
+
+        let target = format!("test/{}/piped-sse-s3.txt", bucket_name);
+        let output = run_rc_with_stdin(
+            &["pipe", &target, "--enc-s3", "--json"],
+            config_dir.path(),
+            "encrypted pipe payload",
+        );
+        assert!(
+            output.status.success(),
+            "Failed to upload via pipe --enc-s3: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        let output = run_rc(&["cat", &target], config_dir.path());
+        assert!(
+            output.status.success(),
+            "Failed to read pipe --enc-s3 object"
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout, "encrypted pipe payload");
+
+        cleanup_bucket(config_dir.path(), &bucket_name);
+    }
+}
+
 mod option_behavior_operations {
     use super::*;
 

--- a/crates/core/src/encryption.rs
+++ b/crates/core/src/encryption.rs
@@ -1,0 +1,100 @@
+//! Bucket and object encryption domain types.
+
+use serde::{Deserialize, Serialize};
+
+/// Bucket default encryption configuration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BucketEncryption {
+    /// Use S3-managed keys.
+    SseS3,
+    /// Use KMS-managed keys with the provided key id.
+    SseKms { key_id: String },
+}
+
+/// Object write encryption request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ObjectEncryptionRequest {
+    /// Use S3-managed keys.
+    SseS3,
+    /// Use KMS-managed keys with the provided key id.
+    SseKms { key_id: String },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn bucket_encryption_serializes_sse_s3() {
+        let json = serde_json::to_value(&BucketEncryption::SseS3).expect("serialize sse-s3");
+        assert_eq!(json, json!("sse-s3"));
+    }
+
+    #[test]
+    fn bucket_encryption_serializes_sse_kms_key_id() {
+        let json = serde_json::to_value(&BucketEncryption::SseKms {
+            key_id: "kms-key".to_string(),
+        })
+        .expect("serialize sse-kms");
+        assert_eq!(json, json!({ "sse-kms": { "key_id": "kms-key" } }));
+    }
+
+    #[test]
+    fn bucket_encryption_round_trips_sse_s3() {
+        let value: BucketEncryption =
+            serde_json::from_value(json!("sse-s3")).expect("deserialize sse-s3");
+        assert_eq!(value, BucketEncryption::SseS3);
+    }
+
+    #[test]
+    fn bucket_encryption_round_trips_sse_kms() {
+        let value: BucketEncryption =
+            serde_json::from_value(json!({ "sse-kms": { "key_id": "kms-key" } }))
+                .expect("deserialize sse-kms");
+        assert_eq!(
+            value,
+            BucketEncryption::SseKms {
+                key_id: "kms-key".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn object_encryption_request_serializes_sse_s3() {
+        let json =
+            serde_json::to_value(&ObjectEncryptionRequest::SseS3).expect("serialize object sse-s3");
+        assert_eq!(json, json!("sse-s3"));
+    }
+
+    #[test]
+    fn object_encryption_request_serializes_sse_kms() {
+        let json = serde_json::to_value(&ObjectEncryptionRequest::SseKms {
+            key_id: "kms-key".to_string(),
+        })
+        .expect("serialize object sse-kms");
+        assert_eq!(json, json!({ "sse-kms": { "key_id": "kms-key" } }));
+    }
+
+    #[test]
+    fn object_encryption_request_round_trips_sse_s3() {
+        let value: ObjectEncryptionRequest =
+            serde_json::from_value(json!("sse-s3")).expect("deserialize object sse-s3");
+        assert_eq!(value, ObjectEncryptionRequest::SseS3);
+    }
+
+    #[test]
+    fn object_encryption_request_round_trips_sse_kms() {
+        let value: ObjectEncryptionRequest =
+            serde_json::from_value(json!({ "sse-kms": { "key_id": "kms-key" } }))
+                .expect("deserialize object sse-kms");
+        assert_eq!(
+            value,
+            ObjectEncryptionRequest::SseKms {
+                key_id: "kms-key".to_string(),
+            }
+        );
+    }
+}

--- a/crates/core/src/encryption.rs
+++ b/crates/core/src/encryption.rs
@@ -8,8 +8,11 @@ use serde::{Deserialize, Serialize};
 pub enum BucketEncryption {
     /// Use S3-managed keys.
     SseS3,
-    /// Use KMS-managed keys with the provided key id.
-    SseKms { key_id: String },
+    /// Use KMS-managed keys with an optional explicit key id.
+    SseKms {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        key_id: Option<String>,
+    },
 }
 
 /// Object write encryption request.
@@ -36,10 +39,17 @@ mod tests {
     #[test]
     fn bucket_encryption_serializes_sse_kms_key_id() {
         let json = serde_json::to_value(&BucketEncryption::SseKms {
-            key_id: "kms-key".to_string(),
+            key_id: Some("kms-key".to_string()),
         })
         .expect("serialize sse-kms");
         assert_eq!(json, json!({ "sse-kms": { "key_id": "kms-key" } }));
+    }
+
+    #[test]
+    fn bucket_encryption_serializes_sse_kms_without_key_id() {
+        let json = serde_json::to_value(&BucketEncryption::SseKms { key_id: None })
+            .expect("serialize sse-kms without key");
+        assert_eq!(json, json!({ "sse-kms": {} }));
     }
 
     #[test]
@@ -57,9 +67,16 @@ mod tests {
         assert_eq!(
             value,
             BucketEncryption::SseKms {
-                key_id: "kms-key".to_string(),
+                key_id: Some("kms-key".to_string()),
             }
         );
+    }
+
+    #[test]
+    fn bucket_encryption_round_trips_sse_kms_without_key_id() {
+        let value: BucketEncryption = serde_json::from_value(json!({ "sse-kms": {} }))
+            .expect("deserialize sse-kms without key");
+        assert_eq!(value, BucketEncryption::SseKms { key_id: None });
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod admin;
 pub mod alias;
 pub mod config;
 pub mod cors;
+pub mod encryption;
 pub mod error;
 pub mod lifecycle;
 pub mod path;
@@ -27,6 +28,7 @@ pub use alias::{
 };
 pub use config::{Config, ConfigManager};
 pub use cors::{CorsConfiguration, CorsRule};
+pub use encryption::{BucketEncryption, ObjectEncryptionRequest};
 pub use error::{Error, Result};
 pub use lifecycle::{
     LifecycleConfiguration, LifecycleExpiration, LifecycleRule, LifecycleRuleStatus,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::AsyncWrite;
 
 use crate::cors::CorsRule;
+use crate::encryption::{BucketEncryption, ObjectEncryptionRequest};
 use crate::error::Result;
 use crate::lifecycle::LifecycleRule;
 use crate::path::RemotePath;
@@ -282,6 +283,7 @@ pub trait ObjectStore: Send + Sync {
         path: &RemotePath,
         data: Vec<u8>,
         content_type: Option<&str>,
+        encryption: Option<&ObjectEncryptionRequest>,
     ) -> Result<ObjectInfo>;
 
     /// Delete an object
@@ -291,7 +293,12 @@ pub trait ObjectStore: Send + Sync {
     async fn delete_objects(&self, bucket: &str, keys: Vec<String>) -> Result<Vec<String>>;
 
     /// Copy object within S3 (server-side copy)
-    async fn copy_object(&self, src: &RemotePath, dst: &RemotePath) -> Result<ObjectInfo>;
+    async fn copy_object(
+        &self,
+        src: &RemotePath,
+        dst: &RemotePath,
+        encryption: Option<&ObjectEncryptionRequest>,
+    ) -> Result<ObjectInfo>;
 
     /// Generate a presigned URL for an object
     async fn presign_get(&self, path: &RemotePath, expires_secs: u64) -> Result<String>;
@@ -311,6 +318,16 @@ pub trait ObjectStore: Send + Sync {
 
     /// Set bucket versioning status
     async fn set_versioning(&self, bucket: &str, enabled: bool) -> Result<()>;
+
+    /// Get bucket default encryption. Returns None when encryption is not configured.
+    async fn get_bucket_encryption(&self, bucket: &str) -> Result<Option<BucketEncryption>>;
+
+    /// Set bucket default encryption.
+    async fn set_bucket_encryption(&self, bucket: &str, encryption: BucketEncryption)
+    -> Result<()>;
+
+    /// Delete bucket default encryption.
+    async fn delete_bucket_encryption(&self, bucket: &str) -> Result<()>;
 
     /// List object versions
     async fn list_object_versions(

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -25,10 +25,10 @@ use bytes::Bytes;
 use jiff::Timestamp;
 use quick_xml::de::from_str as from_xml_str;
 use rc_core::{
-    Alias, BucketNotification, Capabilities, CorsRule, Error, LifecycleRule, ListOptions,
-    ListResult, NotificationTarget, ObjectInfo, ObjectStore, ObjectVersion,
-    ObjectVersionListResult, RemotePath, ReplicationConfiguration, RequestHeader, Result,
-    SelectOptions, global_request_headers,
+    Alias, BucketEncryption, BucketNotification, Capabilities, CorsRule, Error, LifecycleRule,
+    ListOptions, ListResult, NotificationTarget, ObjectEncryptionRequest, ObjectInfo, ObjectStore,
+    ObjectVersion, ObjectVersionListResult, RemotePath, ReplicationConfiguration, RequestHeader,
+    Result, SelectOptions, global_request_headers,
 };
 use reqwest::Method;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
@@ -360,6 +360,110 @@ fn sdk_cors_rule_to_core(rule: &aws_sdk_s3::types::CorsRule) -> CorsRule {
         allowed_headers: normalize_optional_strings(Some(rule.allowed_headers().to_vec())),
         expose_headers: normalize_optional_strings(Some(rule.expose_headers().to_vec())),
         max_age_seconds: rule.max_age_seconds(),
+    }
+}
+
+fn sdk_bucket_encryption_to_core(
+    value: &aws_sdk_s3::types::ServerSideEncryptionByDefault,
+) -> Result<BucketEncryption> {
+    match value.sse_algorithm() {
+        aws_sdk_s3::types::ServerSideEncryption::Aes256 => Ok(BucketEncryption::SseS3),
+        aws_sdk_s3::types::ServerSideEncryption::AwsKms => {
+            let key_id = value.kms_master_key_id().ok_or_else(|| {
+                Error::General("bucket encryption rule missing KMS key id".to_string())
+            })?;
+            Ok(BucketEncryption::SseKms {
+                key_id: key_id.to_string(),
+            })
+        }
+        other => Err(Error::General(format!(
+            "unsupported bucket encryption algorithm: {}",
+            other.as_str()
+        ))),
+    }
+}
+
+fn is_missing_bucket_encryption_error(error_text: &str) -> bool {
+    let normalized = error_text.to_ascii_lowercase();
+    normalized.contains("serversideencryptionconfigurationnotfounderror")
+        || normalized.contains("nosuchbucketencryption")
+        || normalized.contains("encryption configuration was not found")
+}
+
+fn is_missing_bucket_encryption_response(
+    error_code: Option<&str>,
+    status_code: Option<u16>,
+    error_text: &str,
+) -> bool {
+    let error_code = error_code.map(|code| code.to_ascii_lowercase());
+    if matches!(
+        error_code.as_deref(),
+        Some("serversideencryptionconfigurationnotfounderror" | "nosuchbucketencryption")
+    ) {
+        return true;
+    }
+
+    if !is_missing_bucket_encryption_error(error_text) {
+        return false;
+    }
+
+    status_code.is_none_or(|status| status == 404)
+}
+
+fn core_bucket_encryption_to_sdk(
+    value: &BucketEncryption,
+) -> aws_sdk_s3::types::ServerSideEncryptionConfiguration {
+    let encryption_by_default = match value {
+        BucketEncryption::SseS3 => aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+            .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::Aes256)
+            .build()
+            .expect("sse-s3 bucket encryption configuration is valid"),
+        BucketEncryption::SseKms { key_id } => {
+            aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+                .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+                .kms_master_key_id(key_id)
+                .build()
+                .expect("sse-kms bucket encryption configuration is valid")
+        }
+    };
+
+    let rule = aws_sdk_s3::types::ServerSideEncryptionRule::builder()
+        .apply_server_side_encryption_by_default(encryption_by_default)
+        .build();
+
+    aws_sdk_s3::types::ServerSideEncryptionConfiguration::builder()
+        .rules(rule)
+        .build()
+        .expect("bucket encryption configuration requires one rule")
+}
+
+fn apply_object_encryption_to_put_request(
+    request: aws_sdk_s3::operation::put_object::builders::PutObjectFluentBuilder,
+    encryption: Option<&ObjectEncryptionRequest>,
+) -> aws_sdk_s3::operation::put_object::builders::PutObjectFluentBuilder {
+    match encryption {
+        Some(ObjectEncryptionRequest::SseS3) => {
+            request.server_side_encryption(aws_sdk_s3::types::ServerSideEncryption::Aes256)
+        }
+        Some(ObjectEncryptionRequest::SseKms { key_id }) => request
+            .server_side_encryption(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+            .ssekms_key_id(key_id),
+        None => request,
+    }
+}
+
+fn apply_object_encryption_to_copy_request(
+    request: aws_sdk_s3::operation::copy_object::builders::CopyObjectFluentBuilder,
+    encryption: Option<&ObjectEncryptionRequest>,
+) -> aws_sdk_s3::operation::copy_object::builders::CopyObjectFluentBuilder {
+    match encryption {
+        Some(ObjectEncryptionRequest::SseS3) => {
+            request.server_side_encryption(aws_sdk_s3::types::ServerSideEncryption::Aes256)
+        }
+        Some(ObjectEncryptionRequest::SseKms { key_id }) => request
+            .server_side_encryption(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+            .ssekms_key_id(key_id),
+        None => request,
     }
 }
 
@@ -1478,18 +1582,21 @@ impl S3Client {
         file_path: &std::path::Path,
         content_type: Option<&str>,
         file_size: u64,
+        encryption: Option<&ObjectEncryptionRequest>,
     ) -> Result<ObjectInfo> {
         let data = tokio::fs::read(file_path)
             .await
             .map_err(|e| Error::General(format!("read file '{}': {e}", file_path.display())))?;
         let body = aws_sdk_s3::primitives::ByteStream::from(data);
 
-        let mut request = self
-            .inner
-            .put_object()
-            .bucket(&path.bucket)
-            .key(&path.key)
-            .body(body);
+        let mut request = apply_object_encryption_to_put_request(
+            self.inner
+                .put_object()
+                .bucket(&path.bucket)
+                .key(&path.key)
+                .body(body),
+            encryption,
+        );
 
         if let Some(ct) = content_type {
             request = request.content_type(ct);
@@ -1526,6 +1633,7 @@ impl S3Client {
         file_path: &std::path::Path,
         content_type: Option<&str>,
         file_size: u64,
+        encryption: Option<&ObjectEncryptionRequest>,
         on_progress: impl Fn(u64) + Send,
     ) -> Result<ObjectInfo> {
         use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
@@ -1542,6 +1650,15 @@ impl S3Client {
             .create_multipart_upload()
             .bucket(&path.bucket)
             .key(&path.key);
+
+        create_request = match encryption {
+            Some(ObjectEncryptionRequest::SseS3) => create_request
+                .server_side_encryption(aws_sdk_s3::types::ServerSideEncryption::Aes256),
+            Some(ObjectEncryptionRequest::SseKms { key_id }) => create_request
+                .server_side_encryption(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+                .ssekms_key_id(key_id),
+            None => create_request,
+        };
 
         if let Some(ct) = content_type {
             create_request = create_request.content_type(ct);
@@ -1671,6 +1788,7 @@ impl S3Client {
         path: &RemotePath,
         file_path: &std::path::Path,
         content_type: Option<&str>,
+        encryption: Option<&ObjectEncryptionRequest>,
         on_progress: impl Fn(u64) + Send,
     ) -> Result<ObjectInfo> {
         let metadata = tokio::fs::metadata(file_path).await.map_err(|e| {
@@ -1690,12 +1808,19 @@ impl S3Client {
                 file_path,
                 content_type,
                 file_size,
+                encryption,
                 on_progress,
             )
             .await
         } else {
-            self.put_object_single_part_from_path(path, file_path, content_type, file_size)
-                .await
+            self.put_object_single_part_from_path(
+                path,
+                file_path,
+                content_type,
+                file_size,
+                encryption,
+            )
+            .await
         }
     }
 }
@@ -1944,16 +2069,19 @@ impl ObjectStore for S3Client {
         path: &RemotePath,
         data: Vec<u8>,
         content_type: Option<&str>,
+        encryption: Option<&ObjectEncryptionRequest>,
     ) -> Result<ObjectInfo> {
         let size = data.len() as i64;
         let body = aws_sdk_s3::primitives::ByteStream::from(data);
 
-        let mut request = self
-            .inner
-            .put_object()
-            .bucket(&path.bucket)
-            .key(&path.key)
-            .body(body);
+        let mut request = apply_object_encryption_to_put_request(
+            self.inner
+                .put_object()
+                .bucket(&path.bucket)
+                .key(&path.key)
+                .body(body),
+            encryption,
+        );
 
         if let Some(ct) = content_type {
             request = request.content_type(ct);
@@ -1983,26 +2111,33 @@ impl ObjectStore for S3Client {
             .await
     }
 
-    async fn copy_object(&self, src: &RemotePath, dst: &RemotePath) -> Result<ObjectInfo> {
+    async fn copy_object(
+        &self,
+        src: &RemotePath,
+        dst: &RemotePath,
+        encryption: Option<&ObjectEncryptionRequest>,
+    ) -> Result<ObjectInfo> {
         // Build copy source: bucket/key
         let copy_source = format!("{}/{}", src.bucket, src.key);
 
-        let response = self
-            .inner
-            .copy_object()
-            .copy_source(&copy_source)
-            .bucket(&dst.bucket)
-            .key(&dst.key)
-            .send()
-            .await
-            .map_err(|e| {
-                let err_str = e.to_string();
-                if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
-                    Error::NotFound(src.to_string())
-                } else {
-                    Error::Network(err_str)
-                }
-            })?;
+        let response = apply_object_encryption_to_copy_request(
+            self.inner
+                .copy_object()
+                .copy_source(&copy_source)
+                .bucket(&dst.bucket)
+                .key(&dst.key),
+            encryption,
+        )
+        .send()
+        .await
+        .map_err(|e| {
+            let err_str = e.to_string();
+            if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
+                Error::NotFound(src.to_string())
+            } else {
+                Error::Network(err_str)
+            }
+        })?;
 
         // Get size from head_object since copy doesn't return it
         let info = self.head_object(dst).await?;
@@ -2099,6 +2234,97 @@ impl ObjectStore for S3Client {
             .map_err(|e| Error::General(format!("set_versioning: {e}")))?;
 
         Ok(())
+    }
+
+    async fn get_bucket_encryption(&self, bucket: &str) -> Result<Option<BucketEncryption>> {
+        let response = match self
+            .inner
+            .get_bucket_encryption()
+            .bucket(bucket)
+            .send()
+            .await
+        {
+            Ok(response) => response,
+            Err(error) => {
+                let error_text = Self::format_sdk_error(&error);
+                let missing_config =
+                    if let aws_sdk_s3::error::SdkError::ServiceError(service_err) = &error {
+                        is_missing_bucket_encryption_response(
+                            service_err.err().code(),
+                            Some(service_err.raw().status().as_u16()),
+                            &error_text,
+                        )
+                    } else {
+                        is_missing_bucket_encryption_response(None, None, &error_text)
+                    };
+                if missing_config {
+                    return Ok(None);
+                }
+                return Err(Error::General(format!(
+                    "get_bucket_encryption: {error_text}"
+                )));
+            }
+        };
+
+        let rule = response
+            .server_side_encryption_configuration()
+            .and_then(|config| config.rules().first())
+            .and_then(|rule| rule.apply_server_side_encryption_by_default())
+            .ok_or_else(|| {
+                Error::General("get_bucket_encryption: missing bucket encryption rule".to_string())
+            })?;
+
+        sdk_bucket_encryption_to_core(rule).map(Some)
+    }
+
+    async fn set_bucket_encryption(
+        &self,
+        bucket: &str,
+        encryption: BucketEncryption,
+    ) -> Result<()> {
+        let configuration = core_bucket_encryption_to_sdk(&encryption);
+
+        self.inner
+            .put_bucket_encryption()
+            .bucket(bucket)
+            .server_side_encryption_configuration(configuration)
+            .send()
+            .await
+            .map_err(|e| Error::General(format!("set_bucket_encryption: {e}")))?;
+
+        Ok(())
+    }
+
+    async fn delete_bucket_encryption(&self, bucket: &str) -> Result<()> {
+        match self
+            .inner
+            .delete_bucket_encryption()
+            .bucket(bucket)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(error) => {
+                let error_text = Self::format_sdk_error(&error);
+                let missing_config =
+                    if let aws_sdk_s3::error::SdkError::ServiceError(service_err) = &error {
+                        is_missing_bucket_encryption_response(
+                            service_err.err().code(),
+                            Some(service_err.raw().status().as_u16()),
+                            &error_text,
+                        )
+                    } else {
+                        is_missing_bucket_encryption_response(None, None, &error_text)
+                    };
+                if missing_config {
+                    Ok(())
+                } else {
+                    Err(Error::General(format!(
+                        "delete_bucket_encryption: {error_text}"
+                    )))
+                }
+            }
+        }
     }
 
     async fn list_object_versions(
@@ -3411,6 +3637,94 @@ mod tests {
     }
 
     #[test]
+    fn bucket_encryption_rule_maps_sse_s3() {
+        let value = aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+            .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::Aes256)
+            .build()
+            .expect("build rule");
+
+        let encryption = sdk_bucket_encryption_to_core(&value).expect("map rule");
+        assert_eq!(encryption, BucketEncryption::SseS3);
+    }
+
+    #[test]
+    fn bucket_encryption_rule_maps_sse_kms() {
+        let value = aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+            .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+            .kms_master_key_id("kms-key")
+            .build()
+            .expect("build rule");
+
+        let encryption = sdk_bucket_encryption_to_core(&value).expect("map rule");
+        assert_eq!(
+            encryption,
+            BucketEncryption::SseKms {
+                key_id: "kms-key".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn bucket_encryption_rule_missing_kms_key_errors() {
+        let value = aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+            .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
+            .build()
+            .expect("build rule");
+
+        match sdk_bucket_encryption_to_core(&value) {
+            Err(Error::General(message)) => {
+                assert!(message.contains("missing KMS key id"));
+            }
+            other => panic!("expected missing KMS key error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_bucket_encryption_errors_are_detected() {
+        assert!(is_missing_bucket_encryption_error(
+            "ServerSideEncryptionConfigurationNotFoundError"
+        ));
+        assert!(is_missing_bucket_encryption_error(
+            "The server-side encryption configuration was not found"
+        ));
+        assert!(!is_missing_bucket_encryption_error("AccessDenied"));
+    }
+
+    #[test]
+    fn missing_bucket_encryption_response_detects_code_and_status() {
+        assert!(is_missing_bucket_encryption_response(
+            Some("ServerSideEncryptionConfigurationNotFoundError"),
+            Some(404),
+            "service error"
+        ));
+        assert!(is_missing_bucket_encryption_response(
+            Some("NoSuchBucketEncryption"),
+            Some(404),
+            "service error"
+        ));
+        assert!(is_missing_bucket_encryption_response(
+            None,
+            Some(404),
+            "The server-side encryption configuration was not found"
+        ));
+        assert!(is_missing_bucket_encryption_response(
+            None,
+            None,
+            "The server-side encryption configuration was not found"
+        ));
+        assert!(!is_missing_bucket_encryption_response(
+            Some("AccessDenied"),
+            Some(403),
+            "access denied"
+        ));
+        assert!(!is_missing_bucket_encryption_response(
+            None,
+            Some(500),
+            "The server-side encryption configuration was not found"
+        ));
+    }
+
+    #[test]
     fn sdk_cors_rule_to_core_drops_empty_optional_headers() {
         let sdk_rule = aws_sdk_s3::types::CorsRule::builder()
             .allowed_origins("https://app.example.com")
@@ -3482,6 +3796,162 @@ mod tests {
         assert!(body.contains("<AllowedHeader>Authorization</AllowedHeader>"));
         assert!(body.contains("<ExposeHeader>ETag</ExposeHeader>"));
         assert!(body.contains("<MaxAgeSeconds>600</MaxAgeSeconds>"));
+    }
+
+    #[tokio::test]
+    async fn get_bucket_encryption_sends_expected_request_shape() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Rule>
+    <ApplyServerSideEncryptionByDefault>
+      <SSEAlgorithm>AES256</SSEAlgorithm>
+    </ApplyServerSideEncryptionByDefault>
+  </Rule>
+</ServerSideEncryptionConfiguration>"#,
+            ))
+            .expect("build get bucket encryption response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        let encryption = client
+            .get_bucket_encryption("bucket")
+            .await
+            .expect("get bucket encryption");
+
+        assert_eq!(encryption, Some(BucketEncryption::SseS3));
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.method(), http::Method::GET);
+        assert!(
+            request.uri().to_string().contains("?encryption"),
+            "expected bucket encryption subresource in URI: {}",
+            request.uri()
+        );
+    }
+
+    #[tokio::test]
+    async fn get_bucket_encryption_missing_configuration_returns_none() {
+        let response = http::Response::builder()
+            .status(404)
+            .header(
+                "x-amz-error-code",
+                "ServerSideEncryptionConfigurationNotFoundError",
+            )
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>ServerSideEncryptionConfigurationNotFoundError</Code>
+  <Message>The server-side encryption configuration was not found</Message>
+</Error>"#,
+            ))
+            .expect("build missing bucket encryption response");
+        let (client, _) = test_s3_client(Some(response));
+
+        let encryption = client
+            .get_bucket_encryption("bucket")
+            .await
+            .expect("missing bucket encryption should map to None");
+
+        assert_eq!(encryption, None);
+    }
+
+    #[tokio::test]
+    async fn get_bucket_encryption_missing_rule_errors() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Rule />
+</ServerSideEncryptionConfiguration>"#,
+            ))
+            .expect("build malformed bucket encryption response");
+        let (client, _) = test_s3_client(Some(response));
+
+        match client.get_bucket_encryption("bucket").await {
+            Err(Error::General(message)) => {
+                assert!(message.contains("missing bucket encryption rule"))
+            }
+            other => panic!("expected missing rule error, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_bucket_encryption_sends_expected_request_shape() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(""))
+            .expect("build put bucket encryption response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        client
+            .set_bucket_encryption(
+                "bucket",
+                BucketEncryption::SseKms {
+                    key_id: "kms-key".to_string(),
+                },
+            )
+            .await
+            .expect("set bucket encryption");
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.method(), http::Method::PUT);
+        assert!(
+            request.uri().to_string().contains("?encryption"),
+            "expected bucket encryption subresource in URI: {}",
+            request.uri()
+        );
+
+        let body = request.body().bytes().expect("request body bytes");
+        let body = std::str::from_utf8(body).expect("request body is utf8");
+        assert!(body.contains("<ServerSideEncryptionConfiguration"));
+        assert!(body.contains("<SSEAlgorithm>aws:kms</SSEAlgorithm>"));
+        assert!(body.contains("<KMSMasterKeyID>kms-key</KMSMasterKeyID>"));
+    }
+
+    #[tokio::test]
+    async fn delete_bucket_encryption_missing_configuration_is_successful() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NoSuchBucketEncryption")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>NoSuchBucketEncryption</Code>
+  <Message>The server-side encryption configuration was not found</Message>
+</Error>"#,
+            ))
+            .expect("build missing bucket encryption delete response");
+        let (client, _) = test_s3_client(Some(response));
+
+        client
+            .delete_bucket_encryption("bucket")
+            .await
+            .expect("missing bucket encryption should be treated as successful delete");
+    }
+
+    #[tokio::test]
+    async fn delete_bucket_encryption_sends_expected_request_shape() {
+        let response = http::Response::builder()
+            .status(204)
+            .body(SdkBody::from(""))
+            .expect("build delete bucket encryption response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+
+        client
+            .delete_bucket_encryption("bucket")
+            .await
+            .expect("delete bucket encryption");
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.method(), http::Method::DELETE);
+        assert!(
+            request.uri().to_string().contains("?encryption"),
+            "expected bucket encryption subresource in URI: {}",
+            request.uri()
+        );
     }
 
     #[test]
@@ -3804,6 +4274,68 @@ mod tests {
 
         let request = request_receiver.expect_request();
         assert!(request.headers().get("x-rustfs-force-delete").is_none());
+    }
+
+    #[tokio::test]
+    async fn put_object_applies_sse_s3_headers() {
+        let (client, request_receiver) = test_s3_client(None);
+        let path = RemotePath::new("test", "bucket", "file.txt");
+
+        client
+            .put_object(
+                &path,
+                b"payload".to_vec(),
+                Some("text/plain"),
+                Some(&ObjectEncryptionRequest::SseS3),
+            )
+            .await
+            .expect("put object");
+
+        let request = request_receiver.expect_request();
+        assert_eq!(
+            request.headers().get("x-amz-server-side-encryption"),
+            Some("AES256")
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_object_applies_sse_kms_headers() {
+        let response = http::Response::builder()
+            .status(500)
+            .header("x-amz-error-code", "InternalError")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>Something went wrong.</Message>
+</Error>"#,
+            ))
+            .expect("build copy object response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+        let src = RemotePath::new("test", "bucket", "src.txt");
+        let dst = RemotePath::new("test", "bucket", "dst.txt");
+
+        let _ = client
+            .copy_object(
+                &src,
+                &dst,
+                Some(&ObjectEncryptionRequest::SseKms {
+                    key_id: "kms-key".to_string(),
+                }),
+            )
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert_eq!(
+            request.headers().get("x-amz-server-side-encryption"),
+            Some("aws:kms")
+        );
+        assert_eq!(
+            request
+                .headers()
+                .get("x-amz-server-side-encryption-aws-kms-key-id"),
+            Some("kms-key")
+        );
     }
 
     #[tokio::test]

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -368,14 +368,9 @@ fn sdk_bucket_encryption_to_core(
 ) -> Result<BucketEncryption> {
     match value.sse_algorithm() {
         aws_sdk_s3::types::ServerSideEncryption::Aes256 => Ok(BucketEncryption::SseS3),
-        aws_sdk_s3::types::ServerSideEncryption::AwsKms => {
-            let key_id = value.kms_master_key_id().ok_or_else(|| {
-                Error::General("bucket encryption rule missing KMS key id".to_string())
-            })?;
-            Ok(BucketEncryption::SseKms {
-                key_id: key_id.to_string(),
-            })
-        }
+        aws_sdk_s3::types::ServerSideEncryption::AwsKms => Ok(BucketEncryption::SseKms {
+            key_id: value.kms_master_key_id().map(ToString::to_string),
+        }),
         other => Err(Error::General(format!(
             "unsupported bucket encryption algorithm: {}",
             other.as_str()
@@ -419,9 +414,12 @@ fn core_bucket_encryption_to_sdk(
             .build()
             .expect("sse-s3 bucket encryption configuration is valid"),
         BucketEncryption::SseKms { key_id } => {
-            aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
-                .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
-                .kms_master_key_id(key_id)
+            let mut builder = aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
+                .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms);
+            if let Some(key_id) = key_id {
+                builder = builder.kms_master_key_id(key_id);
+            }
+            builder
                 .build()
                 .expect("sse-kms bucket encryption configuration is valid")
         }
@@ -3659,24 +3657,20 @@ mod tests {
         assert_eq!(
             encryption,
             BucketEncryption::SseKms {
-                key_id: "kms-key".to_string(),
+                key_id: Some("kms-key".to_string()),
             }
         );
     }
 
     #[test]
-    fn bucket_encryption_rule_missing_kms_key_errors() {
+    fn bucket_encryption_rule_without_kms_key_maps_to_default_kms() {
         let value = aws_sdk_s3::types::ServerSideEncryptionByDefault::builder()
             .sse_algorithm(aws_sdk_s3::types::ServerSideEncryption::AwsKms)
             .build()
             .expect("build rule");
 
-        match sdk_bucket_encryption_to_core(&value) {
-            Err(Error::General(message)) => {
-                assert!(message.contains("missing KMS key id"));
-            }
-            other => panic!("expected missing KMS key error, got {other:?}"),
-        }
+        let encryption = sdk_bucket_encryption_to_core(&value).expect("map default kms rule");
+        assert_eq!(encryption, BucketEncryption::SseKms { key_id: None });
     }
 
     #[test]
@@ -3890,7 +3884,7 @@ mod tests {
             .set_bucket_encryption(
                 "bucket",
                 BucketEncryption::SseKms {
-                    key_id: "kms-key".to_string(),
+                    key_id: Some("kms-key".to_string()),
                 },
             )
             .await

--- a/docs/reference/rc/README.md
+++ b/docs/reference/rc/README.md
@@ -12,7 +12,7 @@ For installation and quick-start usage, see the [project README](../../../README
 | Bucket workflows | [`rc bucket`](bucket.md) | `rc ls`, `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, `rc replicate` |
 | Object workflows | [`rc object`](object.md) | `rc ls`, `rc cp`, `rc mv`, `rc rm`, `rc cat`, `rc head`, `rc stat`, `rc find`, `rc tree`, `rc share` |
 | Administrative workflows | [`rc admin`](admin.md) | none |
-| Encryption workflows | [`rc encryption`](encryption.md) | none |
+| Encryption guide | [`Encryption workflows`](encryption.md) | `rc bucket encryption`, `rc cp --enc-*`, `rc mv --enc-*`, `rc pipe --enc-*` |
 | Streaming upload | [`rc pipe`](pipe.md) | none |
 | Difference reports | [`rc diff`](diff.md) | none |
 | Mirroring | [`rc mirror`](mirror.md) | none |

--- a/docs/reference/rc/README.md
+++ b/docs/reference/rc/README.md
@@ -12,6 +12,7 @@ For installation and quick-start usage, see the [project README](../../../README
 | Bucket workflows | [`rc bucket`](bucket.md) | `rc ls`, `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, `rc replicate` |
 | Object workflows | [`rc object`](object.md) | `rc ls`, `rc cp`, `rc mv`, `rc rm`, `rc cat`, `rc head`, `rc stat`, `rc find`, `rc tree`, `rc share` |
 | Administrative workflows | [`rc admin`](admin.md) | none |
+| Encryption workflows | [`rc encryption`](encryption.md) | none |
 | Streaming upload | [`rc pipe`](pipe.md) | none |
 | Difference reports | [`rc diff`](diff.md) | none |
 | Mirroring | [`rc mirror`](mirror.md) | none |

--- a/docs/reference/rc/bucket.md
+++ b/docs/reference/rc/bucket.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-The `rc bucket` operation is the preferred noun-first entry point for bucket-oriented workflows. It groups bucket listing, creation, deletion, notification, CORS, versioning, quota, anonymous access, lifecycle, and replication operations under one command family.
+The `rc bucket` operation is the preferred noun-first entry point for bucket-oriented workflows. It groups bucket listing, creation, deletion, notification, CORS, encryption, versioning, quota, anonymous access, lifecycle, and replication operations under one command family.
 
 ## Syntax
 
@@ -13,6 +13,7 @@ rc bucket create [OPTIONS] <ALIAS/BUCKET>
 rc bucket remove [OPTIONS] <ALIAS/BUCKET>
 rc bucket event <add|list|remove> ...
 rc bucket cors <list|set|remove> ...
+rc bucket encryption <set|info|clear> ...
 rc bucket version <enable|suspend|info|list> ...
 rc bucket quota <set|info|clear> ...
 rc bucket anonymous <set|set-json|get|get-json|list|links> ...
@@ -29,6 +30,7 @@ rc bucket replication <add|update|list|status|remove|export|import> ...
 | `remove` | Remove a bucket. |
 | `event` | Manage bucket notification rules. |
 | `cors` | Manage bucket CORS rules. |
+| `encryption` | Manage bucket default encryption. |
 | `version` | Manage bucket versioning and object versions. |
 | `quota` | Manage bucket quota. |
 | `anonymous` | Manage anonymous bucket or prefix access. |
@@ -75,6 +77,12 @@ Set CORS from an XML or JSON file:
 rc bucket cors set local/archive cors.xml
 ```
 
+Inspect default bucket encryption:
+
+```bash
+rc bucket encryption info local/archive
+```
+
 Check replication status:
 
 ```bash
@@ -83,7 +91,7 @@ rc bucket replication status local/archive
 
 ## Behavior
 
-Prefer `rc bucket ...` for new scripts. Legacy commands such as `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, and `rc replicate` remain available and delegate to the same implementations.
+Prefer `rc bucket ...` for new scripts. Legacy commands such as `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, and `rc replicate` remain available and delegate to the same implementations. For encryption-specific behavior and examples, see [`rc encryption`](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/bucket.md
+++ b/docs/reference/rc/bucket.md
@@ -83,6 +83,12 @@ Inspect default bucket encryption:
 rc bucket encryption info local/archive
 ```
 
+Set a bucket default to `SSE-KMS`:
+
+```bash
+rc bucket encryption set local/archive --mode sse-kms --key-id alias/archive-key
+```
+
 Check replication status:
 
 ```bash
@@ -91,7 +97,9 @@ rc bucket replication status local/archive
 
 ## Behavior
 
-Prefer `rc bucket ...` for new scripts. Legacy commands such as `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, and `rc replicate` remain available and delegate to the same implementations. For encryption-specific behavior and examples, see [`rc encryption`](encryption.md).
+Prefer `rc bucket ...` for new scripts. Legacy commands such as `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, and `rc replicate` remain available and delegate to the same implementations.
+
+`rc bucket encryption set`, `info`, and `clear` manage only the bucket default for future writes. They do not rewrite, decrypt, or re-encrypt existing objects in the bucket. For object-level encryption flags and more detailed examples, see [Encryption workflows](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/cp.md
+++ b/docs/reference/rc/cp.md
@@ -51,11 +51,22 @@ Upload with explicit destination encryption:
 rc cp ./report.json local/archive/report.json --enc-s3 local/archive/report.json
 ```
 
+Recursively upload a directory and apply one KMS key to the remote target prefix:
+
+```bash
+rc cp ./reports/ local/archive/ --recursive --enc-kms local/archive/=alias/archive-key
+```
+
 ## Behavior
 
 The last path is the target. Sources can mix local and remote paths only where the command can infer a valid copy direction. S3-to-S3 copies are limited to paths under the same alias in the current implementation; use `rc mirror` for remote-to-remote synchronization across aliases. Use trailing slashes consistently when copying directory-like prefixes.
 
-Destination encryption flags apply only to remote writes and only when the flag target matches the command target exactly. The current implementation supports `SSE-S3` and `SSE-KMS`. For shared encryption rules across commands, see [`rc encryption`](encryption.md).
+Destination encryption flags apply only to remote writes. On `rc cp`, the selector in `--enc-s3` or `--enc-kms` must match the command destination exactly:
+
+- For a single-object write, use the full remote object path.
+- For a recursive upload or remote-to-remote copy, use the same remote prefix passed as `TARGET`.
+
+The current implementation supports `SSE-S3` and `SSE-KMS`. It does not support `SSE-C`, repeated encryption selectors, or MinIO `mc`-style prefix fan-out matching beyond the exact destination argument for the current command. For shared encryption rules across commands, see [Encryption workflows](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/cp.md
+++ b/docs/reference/rc/cp.md
@@ -22,6 +22,8 @@ rc [GLOBAL OPTIONS] cp [OPTIONS] <SOURCE> <TARGET>
 | `--preserve` | Preserve applicable metadata. |
 | `--content-type` | Set object content type for uploads. |
 | `--storage-class` | Set destination storage class for uploads where supported. |
+| `--enc-s3 <TARGET>` | Apply `SSE-S3` to the named remote destination write. |
+| `--enc-kms <TARGET>=<KMS_KEY_ID>` | Apply `SSE-KMS` to the named remote destination write. |
 
 ## Examples
 
@@ -43,9 +45,17 @@ Copy between buckets on the same alias:
 rc cp local/reports/summary.json local/archive/summary.json
 ```
 
+Upload with explicit destination encryption:
+
+```bash
+rc cp ./report.json local/archive/report.json --enc-s3 local/archive/report.json
+```
+
 ## Behavior
 
 The last path is the target. Sources can mix local and remote paths only where the command can infer a valid copy direction. S3-to-S3 copies are limited to paths under the same alias in the current implementation; use `rc mirror` for remote-to-remote synchronization across aliases. Use trailing slashes consistently when copying directory-like prefixes.
+
+Destination encryption flags apply only to remote writes and only when the flag target matches the command target exactly. The current implementation supports `SSE-S3` and `SSE-KMS`. For shared encryption rules across commands, see [`rc encryption`](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/encryption.md
+++ b/docs/reference/rc/encryption.md
@@ -1,0 +1,93 @@
+# rc encryption
+
+## Purpose
+
+`rc encryption` documents the bucket and object encryption workflows exposed by `rc`. Bucket default encryption is managed through the noun-first `rc bucket encryption` command family. Object write encryption is configured per destination write on `rc cp`, `rc mv`, and `rc pipe`.
+
+## Syntax
+
+```bash
+rc bucket encryption set <ALIAS/BUCKET> --mode sse-s3
+rc bucket encryption set <ALIAS/BUCKET> --mode sse-kms --key-id <KMS_KEY_ID>
+rc bucket encryption info <ALIAS/BUCKET>
+rc bucket encryption clear <ALIAS/BUCKET>
+
+rc cp <SOURCE> <TARGET> --enc-s3 <TARGET>
+rc cp <SOURCE> <TARGET> --enc-kms <TARGET>=<KMS_KEY_ID>
+
+rc mv <SOURCE> <TARGET> --enc-s3 <TARGET>
+rc mv <SOURCE> <TARGET> --enc-kms <TARGET>=<KMS_KEY_ID>
+
+rc pipe <ALIAS/BUCKET/KEY> --enc-s3
+rc pipe <ALIAS/BUCKET/KEY> --enc-kms <KMS_KEY_ID>
+```
+
+## Modes
+
+| Mode | Meaning |
+| --- | --- |
+| `sse-s3` | Use S3-managed keys (`AES256`). |
+| `sse-kms` | Use KMS-managed keys with the provided key identifier. |
+
+## Bucket Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `ALIAS/BUCKET` | Bucket whose default encryption is managed. Object paths are invalid here. |
+| `--mode` | Required for `set`. Accepts `sse-s3` or `sse-kms`. |
+| `--key-id` | Required with `--mode sse-kms`. Invalid with `--mode sse-s3`. |
+
+## Object Write Parameters
+
+| Parameter | Description |
+| --- | --- |
+| `--enc-s3 <TARGET>` | Apply `SSE-S3` to the named remote destination write. |
+| `--enc-kms <TARGET>=<KMS_KEY_ID>` | Apply `SSE-KMS` to the named remote destination write. |
+| `--enc-s3` | On `rc pipe`, apply `SSE-S3` to the single upload target. |
+| `--enc-kms <KMS_KEY_ID>` | On `rc pipe`, apply `SSE-KMS` to the single upload target. |
+
+## Examples
+
+Configure bucket default encryption:
+
+```bash
+rc bucket encryption set local/archive --mode sse-s3
+rc bucket encryption info local/archive
+rc bucket encryption clear local/archive
+```
+
+Configure bucket default encryption with KMS:
+
+```bash
+rc bucket encryption set local/archive --mode sse-kms --key-id alias/archive-key
+```
+
+Upload with explicit destination encryption:
+
+```bash
+rc cp ./report.json local/archive/report.json --enc-s3 local/archive/report.json
+rc mv local/inbox/a.txt local/archive/a.txt --enc-kms local/archive/a.txt=alias/archive-key
+printf 'hello\n' | rc pipe local/archive/hello.txt --enc-s3
+```
+
+## Behavior
+
+Bucket default encryption applies to new writes when no object-level encryption flag is supplied. Object-level encryption flags override the bucket default for that specific write.
+
+`rc` currently supports:
+
+- `SSE-S3`
+- `SSE-KMS`
+
+This reference does not document `SSE-C`, KMS encryption context, or bucket key configuration because those are not part of the current implementation.
+
+Global options shown in command syntax use the same meaning everywhere:
+
+| Option | Description |
+| --- | --- |
+| `--format auto\|human\|json` | Select automatic, human-readable, or JSON output. |
+| `--json` | Emit JSON output where the command supports structured output. |
+| `--no-color` | Disable terminal colors. |
+| `--no-progress` | Disable progress bars. |
+| `-q, --quiet` | Suppress non-error output. |
+| `--debug` | Enable debug logging. |

--- a/docs/reference/rc/encryption.md
+++ b/docs/reference/rc/encryption.md
@@ -1,17 +1,23 @@
-# rc encryption
+# Encryption Workflows
 
 ## Purpose
 
-`rc encryption` documents the bucket and object encryption workflows exposed by `rc`. Bucket default encryption is managed through the noun-first `rc bucket encryption` command family. Object write encryption is configured per destination write on `rc cp`, `rc mv`, and `rc pipe`.
+This guide documents the bucket and object encryption workflows exposed by `rc`. It follows the same high-level split as MinIO `mc`: bucket default encryption is a bucket operation, while object write encryption is set per write command. In `rc`, bucket defaults are managed through the noun-first `rc bucket encryption` command family, and object write encryption is configured on `rc cp`, `rc mv`, and `rc pipe`.
 
 ## Syntax
+
+Bucket default encryption:
 
 ```bash
 rc bucket encryption set <ALIAS/BUCKET> --mode sse-s3
 rc bucket encryption set <ALIAS/BUCKET> --mode sse-kms --key-id <KMS_KEY_ID>
 rc bucket encryption info <ALIAS/BUCKET>
 rc bucket encryption clear <ALIAS/BUCKET>
+```
 
+Object write encryption:
+
+```bash
 rc cp <SOURCE> <TARGET> --enc-s3 <TARGET>
 rc cp <SOURCE> <TARGET> --enc-kms <TARGET>=<KMS_KEY_ID>
 
@@ -70,16 +76,39 @@ rc mv local/inbox/a.txt local/archive/a.txt --enc-kms local/archive/a.txt=alias/
 printf 'hello\n' | rc pipe local/archive/hello.txt --enc-s3
 ```
 
+Recursively copy to a remote prefix and encrypt the entire write target:
+
+```bash
+rc cp ./reports/ local/archive/ --recursive --enc-kms local/archive/=alias/archive-key
+rc mv local/inbox/ local/archive/ --recursive --enc-s3 local/archive/
+```
+
 ## Behavior
 
 Bucket default encryption applies to new writes when no object-level encryption flag is supplied. Object-level encryption flags override the bucket default for that specific write.
+
+Changing or clearing a bucket default does not rewrite existing objects. Objects already written with `SSE-S3` or `SSE-KMS` remain as stored until a later write replaces them.
+
+For `rc cp` and `rc mv`, destination encryption is scoped to the current command target only. The selector in `--enc-s3` or `--enc-kms` must exactly match the destination path you passed on the command line:
+
+- Use the full remote object path for one object.
+- Use the exact remote prefix argument for recursive writes.
 
 `rc` currently supports:
 
 - `SSE-S3`
 - `SSE-KMS`
 
-This reference does not document `SSE-C`, KMS encryption context, or bucket key configuration because those are not part of the current implementation.
+## Compatibility Notes
+
+The current implementation intentionally stays smaller than MinIO `mc`:
+
+- No `SSE-C` support.
+- No KMS encryption context or bucket key configuration.
+- No repeated `--enc-s3` or `--enc-kms` selectors on a single command.
+- No selector expansion beyond the exact destination argument of the current `rc cp` or `rc mv` invocation.
+
+These limits are part of the current `rc` contract and are documented here so scripts do not assume broader `mc` compatibility than the implementation provides.
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/mv.md
+++ b/docs/reference/rc/mv.md
@@ -18,17 +18,23 @@ rc [GLOBAL OPTIONS] mv [OPTIONS] <SOURCE> <TARGET>
 | `TARGET` | Local or remote destination path. |
 | `-r, --recursive` | Move a directory or prefix recursively. |
 | `--dry-run` | Show planned changes without moving data. |
+| `--continue-on-error` | Continue recursive moves after per-object failures. |
+| `--enc-s3 <TARGET>` | Apply `SSE-S3` to the named remote destination write. |
+| `--enc-kms <TARGET>=<KMS_KEY_ID>` | Apply `SSE-KMS` to the named remote destination write. |
 
 ## Examples
 
 ```bash
 rc mv local/inbox/report.json local/archive/report.json
 rc object move ./incoming/ local/inbox/ --recursive
+rc mv local/inbox/a.txt local/archive/a.txt --enc-s3 local/archive/a.txt
 ```
 
 ## Behavior
 
 Move operations copy data to the target and remove the source after a successful copy. Review recursive moves with `--dry-run` before running destructive operations.
+
+Destination encryption flags apply only to remote writes and only when the flag target matches the command target exactly. The current implementation supports `SSE-S3` and `SSE-KMS`. For shared encryption rules across commands, see [`rc encryption`](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/mv.md
+++ b/docs/reference/rc/mv.md
@@ -28,13 +28,19 @@ rc [GLOBAL OPTIONS] mv [OPTIONS] <SOURCE> <TARGET>
 rc mv local/inbox/report.json local/archive/report.json
 rc object move ./incoming/ local/inbox/ --recursive
 rc mv local/inbox/a.txt local/archive/a.txt --enc-s3 local/archive/a.txt
+rc mv local/inbox/ local/archive/ --recursive --enc-kms local/archive/=alias/archive-key
 ```
 
 ## Behavior
 
 Move operations copy data to the target and remove the source after a successful copy. Review recursive moves with `--dry-run` before running destructive operations.
 
-Destination encryption flags apply only to remote writes and only when the flag target matches the command target exactly. The current implementation supports `SSE-S3` and `SSE-KMS`. For shared encryption rules across commands, see [`rc encryption`](encryption.md).
+Destination encryption flags apply only to remote writes. On `rc mv`, the selector in `--enc-s3` or `--enc-kms` must match the command destination exactly:
+
+- For a single-object move, use the full remote object path.
+- For a recursive move, use the same remote prefix passed as `TARGET`.
+
+The current implementation supports `SSE-S3` and `SSE-KMS`. It does not support `SSE-C`, repeated encryption selectors, or MinIO `mc`-style prefix fan-out matching beyond the exact destination argument for the current command. For shared encryption rules across commands, see [Encryption workflows](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/pipe.md
+++ b/docs/reference/rc/pipe.md
@@ -17,17 +17,22 @@ rc [GLOBAL OPTIONS] pipe [OPTIONS] <ALIAS/BUCKET/KEY>
 | `ALIAS/BUCKET/KEY` | Destination object path. |
 | `--content-type` | Object content type. Defaults to `application/octet-stream`. |
 | `--storage-class` | Storage class for the uploaded object. |
+| `--enc-s3` | Apply `SSE-S3` to the upload target. |
+| `--enc-kms <KMS_KEY_ID>` | Apply `SSE-KMS` to the upload target. |
 
 ## Examples
 
 ```bash
 tar -czf - ./logs | rc pipe local/backups/logs.tar.gz --content-type application/gzip
 printf 'hello\n' | rc pipe local/tmp/hello.txt --content-type text/plain
+printf 'hello\n' | rc pipe local/archive/hello.txt --enc-s3
 ```
 
 ## Behavior
 
 The command reads from stdin until EOF and uploads that stream as the destination object.
+
+`--enc-s3` and `--enc-kms` are mutually exclusive. The current implementation supports `SSE-S3` and `SSE-KMS`. For shared encryption rules across commands, see [`rc encryption`](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/docs/reference/rc/pipe.md
+++ b/docs/reference/rc/pipe.md
@@ -26,13 +26,14 @@ rc [GLOBAL OPTIONS] pipe [OPTIONS] <ALIAS/BUCKET/KEY>
 tar -czf - ./logs | rc pipe local/backups/logs.tar.gz --content-type application/gzip
 printf 'hello\n' | rc pipe local/tmp/hello.txt --content-type text/plain
 printf 'hello\n' | rc pipe local/archive/hello.txt --enc-s3
+tar -czf - ./logs | rc pipe local/backups/logs.tar.gz --enc-kms alias/backup-key
 ```
 
 ## Behavior
 
 The command reads from stdin until EOF and uploads that stream as the destination object.
 
-`--enc-s3` and `--enc-kms` are mutually exclusive. The current implementation supports `SSE-S3` and `SSE-KMS`. For shared encryption rules across commands, see [`rc encryption`](encryption.md).
+`--enc-s3` and `--enc-kms` are mutually exclusive. When either flag is set, that object write uses the requested mode even if the bucket default encryption is different. The current implementation supports `SSE-S3` and `SSE-KMS` only. For shared encryption rules across commands, see [Encryption workflows](encryption.md).
 
 Global options shown in command syntax use the same meaning everywhere:
 


### PR DESCRIPTION
## Summary
- add `rc bucket encryption set|info|clear` for bucket default encryption management
- add destination encryption flags for `rc cp`, `rc mv`, and `rc pipe` with `SSE-S3` and `SSE-KMS` support
- add CLI contracts, integration coverage, and command reference docs for the new encryption workflows
- fix encryption target validation so unmatched `--enc-*` selectors fail fast instead of silently disabling encryption
- accept `aws:kms` bucket defaults without an explicit key id when reading server-side encryption state

## Breaking Changes
BREAKING: updated reference documentation for rc
BREAKING: this PR updates `docs/reference/rc/`, which is a protected CLI contract path in this repository
BREAKING: the documented command surface now includes bucket encryption workflows and object write encryption flags

## Test Plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
- [x] `cargo test -p rustfs-cli --features integration encryption_operations::test_bucket_encryption_set_info_clear -- --exact`
- [x] `cargo test -p rustfs-cli --features integration encryption_operations::test_cp_enc_s3_upload -- --exact`
- [x] `cargo test -p rustfs-cli --features integration encryption_operations::test_mv_enc_s3_remote_copy -- --exact`
- [x] `cargo test -p rustfs-cli --features integration encryption_operations::test_pipe_enc_s3_upload -- --exact`

## RustFS Runtime Verification
- [x] Started a local RustFS server on `127.0.0.1:9000` and verified the health endpoint returned ready
- [x] Verified `rc bucket encryption set local/<bucket> --mode sse-s3 --json` returns `Configured`
- [x] Verified `rc bucket encryption info local/<bucket> --json` reports `Configured` after `set`
- [x] Verified a normal `rc cp` upload inherits bucket default encryption and `mc stat --json` reports `X-Amz-Server-Side-Encryption: AES256`
- [x] Verified `rc cp --enc-s3`, `rc mv --enc-s3`, and `rc pipe --enc-s3` all produce encrypted objects with `X-Amz-Server-Side-Encryption: AES256`
- [x] Verified `rc bucket encryption clear local/<bucket> --json` returns `Cleared`
- [x] Verified `rc bucket encryption info local/<bucket> --json` reports `Not configured` after `clear`
- [x] Verified a normal upload after `clear` no longer includes `X-Amz-Server-Side-Encryption`
- [x] Cross-checked bucket encryption state with `mc encrypt info` and object metadata with `mc stat --json`
