### PR TITLE
docs(admin)!: clarify RustFS-only Admin API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A S3-compatible command-line client written in Rust.
 ## Features
 
 - 🚀 **High Performance** - Written in Rust with async concurrent operations
-- 🔧 **S3 Compatible** - Supports RustFS, MinIO, AWS S3, and other S3-compatible services
+- 🔧 **S3 Compatible** - Data operations support RustFS, MinIO, AWS S3, and other S3-compatible services
 - 📦 **Cross-Platform** - Supports Linux, macOS, and Windows
 - 🎨 **Friendly Output** - Human-readable and JSON format output
 - 🔒 **Secure** - Secure credential storage, no sensitive data in logs
@@ -469,12 +469,14 @@ region = "us-east-1"
 
 ### Supported Backends
 
-| Backend             | Tier        | Description         |
-|---------------------|-------------|---------------------|
-| RustFS              | Tier 1      | Fully supported     |
-| MinIO               | Tier 2      | Fully supported     |
-| AWS S3              | Tier 3      | Best effort support |
-| Other S3-compatible | Best Effort | No guarantee        |
+These tiers describe S3-compatible data operations. The `rc admin` commands use the RustFS Admin API and do not support MinIO Admin API endpoints.
+
+| Backend             | Tier        | Description                       |
+|---------------------|-------------|-----------------------------------|
+| RustFS              | Tier 1      | S3 and Admin APIs supported       |
+| MinIO               | Tier 2      | S3 operations supported           |
+| AWS S3              | Tier 3      | Best effort S3 support            |
+| Other S3-compatible | Best Effort | No compatibility guarantee        |
 
 ### Minimum Rust Version
 

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -1,7 +1,7 @@
 //! Admin commands for IAM and cluster management
 //!
 //! This module provides commands for managing users, policies, groups,
-//! service accounts, and cluster operations on RustFS/MinIO-compatible servers.
+//! service accounts, and cluster operations through the RustFS Admin API.
 
 mod access_key;
 mod decommission;

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -33,7 +33,7 @@ use crate::error::Result;
 ///
 /// This trait defines the interface for managing users, policies, groups,
 /// service accounts, and cluster operations on S3-compatible storage systems
-/// that support the RustFS/MinIO Admin API.
+/// that support the RustFS Admin API.
 #[async_trait]
 pub trait AdminApi: Send + Sync {
     // ==================== Cluster Operations ====================

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -24,7 +24,7 @@ use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 
-/// Admin API client for RustFS/MinIO-compatible servers
+/// Admin API client for RustFS servers
 pub struct AdminClient {
     http_client: Client,
     endpoint: String,
@@ -944,7 +944,7 @@ impl AdminApi for AdminClient {
         entity_name: &str,
     ) -> Result<()> {
         // Detach by setting empty policy
-        // In RustFS/MinIO, you typically set a new policy which replaces the old one
+        // RustFS replaces the previous policy association when a new one is set.
         // For detach, we need to get current policies and remove the specified ones
         let _ = (policy_names, entity_type, entity_name);
         Err(Error::UnsupportedFeature(

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -2,7 +2,9 @@
 
 ## Purpose
 
-The `rc admin` operation manages RustFS or MinIO-compatible administrative APIs, including cluster information, healing, pools, expansion, decommissioning, rebalance workflows, IAM users, policies, groups, and service accounts.
+The `rc admin` operation manages the RustFS Admin API, including cluster information, healing, pools, expansion, decommissioning, rebalance workflows, IAM users, policies, groups, and service accounts.
+
+`rc admin` does not implement the MinIO Admin API. MinIO aliases remain available to S3 data commands, but MinIO administrative operations require a MinIO-compatible admin client.
 
 ## Syntax
 
@@ -111,7 +113,7 @@ rc admin service-account create local SA_ACCESS_KEY SA_SECRET_KEY --policy ./pol
 
 ## Behavior
 
-Admin operations use the configured alias to create an admin client. The credentials behind the alias must have permissions for the requested administrative API. The command accepts aliases with or without a trailing slash.
+Admin operations use the configured alias to create a RustFS admin client. The credentials behind the alias must have permissions for the requested administrative API. The command accepts aliases with or without a trailing slash.
 
 `rc admin heal status <ALIAS>` reports aggregate background heal status. Manual bucket or prefix heals started with `rc admin heal start` are token-scoped tasks; the start output includes a client token, and subsequent task status or stop requests must pass that token with `--bucket`, optional `--prefix`, and `--client-token`.
 


### PR DESCRIPTION
Closes #235.

## What changed

- Clarify that MinIO compatibility covers S3 data operations.
- Document that `rc admin` targets the RustFS Admin API only.
- Align public Rust documentation with that boundary.

## Why

MinIO uses different admin routes, API versions, encrypted payloads, and response contracts. Replacing `/rustfs/admin/v3` with a MinIO prefix would not provide reliable compatibility, so the previous documentation was misleading.

## Validation

- `make pre-commit`

BREAKING CHANGE: The documented Admin API compatibility contract is narrowed to RustFS. MinIO S3 data operations remain supported.
