### PR TITLE
test(cp): cover symlink file download destination

### DIFF
--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -1156,6 +1156,22 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn download_destination_rejects_existing_symlink_file() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().expect("create destination root");
+        let outside = tempfile::tempdir().expect("create outside directory");
+        let outside_file = outside.path().join("file.txt");
+        std::fs::write(&outside_file, b"outside").expect("write outside file");
+        symlink(&outside_file, root.path().join("file.txt")).expect("create test symlink");
+
+        let result = safe_download_destination(root.path(), &PathBuf::from("file.txt")).await;
+
+        assert!(result.is_err());
+    }
+
     #[test]
     fn test_select_upload_content_type_uses_guess_for_small_files() {
         let selected =


### PR DESCRIPTION
## Summary
- Add a focused regression test for recursive download destination hardening when the final target file is a symlink.
- Covers the adjacent branch added by recent download safety hardening; existing coverage only checked symlink directory components.

## Validation
- cargo test -p rustfs-cli download_destination_rejects_existing_symlink_file
- cargo fmt --all --check
- make pre-commit