### PR TITLE
fix(cli): trim leading slash in download_prefix to prevent Path::join treating relative path as absolute

### DIFF
--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -631,7 +631,11 @@ async fn download_prefix(
                     }
 
                     // Calculate relative path from prefix
-                    let relative_key = item.key.strip_prefix(&src.key).unwrap_or(&item.key);
+                    let relative_key = item
+                        .key
+                        .strip_prefix(&src.key)
+                        .unwrap_or(&item.key)
+                        .trim_start_matches('/');
                     let dst_path =
                         dst.join(relative_key.replace('/', std::path::MAIN_SEPARATOR_STR));
 


### PR DESCRIPTION
### Summary
Fix `rc cp -r` incorrectly writing files to the system root (`/`) when the source prefix lacks a trailing slash (e.g., `alias/bucket/dir` instead of `alias/bucket/dir/`).

Related: #244 

### What Changed
- Modified `download_prefix` in `crates/cli/src/commands/cp.rs`:
  - Added `.trim_start_matches('/')` to the relative key computed by `strip_prefix`.
  - This ensures the relative path does **not** start with a slash, preventing `Path::join` from interpreting it as an absolute path and discarding the destination directory.

### Why
When `src.key = "dir"` and `item.key = "dir/file"`, `strip_prefix` returns `"/file"` (leading slash). `Path::join` treats any argument starting with `/` as an absolute path, ignoring the user-specified destination and writing files to the system root. This violates user expectations and is inconsistent with other S3 clients like `mcli`.

### Impact
- Users can now use `rc cp -r alias/bucket/dir ./` without needing to append a trailing slash.
- Files are correctly copied to the intended destination directory.
- Existing behavior when source prefix ends with `/` remains unchanged.

### Verification
- `cargo fmt --all --check` (pass)
- `cargo clippy --workspace -- -D warnings` (pass)
- `cargo test --workspace` (pass)
- Manually tested on Linux and Windows 11 with both slash-terminated and non-slash-terminated source paths; files correctly copied to the specified destination.