### PR TITLE
fix(admin): support manual heal task status

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,9 @@ rc admin info disk local --offline
 # Heal operations
 rc admin heal status local
 rc admin heal start local --bucket mybucket --scan-mode deep
+rc admin heal status local --bucket mybucket --client-token <TOKEN_FROM_START>
 rc admin heal start local --dry-run
+rc admin heal stop local --bucket mybucket --client-token <TOKEN_FROM_START>
 rc admin heal stop local
 
 # Pool expansion and decommission workflows

--- a/crates/cli/src/commands/admin/heal.rs
+++ b/crates/cli/src/commands/admin/heal.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use super::get_admin_client;
 use crate::exit_code::ExitCode;
 use crate::output::Formatter;
-use rc_core::admin::{AdminApi, HealScanMode, HealStartRequest, HealStatus};
+use rc_core::admin::{AdminApi, HealScanMode, HealStartRequest, HealStatus, HealTaskRequest};
 
 const HEAL_STOP_SUCCESS_MESSAGE: &str = "Heal operation stopped successfully";
 const HEAL_STOP_STILL_RUNNING_MESSAGE: &str =
@@ -31,6 +31,18 @@ pub enum HealCommands {
 pub struct StatusArgs {
     /// Alias name of the server
     pub alias: String,
+
+    /// Bucket for token-scoped manual heal task status
+    #[arg(short, long)]
+    pub bucket: Option<String>,
+
+    /// Object prefix for token-scoped manual heal task status
+    #[arg(short, long)]
+    pub prefix: Option<String>,
+
+    /// Client token returned by heal start
+    #[arg(long)]
+    pub client_token: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -67,6 +79,18 @@ pub struct StartArgs {
 pub struct StopArgs {
     /// Alias name of the server
     pub alias: String,
+
+    /// Bucket for token-scoped manual heal task stop
+    #[arg(short, long)]
+    pub bucket: Option<String>,
+
+    /// Object prefix for token-scoped manual heal task stop
+    #[arg(short, long)]
+    pub prefix: Option<String>,
+
+    /// Client token returned by heal start
+    #[arg(long)]
+    pub client_token: Option<String>,
 }
 
 /// JSON output for heal status
@@ -75,6 +99,10 @@ pub struct StopArgs {
 struct HealStatusOutput {
     heal_id: String,
     healing: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
     bucket: String,
     object: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -98,6 +126,8 @@ impl From<&HealStatus> for HealStatusOutput {
         Self {
             heal_id: status.heal_id.clone(),
             healing: status.healing,
+            summary: status.summary.clone(),
+            detail: status.detail.clone(),
             bucket: status.bucket.clone(),
             object: status.object.clone(),
             scan_mode: status.scan_mode,
@@ -118,6 +148,8 @@ impl From<&HealStatus> for HealStatusOutput {
 fn has_heal_status_details(status: &HealStatus) -> bool {
     status.healing
         || !status.heal_id.is_empty()
+        || status.summary.is_some()
+        || status.detail.is_some()
         || !status.bucket.is_empty()
         || !status.object.is_empty()
         || status.scan_mode.is_some()
@@ -138,6 +170,8 @@ fn has_heal_status_details(status: &HealStatus) -> bool {
 struct HealOperationOutput {
     success: bool,
     message: String,
+    #[serde(skip_serializing_if = "Option::is_none", rename = "clientToken")]
+    client_token: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     status: Option<HealStatusOutput>,
 }
@@ -159,6 +193,7 @@ fn heal_stop_output(status: &HealStatus) -> (ExitCode, HealOperationOutput) {
         HealOperationOutput {
             success,
             message: message.to_string(),
+            client_token: None,
             status: has_heal_status_details(status).then(|| HealStatusOutput::from(status)),
         },
     )
@@ -179,7 +214,23 @@ async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
         Err(code) => return code,
     };
 
-    match client.heal_status().await {
+    let task_request = match heal_task_request(
+        args.bucket.clone(),
+        args.prefix.clone(),
+        args.client_token.clone(),
+        formatter,
+    ) {
+        Ok(request) => request,
+        Err(code) => return code,
+    };
+
+    let result = if let Some(request) = task_request {
+        client.heal_task_status(request).await
+    } else {
+        client.heal_status().await
+    };
+
+    match result {
         Ok(status) => {
             if formatter.is_json() {
                 formatter.json(&HealStatusOutput::from(&status));
@@ -196,10 +247,13 @@ async fn execute_status(args: StatusArgs, formatter: &Formatter) -> ExitCode {
 }
 
 fn print_heal_status(status: &HealStatus, formatter: &Formatter) {
-    let healing_status = if status.healing {
-        formatter.style_size("In Progress")
-    } else {
-        formatter.style_date("Idle")
+    let healing_status = match status.summary.as_deref() {
+        Some("running") => formatter.style_size("In Progress"),
+        Some("finished") => formatter.style_size("Finished"),
+        Some("stopped") => formatter.style_date("Stopped"),
+        Some("notFound") => formatter.style_date("Not Found"),
+        _ if status.healing => formatter.style_size("In Progress"),
+        _ => formatter.style_date("Idle"),
     };
 
     formatter.println(&format!(
@@ -213,7 +267,14 @@ fn print_heal_status(status: &HealStatus, formatter: &Formatter) {
         formatter.println(&format!("  Heal ID:       {}", status.heal_id));
     }
 
-    if status.healing {
+    if let Some(ref summary) = status.summary {
+        formatter.println(&format!("  Summary:       {}", summary));
+    }
+    if let Some(ref detail) = status.detail {
+        formatter.println(&format!("  Detail:        {}", detail));
+    }
+
+    if status.healing || status.summary.is_some() {
         if !status.bucket.is_empty() {
             formatter.println(&format!(
                 "  Current:       {}/{}",
@@ -289,6 +350,7 @@ async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
                 let output = HealOperationOutput {
                     success: true,
                     message: "Heal operation started successfully".to_string(),
+                    client_token: (!status.heal_id.is_empty()).then(|| status.heal_id.clone()),
                     status: status_output,
                 };
                 formatter.json(&output);
@@ -298,9 +360,11 @@ async fn execute_start(args: StartArgs, formatter: &Formatter) -> ExitCode {
                 } else {
                     formatter.success("Heal operation started successfully.");
                 }
-                if has_heal_status_details(&status) {
-                    formatter.println("");
-                    print_heal_status(&status, formatter);
+                if !status.heal_id.is_empty() {
+                    formatter.println(&format!("  Client Token:  {}", status.heal_id));
+                }
+                if let Some(ref started) = status.started {
+                    formatter.println(&format!("  Started:       {}", started));
                 }
             }
             ExitCode::Success
@@ -317,6 +381,40 @@ async fn execute_stop(args: StopArgs, formatter: &Formatter) -> ExitCode {
         Ok(c) => c,
         Err(code) => return code,
     };
+
+    let task_request = match heal_task_request(
+        args.bucket.clone(),
+        args.prefix.clone(),
+        args.client_token.clone(),
+        formatter,
+    ) {
+        Ok(request) => request,
+        Err(code) => return code,
+    };
+
+    if let Some(request) = task_request {
+        return match client.heal_task_stop(request).await {
+            Ok(status) => {
+                let (exit_code, mut output) = heal_stop_output(&status);
+                output.client_token = (!status.heal_id.is_empty()).then(|| status.heal_id.clone());
+
+                if formatter.is_json() {
+                    formatter.json(&output);
+                } else if output.success {
+                    formatter.success(&format!("{}.", output.message));
+                } else {
+                    formatter.error(&format!("{}.", output.message));
+                    formatter.println("");
+                    print_heal_status(&status, formatter);
+                }
+                exit_code
+            }
+            Err(e) => {
+                formatter.error(&format!("Failed to stop heal operation: {e}"));
+                ExitCode::GeneralError
+            }
+        };
+    }
 
     match client.heal_stop().await {
         Ok(()) => {
@@ -345,6 +443,42 @@ async fn execute_stop(args: StopArgs, formatter: &Formatter) -> ExitCode {
         Err(e) => {
             formatter.error(&format!("Failed to stop heal operation: {e}"));
             ExitCode::GeneralError
+        }
+    }
+}
+
+fn heal_task_request(
+    bucket: Option<String>,
+    prefix: Option<String>,
+    client_token: Option<String>,
+    formatter: &Formatter,
+) -> Result<Option<HealTaskRequest>, ExitCode> {
+    if prefix.as_deref().is_some_and(|prefix| !prefix.is_empty())
+        && bucket.as_deref().is_none_or(|bucket| bucket.is_empty())
+    {
+        formatter.error("Heal task prefix requires --bucket.");
+        return Err(ExitCode::UsageError);
+    }
+
+    let has_target = bucket.as_deref().is_some_and(|bucket| !bucket.is_empty());
+    let has_token = client_token
+        .as_deref()
+        .is_some_and(|client_token| !client_token.is_empty());
+
+    match (has_target, has_token) {
+        (false, false) => Ok(None),
+        (true, true) => Ok(Some(HealTaskRequest {
+            bucket: bucket.expect("bucket is present"),
+            prefix,
+            client_token: client_token.expect("client token is present"),
+        })),
+        (true, false) => {
+            formatter.error("Heal task request requires --client-token when --bucket is set.");
+            Err(ExitCode::UsageError)
+        }
+        (false, true) => {
+            formatter.error("Heal task request requires --bucket when --client-token is set.");
+            Err(ExitCode::UsageError)
         }
     }
 }
@@ -399,15 +533,18 @@ mod tests {
             bytes_healed: 1024 * 1024 * 5,
             started: Some("2024-01-01T10:00:00Z".to_string()),
             last_update: Some("2024-01-01T10:30:00Z".to_string()),
+            ..Default::default()
         };
 
         let output = HealOperationOutput {
             success: true,
             message: "Heal operation started successfully".to_string(),
+            client_token: Some("heal-123".to_string()),
             status: Some(HealStatusOutput::from(&status)),
         };
 
         let value = serde_json::to_value(&output).expect("serialize heal operation output");
+        assert_eq!(value["clientToken"], "heal-123");
         let status_value = value
             .get("status")
             .expect("status field exists")
@@ -467,6 +604,7 @@ mod tests {
             bytes_healed: 1024 * 1024 * 5,
             started: Some("2024-01-01T10:00:00Z".to_string()),
             last_update: Some("2024-01-01T10:30:00Z".to_string()),
+            ..Default::default()
         };
 
         let output = HealStatusOutput::from(&status);

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -209,6 +209,56 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_admin_heal_status_task_options() {
+        let cli = TestCli::parse_from([
+            "rc",
+            "heal",
+            "status",
+            "local",
+            "--bucket",
+            "mybucket",
+            "--prefix",
+            "logs/",
+            "--client-token",
+            "heal-token-123",
+        ]);
+
+        match cli.command {
+            AdminCommands::Heal(heal::HealCommands::Status(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.bucket.as_deref(), Some("mybucket"));
+                assert_eq!(args.prefix.as_deref(), Some("logs/"));
+                assert_eq!(args.client_token.as_deref(), Some("heal-token-123"));
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_heal_stop_task_options() {
+        let cli = TestCli::parse_from([
+            "rc",
+            "heal",
+            "stop",
+            "local",
+            "--bucket",
+            "mybucket",
+            "--client-token",
+            "heal-token-123",
+        ]);
+
+        match cli.command {
+            AdminCommands::Heal(heal::HealCommands::Stop(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.bucket.as_deref(), Some("mybucket"));
+                assert_eq!(args.prefix.as_deref(), None);
+                assert_eq!(args.client_token.as_deref(), Some("heal-token-123"));
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
     fn test_parse_admin_pool_status_by_id() {
         let cli = TestCli::parse_from(["rc", "pool", "status", "local", "1", "--by-id"]);
 

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -476,7 +476,7 @@ fn nested_subcommand_help_contract() {
         HelpCase {
             args: &["admin", "heal", "status"],
             usage: "Usage: rc admin heal status [OPTIONS] <ALIAS>",
-            expected_tokens: &[],
+            expected_tokens: &["--bucket", "--prefix", "--client-token"],
         },
         HelpCase {
             args: &["admin", "heal", "start"],
@@ -493,7 +493,7 @@ fn nested_subcommand_help_contract() {
         HelpCase {
             args: &["admin", "heal", "stop"],
             usage: "Usage: rc admin heal stop [OPTIONS] <ALIAS>",
-            expected_tokens: &[],
+            expected_tokens: &["--bucket", "--prefix", "--client-token"],
         },
         HelpCase {
             args: &["admin", "pool", "list"],

--- a/crates/core/src/admin/cluster.rs
+++ b/crates/core/src/admin/cluster.rs
@@ -485,6 +485,21 @@ pub struct HealStartRequest {
     pub dry_run: bool,
 }
 
+/// Request to inspect or stop a token-scoped heal task
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealTaskRequest {
+    /// Bucket being healed
+    pub bucket: String,
+
+    /// Object prefix being healed
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prefix: Option<String>,
+
+    /// Client token returned by the heal start request
+    pub client_token: String,
+}
+
 /// Information about a single heal drive
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct HealDriveInfo {
@@ -569,6 +584,14 @@ pub struct HealStatus {
     /// Whether healing is in progress
     #[serde(default)]
     pub healing: bool,
+
+    /// Task summary for token-scoped manual heal status
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
+    /// Task detail for token-scoped manual heal status
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 
     /// Current bucket being healed
     #[serde(default)]

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -10,9 +10,9 @@ mod types;
 pub use cluster::{
     BackendInfo, BackendType, BucketsInfo, ClusterInfo, DecommissionPoolStatus, DecommissionStatus,
     DiskInfo, HealDriveInfo, HealDriveInfos, HealResultItem, HealScanMode, HealStartRequest,
-    HealStatus, HealingDiskInfo, MemStats, ObjectsInfo, PoolDecommissionInfo, PoolErasureSetInfo,
-    PoolStatus, PoolTarget, RebalanceCleanupWarnings, RebalancePoolProgress, RebalancePoolStatus,
-    RebalanceStartResult, RebalanceStatus, ServerInfo, UsageInfo,
+    HealStatus, HealTaskRequest, HealingDiskInfo, MemStats, ObjectsInfo, PoolDecommissionInfo,
+    PoolErasureSetInfo, PoolStatus, PoolTarget, RebalanceCleanupWarnings, RebalancePoolProgress,
+    RebalancePoolStatus, RebalanceStartResult, RebalanceStatus, ServerInfo, UsageInfo,
 };
 pub use tier::{
     TierAliyun, TierAzure, TierConfig, TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2,
@@ -47,8 +47,14 @@ pub trait AdminApi: Send + Sync {
     /// Start a heal operation
     async fn heal_start(&self, request: HealStartRequest) -> Result<HealStatus>;
 
+    /// Get status for a token-scoped heal task
+    async fn heal_task_status(&self, request: HealTaskRequest) -> Result<HealStatus>;
+
     /// Stop a running heal operation
     async fn heal_stop(&self) -> Result<()>;
+
+    /// Stop a token-scoped heal task
+    async fn heal_task_stop(&self, request: HealTaskRequest) -> Result<HealStatus>;
 
     /// List storage pools
     async fn list_pools(&self) -> Result<Vec<PoolStatus>>;

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -12,9 +12,9 @@ use aws_sigv4::sign::v4;
 use rc_core::admin::{
     AccessKeyInfo, AdminApi, BucketQuota, ClusterInfo, CreateServiceAccountRequest,
     DecommissionPoolStatus, DecommissionStatus, Group, GroupStatus, HealScanMode, HealStartRequest,
-    HealStatus, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RebalanceStartResult,
-    RebalanceStatus, ServiceAccount, ServiceAccountCreateResponse, UpdateGroupMembersRequest, User,
-    UserStatus,
+    HealStatus, HealTaskRequest, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
+    RebalanceStartResult, RebalanceStatus, ServiceAccount, ServiceAccountCreateResponse,
+    UpdateGroupMembersRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
@@ -430,7 +430,7 @@ fn background_heal_scan_mode(scan_mode: Option<u8>) -> Option<HealScanMode> {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Deserialize)]
 struct RustfsHealOptions {
     recursive: bool,
     #[serde(rename = "dryRun")]
@@ -496,6 +496,28 @@ fn rustfs_heal_path(request: &HealStartRequest) -> Result<String> {
     }
 }
 
+fn rustfs_heal_task_path(request: &HealTaskRequest) -> Result<String> {
+    if request.bucket.is_empty() {
+        return Err(Error::InvalidPath(
+            "heal task status requires a bucket target".to_string(),
+        ));
+    }
+
+    let prefix = request
+        .prefix
+        .as_deref()
+        .filter(|prefix| !prefix.is_empty());
+
+    match prefix {
+        Some(prefix) => Ok(format!(
+            "/heal/{}/{}",
+            urlencoding::encode(&request.bucket),
+            urlencoding::encode(prefix)
+        )),
+        None => Ok(format!("/heal/{}", urlencoding::encode(&request.bucket))),
+    }
+}
+
 fn rustfs_heal_body(request: &HealStartRequest) -> Result<Vec<u8>> {
     serde_json::to_vec(&RustfsHealOptions::from(request)).map_err(Error::Json)
 }
@@ -518,6 +540,63 @@ fn pool_target_query(target: &PoolTarget) -> Vec<(&str, &str)> {
         query.push(("by-id", "true"));
     }
     query
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HealStartSuccessResponse {
+    #[serde(default)]
+    client_token: String,
+    #[serde(default, rename = "clientAddress")]
+    _client_address: String,
+    #[serde(default)]
+    start_time: Option<String>,
+}
+
+impl HealStartSuccessResponse {
+    fn into_status(self, request: &HealStartRequest) -> HealStatus {
+        HealStatus {
+            heal_id: self.client_token,
+            bucket: request.bucket.clone().unwrap_or_default(),
+            object: request.prefix.clone().unwrap_or_default(),
+            started: self.start_time,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HealTaskStatusResponse {
+    #[serde(default)]
+    summary: String,
+    #[serde(default, rename = "detail")]
+    detail: String,
+    #[serde(default)]
+    start_time: Option<String>,
+    #[serde(default)]
+    settings: Option<RustfsHealOptions>,
+}
+
+impl HealTaskStatusResponse {
+    fn into_status(self, request: &HealTaskRequest) -> HealStatus {
+        let healing = matches!(self.summary.as_str(), "running");
+        let scan_mode = self.settings.map(|settings| {
+            background_heal_scan_mode(Some(settings.scan_mode)).unwrap_or(HealScanMode::Normal)
+        });
+
+        HealStatus {
+            heal_id: request.client_token.clone(),
+            healing,
+            summary: (!self.summary.is_empty()).then_some(self.summary),
+            detail: (!self.detail.is_empty()).then_some(self.detail),
+            bucket: request.bucket.clone(),
+            object: request.prefix.clone().unwrap_or_default(),
+            scan_mode,
+            started: self.start_time,
+            ..Default::default()
+        }
+    }
 }
 
 /// Request body for setting bucket quota
@@ -546,9 +625,18 @@ impl AdminApi for AdminClient {
     async fn heal_start(&self, request: HealStartRequest) -> Result<HealStatus> {
         let path = rustfs_heal_path(&request)?;
         let body = rustfs_heal_start_body(&request)?;
-        self.request_no_response(Method::POST, &path, None, Some(&body))
+        let response: HealStartSuccessResponse =
+            self.request(Method::POST, &path, None, Some(&body)).await?;
+        Ok(response.into_status(&request))
+    }
+
+    async fn heal_task_status(&self, request: HealTaskRequest) -> Result<HealStatus> {
+        let path = rustfs_heal_task_path(&request)?;
+        let query = [("clientToken", request.client_token.as_str())];
+        let response: HealTaskStatusResponse = self
+            .request(Method::POST, &path, Some(&query), None)
             .await?;
-        Ok(HealStatus::default())
+        Ok(response.into_status(&request))
     }
 
     async fn heal_stop(&self) -> Result<()> {
@@ -560,6 +648,18 @@ impl AdminApi for AdminClient {
             Some(&body),
         )
         .await
+    }
+
+    async fn heal_task_stop(&self, request: HealTaskRequest) -> Result<HealStatus> {
+        let path = rustfs_heal_task_path(&request)?;
+        let query = [
+            ("clientToken", request.client_token.as_str()),
+            ("forceStop", "true"),
+        ];
+        let response: HealTaskStatusResponse = self
+            .request(Method::POST, &path, Some(&query), None)
+            .await?;
+        Ok(response.into_status(&request))
     }
 
     async fn list_pools(&self) -> Result<Vec<PoolStatus>> {
@@ -1413,7 +1513,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_anonymous_admin_no_response_requests_skip_authorization_header() {
-        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"clientToken":"token-anon","clientAddress":"","startTime":"2026-06-25T10:00:00Z"}"#,
+        );
         let client = anonymous_admin_client_for_endpoint(&endpoint);
         let request = HealStartRequest {
             bucket: Some("raw photos".to_string()),
@@ -1449,7 +1552,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_heal_start_posts_to_bucket_prefix_route_with_options_body() {
-        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"clientToken":"heal-token-123","clientAddress":"127.0.0.1:9000","startTime":"2026-06-25T10:00:00Z"}"#,
+        );
         let client = admin_client_for_endpoint(&endpoint);
         let request = HealStartRequest {
             bucket: Some("raw photos".to_string()),
@@ -1466,8 +1572,10 @@ mod tests {
             .expect("heal start request");
 
         assert!(!status.healing);
-        assert!(status.heal_id.is_empty());
-        assert!(status.started.is_none());
+        assert_eq!(status.heal_id, "heal-token-123");
+        assert_eq!(status.bucket, "raw photos");
+        assert_eq!(status.object, "2026/april");
+        assert_eq!(status.started.as_deref(), Some("2026-06-25T10:00:00Z"));
 
         let request = receiver.recv().expect("captured request");
         assert_eq!(request.method, "POST");
@@ -1481,7 +1589,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_heal_start_without_bucket_posts_recursive_root_route() {
-        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", "");
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"clientToken":"root-token","clientAddress":"127.0.0.1:9000","startTime":"2026-06-25T10:00:00Z"}"#,
+        );
         let client = admin_client_for_endpoint(&endpoint);
         let request = HealStartRequest {
             scan_mode: HealScanMode::Deep,
@@ -1497,13 +1608,113 @@ mod tests {
             .expect("recursive root heal start request");
 
         assert!(!status.healing);
-        assert!(status.heal_id.is_empty());
-        assert!(status.started.is_none());
+        assert_eq!(status.heal_id, "root-token");
+        assert!(status.bucket.is_empty());
+        assert!(status.object.is_empty());
+        assert_eq!(status.started.as_deref(), Some("2026-06-25T10:00:00Z"));
 
         let request = receiver.recv().expect("captured request");
         assert_eq!(request.method, "POST");
         assert_eq!(request.target, "/rustfs/admin/v3/heal/");
         assert_heal_options_body(&request.body, true, 2, true, true, true);
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_heal_task_status_queries_bucket_route_with_client_token() {
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"summary":"running","detail":"","startTime":"2026-06-25T10:00:00Z","settings":{"recursive":true,"dryRun":false,"remove":false,"recreate":true,"scanMode":2,"updateParity":false,"nolock":false},"items":[]}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client
+            .heal_task_status(HealTaskRequest {
+                bucket: "raw photos".to_string(),
+                prefix: None,
+                client_token: "heal-token-123".to_string(),
+            })
+            .await
+            .expect("heal task status request");
+
+        assert_eq!(status.heal_id, "heal-token-123");
+        assert!(status.healing);
+        assert_eq!(status.bucket, "raw photos");
+        assert!(status.object.is_empty());
+        assert_eq!(status.scan_mode, Some(HealScanMode::Deep));
+        assert_eq!(status.started.as_deref(), Some("2026-06-25T10:00:00Z"));
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/heal/raw%20photos?clientToken=heal-token-123"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_heal_task_status_queries_prefix_route_with_client_token() {
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"summary":"finished","detail":"","startTime":"2026-06-25T10:00:00Z","settings":{"recursive":false,"dryRun":false,"remove":false,"recreate":false,"scanMode":1,"updateParity":false,"nolock":false},"items":[]}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client
+            .heal_task_status(HealTaskRequest {
+                bucket: "raw photos".to_string(),
+                prefix: Some("2026/april".to_string()),
+                client_token: "heal-token-123".to_string(),
+            })
+            .await
+            .expect("heal task status request");
+
+        assert_eq!(status.heal_id, "heal-token-123");
+        assert!(!status.healing);
+        assert_eq!(status.bucket, "raw photos");
+        assert_eq!(status.object, "2026/april");
+        assert_eq!(status.scan_mode, Some(HealScanMode::Normal));
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/heal/raw%20photos/2026%2Fapril?clientToken=heal-token-123"
+        );
+        assert!(request.body.is_empty());
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn test_heal_task_stop_posts_force_stop_with_client_token() {
+        let (endpoint, receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"summary":"stopped","detail":"heal task cancelled","startTime":"2026-06-25T10:00:00Z","settings":{"recursive":true,"dryRun":false,"remove":false,"recreate":true,"scanMode":2,"updateParity":false,"nolock":false},"items":[]}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client
+            .heal_task_stop(HealTaskRequest {
+                bucket: "raw photos".to_string(),
+                prefix: None,
+                client_token: "heal-token-123".to_string(),
+            })
+            .await
+            .expect("heal task stop request");
+
+        assert_eq!(status.heal_id, "heal-token-123");
+        assert!(!status.healing);
+        assert_eq!(status.bucket, "raw photos");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "POST");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/heal/raw%20photos?clientToken=heal-token-123&forceStop=true"
+        );
+        assert!(request.body.is_empty());
         handle.join().expect("server thread should finish");
     }
 

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -49,6 +49,24 @@ Start a deep heal for a prefix:
 rc admin heal start local --bucket logs --prefix 2026/ --scan-mode deep
 ```
 
+Check global background heal status:
+
+```bash
+rc admin heal status local
+```
+
+Check a manual bucket heal task using the client token returned by `start`:
+
+```bash
+rc admin heal status local --bucket logs --prefix 2026/ --client-token <TOKEN_FROM_START>
+```
+
+Stop a manual bucket heal task:
+
+```bash
+rc admin heal stop local --bucket logs --client-token <TOKEN_FROM_START>
+```
+
 Create a user and attach a policy:
 
 ```bash
@@ -65,6 +83,8 @@ rc admin service-account create local SA_ACCESS_KEY SA_SECRET_KEY --policy ./pol
 ## Behavior
 
 Admin operations use the configured alias to create an admin client. The credentials behind the alias must have permissions for the requested administrative API. The command accepts aliases with or without a trailing slash.
+
+`rc admin heal status <ALIAS>` reports aggregate background heal status. Manual bucket or prefix heals started with `rc admin heal start` are token-scoped tasks; the start output includes a client token, and subsequent task status or stop requests must pass that token with `--bucket`, optional `--prefix`, and `--client-token`.
 
 Global options shown in command syntax use the same meaning everywhere:
 

--- a/schemas/output_v2.json
+++ b/schemas/output_v2.json
@@ -262,6 +262,14 @@
           "type": "boolean",
           "description": "Whether a heal operation is active"
         },
+        "summary": {
+          "type": "string",
+          "description": "Token-scoped manual heal task summary"
+        },
+        "detail": {
+          "type": "string",
+          "description": "Token-scoped manual heal task detail"
+        },
         "bucket": {
           "type": "string",
           "description": "Bucket being healed"
@@ -881,6 +889,10 @@
         },
         "message": {
           "type": "string"
+        },
+        "clientToken": {
+          "type": "string",
+          "description": "Client token returned by a manual heal start request"
         },
         "status": {
           "$ref": "#/definitions/healStatus"


### PR DESCRIPTION
## Related issue

Closes #246

## Background

Manual bucket heal tasks started with `rc admin heal start -b` return a RustFS `clientToken`. The existing `rc admin heal status <ALIAS>` path only queried aggregate background heal status, so it could not report the token-scoped manual task status.

## Root cause

RustFS exposes manual heal task lifecycle APIs through `/heal/{bucket}[/{prefix}]` with `clientToken` and optional `forceStop=true`, while rc only used `/background-heal/status` for status and the root heal route for stop.

## Solution

- Parse and expose the `clientToken` returned by manual heal start.
- Add token-scoped `admin heal status` and `admin heal stop` options: `--bucket`, optional `--prefix`, and `--client-token`.
- Preserve existing `admin heal status <ALIAS>` behavior for aggregate background heal status.
- Update README, admin reference docs, help contract, and output schema.

## BREAKING

This PR updates the protected rc command reference because the heal command behavior contract now documents token-scoped manual heal task status/stop options. Existing `rc admin heal status <ALIAS>` behavior is preserved.

## Test status

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo test --workspace`