### PR TITLE
test(s3): cover JSON select output delimiter

### DIFF
--- a/crates/s3/src/select.rs
+++ b/crates/s3/src/select.rs
@@ -366,8 +366,8 @@ mod tests {
     use rc_core::Error;
     use rc_core::{
         SelectCompression, SelectCsvInputOptions, SelectCsvOutputOptions, SelectInputFormat,
-        SelectJsonInputOptions, SelectJsonInputType, SelectOptions, SelectOutputFormat,
-        SelectScanRangeOptions,
+        SelectJsonInputOptions, SelectJsonInputType, SelectJsonOutputOptions, SelectOptions,
+        SelectOutputFormat, SelectScanRangeOptions,
     };
 
     #[test]
@@ -592,6 +592,22 @@ mod tests {
         let error = build_output_serialization(&options)
             .expect_err("multi-byte CSV output record delimiter should be rejected");
         assert!(matches!(error, Error::General(msg) if msg.contains("record delimiter")));
+    }
+
+    #[test]
+    fn json_output_serialization_sets_record_delimiter() {
+        let options = SelectOptions {
+            expression: "SELECT * FROM S3Object".to_string(),
+            output_format: SelectOutputFormat::Json,
+            json_output: SelectJsonOutputOptions {
+                record_delimiter: Some("\n".to_string()),
+            },
+            ..SelectOptions::default()
+        };
+
+        let output = build_output_serialization(&options).expect("json output serialization");
+        let json = output.json().expect("json output is configured");
+        assert_eq!(json.record_delimiter(), Some("\n"));
     }
 
     #[test]


### PR DESCRIPTION
Related issue: none

Background: Recent SQL select option changes added JSON output record delimiter support in the S3 Select serialization path. Existing tests only checked that JSON output serialization was selected, not that the delimiter value was preserved.

Solution: Add a focused rc-s3 unit test for JSON output record delimiter mapping.

Validation:
- cargo test -p rc-s3 json_output_serialization_sets_record_delimiter
- cargo fmt --all --check
- make pre-commit