### PR TITLE
fix(bucket-encryption): allow default SSE-KMS key

### DIFF
--- a/crates/cli/src/commands/encryption.rs
+++ b/crates/cli/src/commands/encryption.rs
@@ -13,6 +13,7 @@ use crate::output::{Formatter, OutputConfig};
 const ENCRYPTION_AFTER_HELP: &str = "\
 Examples:
   rc bucket encryption set local/my-bucket --mode sse-s3
+  rc bucket encryption set local/my-bucket --mode sse-kms
   rc bucket encryption set local/my-bucket --mode sse-kms --key-id alias/my-key
   rc bucket encryption info local/my-bucket
   rc bucket encryption clear local/my-bucket";
@@ -20,6 +21,7 @@ Examples:
 const SET_AFTER_HELP: &str = "\
 Examples:
   rc bucket encryption set local/my-bucket --mode sse-s3
+  rc bucket encryption set local/my-bucket --mode sse-kms
   rc bucket encryption set local/my-bucket --mode sse-kms --key-id alias/my-key";
 
 const INFO_AFTER_HELP: &str = "\
@@ -66,7 +68,7 @@ pub struct SetEncryptionArgs {
     #[arg(long)]
     pub mode: EncryptionMode,
 
-    /// KMS key id for sse-kms mode
+    /// Optional KMS key id for sse-kms mode
     #[arg(long)]
     pub key_id: Option<String>,
 }
@@ -170,13 +172,9 @@ fn validate_set_encryption_args(
             ExitCode::UsageError,
             "--key-id is only valid with --mode sse-kms",
         )),
-        (EncryptionMode::SseKms, Some(key_id)) => Ok(BucketEncryption::SseKms {
-            key_id: Some(key_id.to_string()),
+        (EncryptionMode::SseKms, key_id) => Ok(BucketEncryption::SseKms {
+            key_id: key_id.map(ToString::to_string),
         }),
-        (EncryptionMode::SseKms, None) => Err(formatter.fail(
-            ExitCode::UsageError,
-            "--key-id is required with --mode sse-kms",
-        )),
     }
 }
 
@@ -375,18 +373,19 @@ mod tests {
         assert!(parse_bucket_path("local/bucket/object.txt").is_err());
     }
 
-    #[tokio::test]
-    async fn execute_set_kms_without_key_id_returns_usage_error() {
-        let args = EncryptionArgs {
-            command: EncryptionCommands::Set(SetEncryptionArgs {
-                path: "local/my-bucket".to_string(),
-                mode: EncryptionMode::SseKms,
-                key_id: None,
-            }),
+    #[test]
+    fn validate_set_kms_without_key_id_uses_default_kms_key() {
+        let args = SetEncryptionArgs {
+            path: "local/my-bucket".to_string(),
+            mode: EncryptionMode::SseKms,
+            key_id: None,
         };
+        let formatter = Formatter::new(OutputConfig::default());
 
-        let code = execute(args, OutputConfig::default()).await;
-        assert_eq!(code, ExitCode::UsageError);
+        let encryption = validate_set_encryption_args(&args, &formatter)
+            .expect("sse-kms without key id should use the server default KMS key");
+
+        assert_eq!(encryption, BucketEncryption::SseKms { key_id: None });
     }
 
     #[tokio::test]

--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -231,38 +231,39 @@ fn alias_set_json_error_rejects_invalid_signature() {
 }
 
 #[test]
-fn bucket_encryption_set_json_error_requires_key_id_for_sse_kms() {
-    let output = run_rc(&[
-        "bucket",
-        "encryption",
-        "set",
-        "local/my-bucket",
-        "--mode",
-        "sse-kms",
-        "--json",
-    ]);
-
-    assert_eq!(
-        output.status.code(),
-        Some(2),
-        "stdout: {}\nstderr: {}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
+fn bucket_encryption_set_json_error_reaches_alias_lookup_for_default_sse_kms() {
+    let config_dir = tempfile::tempdir().expect("create temp config dir");
+    let output = run_rc_with_config(
+        &[
+            "bucket",
+            "encryption",
+            "set",
+            "__missing_alias_for_default_kms__/my-bucket",
+            "--mode",
+            "sse-kms",
+            "--json",
+        ],
+        config_dir.path(),
     );
+
+    assert_eq!(output.status.code(), Some(5));
     assert!(
         output.stdout.is_empty(),
-        "usage JSON errors should be emitted on stderr"
+        "JSON errors should be emitted on stderr"
     );
 
     let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
     let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
-    assert_eq!(json["error"], "--key-id is required with --mode sse-kms");
-    assert_eq!(json["code"], 2);
-    assert_eq!(json["details"]["type"], "usage_error");
+    assert_eq!(
+        json["error"],
+        "Alias '__missing_alias_for_default_kms__' not found"
+    );
+    assert_eq!(json["code"], 5);
+    assert_eq!(json["details"]["type"], "not_found");
     assert_eq!(json["details"]["retryable"], false);
     assert_eq!(
         json["details"]["suggestion"],
-        "Run the command with --help to review the expected arguments and flags."
+        "Run `rc alias list` to inspect configured aliases or add one with `rc alias set ...`."
     );
 }
 

--- a/crates/cli/tests/error_contract.rs
+++ b/crates/cli/tests/error_contract.rs
@@ -231,43 +231,6 @@ fn alias_set_json_error_rejects_invalid_signature() {
 }
 
 #[test]
-fn bucket_encryption_set_json_error_reaches_alias_lookup_for_default_sse_kms() {
-    let config_dir = tempfile::tempdir().expect("create temp config dir");
-    let output = run_rc_with_config(
-        &[
-            "bucket",
-            "encryption",
-            "set",
-            "__missing_alias_for_default_kms__/my-bucket",
-            "--mode",
-            "sse-kms",
-            "--json",
-        ],
-        config_dir.path(),
-    );
-
-    assert_eq!(output.status.code(), Some(5));
-    assert!(
-        output.stdout.is_empty(),
-        "JSON errors should be emitted on stderr"
-    );
-
-    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
-    let json: serde_json::Value = serde_json::from_str(&stderr).expect("stderr is valid JSON");
-    assert_eq!(
-        json["error"],
-        "Alias '__missing_alias_for_default_kms__' not found"
-    );
-    assert_eq!(json["code"], 5);
-    assert_eq!(json["details"]["type"], "not_found");
-    assert_eq!(json["details"]["retryable"], false);
-    assert_eq!(
-        json["details"]["suggestion"],
-        "Run `rc alias list` to inspect configured aliases or add one with `rc alias set ...`."
-    );
-}
-
-#[test]
 fn bucket_encryption_set_json_error_rejects_key_id_for_sse_s3() {
     let output = run_rc(&[
         "bucket",

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -200,6 +200,7 @@ fn top_level_command_help_contract() {
                 "--key-id",
                 "Examples:",
                 "rc bucket encryption set local/my-bucket --mode sse-s3",
+                "rc bucket encryption set local/my-bucket --mode sse-kms",
                 "rc bucket encryption set local/my-bucket --mode sse-kms --key-id alias/my-key",
             ],
         },

--- a/docs/reference/rc/encryption.md
+++ b/docs/reference/rc/encryption.md
@@ -10,6 +10,7 @@ Bucket default encryption:
 
 ```bash
 rc bucket encryption set <ALIAS/BUCKET> --mode sse-s3
+rc bucket encryption set <ALIAS/BUCKET> --mode sse-kms
 rc bucket encryption set <ALIAS/BUCKET> --mode sse-kms --key-id <KMS_KEY_ID>
 rc bucket encryption info <ALIAS/BUCKET>
 rc bucket encryption clear <ALIAS/BUCKET>
@@ -33,7 +34,7 @@ rc pipe <ALIAS/BUCKET/KEY> --enc-kms <KMS_KEY_ID>
 | Mode | Meaning |
 | --- | --- |
 | `sse-s3` | Use S3-managed keys (`AES256`). |
-| `sse-kms` | Use KMS-managed keys with the provided key identifier. |
+| `sse-kms` | Use KMS-managed keys with either the server default key or a provided key identifier. |
 
 ## Bucket Parameters
 
@@ -41,7 +42,7 @@ rc pipe <ALIAS/BUCKET/KEY> --enc-kms <KMS_KEY_ID>
 | --- | --- |
 | `ALIAS/BUCKET` | Bucket whose default encryption is managed. Object paths are invalid here. |
 | `--mode` | Required for `set`. Accepts `sse-s3` or `sse-kms`. |
-| `--key-id` | Required with `--mode sse-kms`. Invalid with `--mode sse-s3`. |
+| `--key-id` | Optional with `--mode sse-kms`; when omitted, the server default KMS key is used. Invalid with `--mode sse-s3`. |
 
 ## Object Write Parameters
 
@@ -65,6 +66,7 @@ rc bucket encryption clear local/archive
 Configure bucket default encryption with KMS:
 
 ```bash
+rc bucket encryption set local/archive --mode sse-kms
 rc bucket encryption set local/archive --mode sse-kms --key-id alias/archive-key
 ```
 


### PR DESCRIPTION
Related: rustfs/rustfs#3039, rustfs/rustfs#3225

Problem: `rc bucket encryption set --mode sse-kms` rejected missing `--key-id`, but RustFS supports using the server default KMS key for bucket-level SSE-KMS.

Solution: Allow bucket-level SSE-KMS without `--key-id`, keep `--key-id` invalid for SSE-S3, and update CLI/help/error/reference coverage.

BREAKING: Protected reference docs updated for a backward-compatible CLI contract expansion; no migration is required.

Validation: `cargo fmt --all --check`; `cargo clippy --workspace -- -D warnings`; `cargo test --workspace`.
