### PR TITLE
fix(admin): align pool status usage source

### DIFF
--- a/crates/cli/src/commands/admin/pool.rs
+++ b/crates/cli/src/commands/admin/pool.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use super::get_admin_client;
 use crate::exit_code::ExitCode;
 use crate::output::Formatter;
-use rc_core::admin::{AdminApi, ClusterInfo, PoolDecommissionInfo, PoolStatus, PoolTarget};
+use rc_core::admin::{AdminApi, PoolDecommissionInfo, PoolStatus, PoolTarget};
 
 /// Pool subcommands
 #[derive(Subcommand, Debug)]
@@ -98,9 +98,8 @@ async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
             }
         }
     } else {
-        match client.cluster_info().await {
-            Ok(info) => {
-                let pools = pool_statuses_from_cluster_info(&info);
+        match client.list_pools().await {
+            Ok(pools) => {
                 if formatter.is_json() {
                     formatter.json(&PoolListOutput { pools });
                 } else {
@@ -114,60 +113,6 @@ async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
             }
         }
     }
-}
-
-fn pool_statuses_from_cluster_info(info: &ClusterInfo) -> Vec<PoolStatus> {
-    let mut pools: Vec<PoolStatus> = info
-        .pools
-        .as_ref()
-        .map(|pools| {
-            pools
-                .iter()
-                .filter_map(|(pool_id, sets)| {
-                    let id = usize::try_from(*pool_id).ok()?;
-                    let raw_capacity = sets.values().map(|set| set.raw_capacity).sum::<u64>();
-                    let raw_usage = sets.values().map(|set| set.raw_usage).sum::<u64>();
-
-                    Some(PoolStatus {
-                        id,
-                        cmd_line: format!("pool {pool_id}"),
-                        decommission: Some(PoolDecommissionInfo {
-                            total_size: raw_capacity,
-                            current_size: raw_capacity.saturating_sub(raw_usage),
-                            ..Default::default()
-                        }),
-                        ..Default::default()
-                    })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if pools.is_empty() {
-        pools = info
-            .servers
-            .as_ref()
-            .map(|servers| {
-                let mut pool_ids = servers
-                    .iter()
-                    .flat_map(|server| &server.disks)
-                    .filter_map(|disk| usize::try_from(disk.pool_index).ok())
-                    .collect::<Vec<_>>();
-                pool_ids.sort_unstable();
-                pool_ids.dedup();
-                pool_ids
-                    .into_iter()
-                    .map(|id| PoolStatus {
-                        id,
-                        cmd_line: format!("pool {id}"),
-                        ..Default::default()
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
-    }
-
-    pools
 }
 
 pub(super) fn print_pool_list(pools: &[PoolStatus], formatter: &Formatter) {

--- a/crates/cli/tests/admin_pool.rs
+++ b/crates/cli/tests/admin_pool.rs
@@ -44,10 +44,10 @@ fn pool_list_dispatches_to_pool_list_json() {
 }
 
 #[test]
-fn pool_status_without_target_dispatches_to_cluster_info_json() {
+fn pool_status_without_target_dispatches_to_pool_list_json() {
     let config_dir = tempfile::tempdir().expect("create config dir");
     let (endpoint, receiver, handle) = start_admin_test_server(
-        r#"{"pools":{"0":{"0":{"id":0,"rawUsage":10,"rawCapacity":100,"usage":4,"objectsCount":1,"versionsCount":1,"deleteMarkersCount":0,"healDisks":0}},"1":{"0":{"id":0,"rawUsage":20,"rawCapacity":200,"usage":8,"objectsCount":2,"versionsCount":2,"deleteMarkersCount":0,"healDisks":0}}}}"#,
+        r#"[{"id":0,"cmdline":"/data/pool0/disk{1...4}","lastUpdate":"2026-05-10T00:00:00Z","decommissionInfo":{"totalSize":100,"currentSize":90}}]"#,
     );
 
     let output = Command::new(rc_binary())
@@ -66,15 +66,17 @@ fn pool_status_without_target_dispatches_to_cluster_info_json() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     let payload: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
     let pools = payload["pools"].as_array().expect("pools array");
-    assert_eq!(pools.len(), 2);
+    assert_eq!(pools.len(), 1);
     assert_eq!(pools[0]["id"], 0);
-    assert_eq!(pools[1]["id"], 1);
+    assert_eq!(pools[0]["cmdline"], "/data/pool0/disk{1...4}");
+    assert_eq!(pools[0]["decommissionInfo"]["totalSize"], 100);
+    assert_eq!(pools[0]["decommissionInfo"]["currentSize"], 90);
 
     let request = receiver
         .recv_timeout(Duration::from_secs(5))
         .expect("captured admin request");
     assert_eq!(request.method, "GET");
-    assert_eq!(request.target, "/rustfs/admin/v3/info");
+    assert_eq!(request.target, "/rustfs/admin/v3/pools/list");
 
     handle.join().expect("admin test server finished");
 }


### PR DESCRIPTION
## Summary
- Route `rc admin pool status <alias>` without a pool target through `/pools/list`.
- Remove the raw-capacity fallback that synthesized pool status from cluster info.
- Update the admin pool integration test to lock the `/pools/list` behavior.

## Test Plan
- [x] CARGO_TARGET_DIR=/tmp/rc-cli-target make pre-commit
