### PR TITLE
docs(admin): document heal and rebalance workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ rc admin expand stop local
 rc admin decommission start local '/data/pool1/disk{1...4}'
 rc admin decommission status local '/data/pool1/disk{1...4}'
 rc admin decommission cancel local 1 --by-id
+rc admin decommission clear local 1 --by-id
 
 # Rebalance data after adding server pools
 rc admin rebalance start local
@@ -331,7 +332,7 @@ For full command documentation, see the [`rc` command reference](docs/reference/
 | `admin heal`            | Manage cluster healing operations (status, start, stop)                               |
 | `admin pool`            | List pools and inspect expansion/decommission status                                  |
 | `admin expand`          | Manage post-expansion data rebalancing (start, status, stop)                          |
-| `admin decommission`    | Manage server pool decommissioning (start, status, cancel)                            |
+| `admin decommission`    | Manage server pool decommissioning (start, status, cancel, clear)                     |
 | `admin rebalance`       | Manage post-expansion rebalancing (start, status, stop)                               |
 
 ### ILM Subcommands

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -12,7 +12,8 @@ rc admin info <cluster|server|disk> <ALIAS> [OPTIONS]
 rc admin heal <status|start|stop> <ALIAS> [OPTIONS]
 rc admin pool <list|status> <ALIAS> [POOL] [OPTIONS]
 rc admin expand <start|status|stop> <ALIAS>
-rc admin decommission <start|status|cancel> <ALIAS> <POOL> [OPTIONS]
+rc admin decommission <start|cancel|clear> <ALIAS> <POOL> [OPTIONS]
+rc admin decommission status <ALIAS> [POOL] [OPTIONS]
 rc admin rebalance <start|status|stop> <ALIAS>
 rc admin user <ls|add|info|rm|enable|disable> ...
 rc admin policy <ls|create|info|rm|attach> ...
@@ -67,6 +68,34 @@ Stop a manual bucket heal task:
 rc admin heal stop local --bucket logs --client-token <TOKEN_FROM_START>
 ```
 
+Start decommissioning a pool:
+
+```bash
+rc admin decommission start local '/data/pool1/disk{1...4}'
+```
+
+Check decommissioning status for all pools:
+
+```bash
+rc admin decommission status local
+```
+
+Check, cancel, or clear decommissioning by pool ID:
+
+```bash
+rc admin decommission status local 1 --by-id
+rc admin decommission cancel local 1 --by-id
+rc admin decommission clear local 1 --by-id
+```
+
+Start and inspect post-expansion rebalancing:
+
+```bash
+rc admin rebalance start local
+rc admin rebalance status local
+rc admin rebalance stop local
+```
+
 Create a user and attach a policy:
 
 ```bash
@@ -85,6 +114,56 @@ rc admin service-account create local SA_ACCESS_KEY SA_SECRET_KEY --policy ./pol
 Admin operations use the configured alias to create an admin client. The credentials behind the alias must have permissions for the requested administrative API. The command accepts aliases with or without a trailing slash.
 
 `rc admin heal status <ALIAS>` reports aggregate background heal status. Manual bucket or prefix heals started with `rc admin heal start` are token-scoped tasks; the start output includes a client token, and subsequent task status or stop requests must pass that token with `--bucket`, optional `--prefix`, and `--client-token`.
+
+## Heal Workflow
+
+`rc admin heal` manages cluster healing operations.
+
+| Command | Description |
+| --- | --- |
+| `rc admin heal status <ALIAS>` | Show aggregate background heal status. |
+| `rc admin heal status <ALIAS> --bucket <BUCKET> [--prefix <PREFIX>] --client-token <TOKEN>` | Show a token-scoped manual heal task. |
+| `rc admin heal start <ALIAS> [OPTIONS]` | Start a manual heal operation. |
+| `rc admin heal stop <ALIAS>` | Stop the global background heal operation. |
+| `rc admin heal stop <ALIAS> --bucket <BUCKET> [--prefix <PREFIX>] --client-token <TOKEN>` | Stop a token-scoped manual heal task. |
+
+`heal start` accepts these operation options:
+
+| Option | Description |
+| --- | --- |
+| `-b, --bucket <BUCKET>` | Heal a single bucket. Omit this option to recursively heal all buckets. |
+| `-p, --prefix <PREFIX>` | Limit a bucket heal to an object prefix. |
+| `--scan-mode normal\|deep` | Select the scan mode. Defaults to `normal`. |
+| `--remove` | Remove dangling objects or parts found by the heal scan. |
+| `--recreate` | Recreate missing data. |
+| `--dry-run` | Report what would be healed without applying changes. |
+
+Manual bucket and prefix heals are token-scoped. Save the `clientToken` returned by `heal start`; the token is required to inspect or stop that manual task.
+
+## Decommission Workflow
+
+`rc admin decommission` retires server pools from a cluster. The `POOL` argument can be a pool command line, comma-separated pool command lines, or a zero-based pool ID when `--by-id` is set.
+
+| Command | Description |
+| --- | --- |
+| `rc admin decommission start <ALIAS> <POOL> [--by-id]` | Start decommissioning one or more pools. |
+| `rc admin decommission status <ALIAS> [POOL] [--by-id]` | Show decommissioning status for all pools or one pool. |
+| `rc admin decommission cancel <ALIAS> <POOL> [--by-id]` | Cancel decommissioning for a pool. |
+| `rc admin decommission clear <ALIAS> <POOL> [--by-id]` | Clear failed or canceled decommissioning metadata for a pool. |
+
+Use `rc admin pool list <ALIAS>` or `rc admin pool status <ALIAS>` to find pool IDs and pool command lines before starting a decommission.
+
+## Rebalance Workflow
+
+`rc admin rebalance` manages post-expansion data movement after server pools are added to a deployment.
+
+| Command | Description |
+| --- | --- |
+| `rc admin rebalance start <ALIAS>` | Start a cluster rebalance operation. |
+| `rc admin rebalance status <ALIAS>` | Show cluster-wide and per-pool rebalance status. |
+| `rc admin rebalance stop <ALIAS>` | Stop a running rebalance operation. |
+
+`rc admin expand` is an alias-oriented workflow for the same post-expansion rebalance step. The `expand` command is also available as `scale`.
 
 Global options shown in command syntax use the same meaning everywhere:
 


### PR DESCRIPTION
## Summary
- Document `admin heal` status/start/stop workflow and manual heal token usage.
- Document `admin decommission` start/status/cancel/clear workflow, including the existing `clear` subcommand.
- Document `admin rebalance` start/status/stop workflow and align README examples with the reference docs.

## Breaking Change Process
BREAKING: This PR updates protected CLI reference documentation for existing admin workflows. It does not change CLI runtime behavior, JSON output, or config schema.

## Test Plan
- `git diff --check`

## Notes
- Docs-only update; Rust formatting, clippy, and tests were skipped under the markdown-only exception.
- No CLI, JSON output, or config contract behavior was changed.