### PR TITLE
feat(admin): add decommission clear command

### DIFF
--- a/crates/cli/src/commands/admin/decommission.rs
+++ b/crates/cli/src/commands/admin/decommission.rs
@@ -19,6 +19,9 @@ pub enum DecommissionCommands {
 
     /// Cancel decommissioning a pool
     Cancel(CancelArgs),
+
+    /// Clear failed or canceled decommissioning metadata for a pool
+    Clear(ClearArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -60,6 +63,19 @@ pub struct CancelArgs {
     pub by_id: bool,
 }
 
+#[derive(clap::Args, Debug)]
+pub struct ClearArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Pool command line, or zero-based pool ID with --by-id
+    pub pool: String,
+
+    /// Interpret POOL as a zero-based pool ID
+    #[arg(long)]
+    pub by_id: bool,
+}
+
 #[derive(Serialize)]
 struct DecommissionOperationOutput {
     success: bool,
@@ -78,6 +94,7 @@ pub async fn execute(cmd: DecommissionCommands, formatter: &Formatter) -> ExitCo
         DecommissionCommands::Start(args) => execute_start(args, formatter).await,
         DecommissionCommands::Status(args) => execute_status(args, formatter).await,
         DecommissionCommands::Cancel(args) => execute_cancel(args, formatter).await,
+        DecommissionCommands::Clear(args) => execute_clear(args, formatter).await,
     }
 }
 
@@ -187,6 +204,40 @@ async fn execute_cancel(args: CancelArgs, formatter: &Formatter) -> ExitCode {
         }
         Err(e) => {
             formatter.error(&format!("Failed to cancel decommission: {e}"));
+            ExitCode::GeneralError
+        }
+    }
+}
+
+async fn execute_clear(args: ClearArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(c) => c,
+        Err(code) => return code,
+    };
+
+    let target = PoolTarget {
+        pool: args.pool,
+        by_id: args.by_id,
+    };
+
+    match client.decommission_clear(target.clone()).await {
+        Ok(()) => {
+            if formatter.is_json() {
+                formatter.json(&DecommissionOperationOutput {
+                    success: true,
+                    message: "Decommission cleared successfully".to_string(),
+                    pool: target.pool,
+                });
+            } else {
+                formatter.success(&format!(
+                    "Decommission cleared successfully for `{}`.",
+                    target.pool
+                ));
+            }
+            ExitCode::Success
+        }
+        Err(e) => {
+            formatter.error(&format!("Failed to clear decommission: {e}"));
             ExitCode::GeneralError
         }
     }

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -341,6 +341,20 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_admin_decommission_clear_by_id() {
+        let cli = TestCli::parse_from(["rc", "decommission", "clear", "local", "3", "--by-id"]);
+
+        match cli.command {
+            AdminCommands::Decommission(decommission::DecommissionCommands::Clear(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.pool, "3");
+                assert!(args.by_id);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
     fn test_parse_admin_rebalance_start() {
         let cli = TestCli::parse_from(["rc", "rebalance", "start", "local"]);
 

--- a/crates/cli/tests/admin_decommission.rs
+++ b/crates/cli/tests/admin_decommission.rs
@@ -124,3 +124,47 @@ fn decom_cancel_dispatches_by_id_pool_json() {
 
     handle.join().expect("admin test server finished");
 }
+
+#[test]
+fn decommission_clear_dispatches_by_id_pool_json() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server("");
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "decommission",
+            "clear",
+            "myalias",
+            "3",
+            "--by-id",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
+    assert_eq!(payload["success"], true);
+    assert_eq!(payload["message"], "Decommission cleared successfully");
+    assert_eq!(payload["pool"], "3");
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/pools/clear?pool=3&by-id=true"
+    );
+
+    handle.join().expect("admin test server finished");
+}

--- a/crates/cli/tests/admin_support/mod.rs
+++ b/crates/cli/tests/admin_support/mod.rs
@@ -69,7 +69,7 @@ pub fn start_admin_test_server(
     let (sender, receiver) = mpsc::channel();
 
     let handle = thread::spawn(move || {
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(120);
         let (mut stream, _) = loop {
             match listener.accept() {
                 Ok(accepted) => break accepted,

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -547,6 +547,11 @@ fn nested_subcommand_help_contract() {
             expected_tokens: &["--by-id"],
         },
         HelpCase {
+            args: &["admin", "decommission", "clear"],
+            usage: "Usage: rc admin decommission clear [OPTIONS] <ALIAS> <POOL>",
+            expected_tokens: &["--by-id"],
+        },
+        HelpCase {
             args: &["admin", "rebalance", "start"],
             usage: "Usage: rc admin rebalance start [OPTIONS] <ALIAS>",
             expected_tokens: &[],

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -62,6 +62,9 @@ pub trait AdminApi: Send + Sync {
     /// Cancel decommissioning a storage pool
     async fn decommission_cancel(&self, target: PoolTarget) -> Result<()>;
 
+    /// Clear failed or canceled decommissioning metadata for a storage pool
+    async fn decommission_clear(&self, target: PoolTarget) -> Result<()>;
+
     /// Start a rebalance operation
     async fn rebalance_start(&self) -> Result<RebalanceStartResult>;
 

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -565,6 +565,12 @@ impl AdminApi for AdminClient {
             .await
     }
 
+    async fn decommission_clear(&self, target: PoolTarget) -> Result<()> {
+        let query = pool_target_query(&target);
+        self.request_no_response(Method::POST, "/pools/clear", Some(&query), None)
+            .await
+    }
+
     async fn rebalance_start(&self) -> Result<RebalanceStartResult> {
         self.request(Method::POST, "/rebalance/start", None, None)
             .await
@@ -1592,6 +1598,29 @@ mod tests {
         assert_eq!(
             request.target,
             "/rustfs/admin/v3/pools/cancel?pool=1&by-id=true"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_decommission_clear_posts_pool_clear_route_with_by_id_query() {
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let client = admin_client_for_endpoint(&endpoint);
+
+        client
+            .decommission_clear(PoolTarget {
+                pool: "3".to_string(),
+                by_id: true,
+            })
+            .await
+            .expect("decommission clear request");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/pools/clear?pool=3&by-id=true"
         );
         assert!(request.body.is_empty());
         handle.join().expect("server thread should finish");


### PR DESCRIPTION
## Related Issue

None.

## Background

`rc admin decommission` supported start, status, and cancel, but it did not expose RustFS' pool decommission clear operation. Operators need this command to clear failed or canceled decommission metadata by pool, including by pool ID.

## Root Cause

The admin API trait and S3 admin client did not include a `decommission_clear` operation, and the CLI decommission subcommands did not include `clear`.

## Solution

- Add `rc admin decommission clear <ALIAS> <POOL> [--by-id]`.
- Dispatch clear requests to `POST /rustfs/admin/v3/pools/clear` with the existing pool query shape.
- Add parser, help contract, CLI dispatch, and S3 route coverage.
- Extend the shared admin test server accept deadline to avoid false failures when spawned CLI tests start slowly under local load.

## Test Status

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`
