### PR TITLE
feat(admin): support inline service account policy JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,11 @@ rc admin policy attach local/ readonly --user newuser
 # Create a service account (access_key + secret_key)
 rc admin service-account create local/ AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
-# Create a service account with inline policy file
+# Create a service account with a policy file
 rc admin service-account create local/ SAKEY123 SASECRET123 --policy ./service-account-policy.json
+
+# Create a service account with inline policy JSON
+rc admin service-account create local/ SAKEY123 SASECRET123 --policy-json '{"Version":"2012-10-17","Statement":[]}'
 
 # Update selected fields on an existing service account
 rc admin service-account update local/ SAKEY123 --policy ./service-account-policy.json --description "Automation access"

--- a/crates/cli/src/commands/admin/service_account.rs
+++ b/crates/cli/src/commands/admin/service_account.rs
@@ -66,8 +66,12 @@ pub struct CreateArgs {
     pub description: Option<String>,
 
     /// Optional policy document (JSON file path)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "policy_json")]
     pub policy: Option<String>,
+
+    /// Optional inline policy document (JSON string)
+    #[arg(long, conflicts_with = "policy")]
+    pub policy_json: Option<String>,
 
     /// Optional expiration time (ISO 8601 format)
     #[arg(long)]
@@ -95,8 +99,12 @@ pub struct UpdateArgs {
     pub description: Option<String>,
 
     /// Replacement policy document (JSON file path)
-    #[arg(long)]
+    #[arg(long, conflicts_with = "policy_json")]
     pub policy: Option<String>,
+
+    /// Replacement inline policy document (JSON string)
+    #[arg(long, conflicts_with = "policy")]
+    pub policy_json: Option<String>,
 
     /// Replacement expiration time (ISO 8601 format)
     #[arg(long)]
@@ -226,25 +234,17 @@ async fn execute_list(args: ListArgs, formatter: &Formatter) -> ExitCode {
 }
 
 async fn execute_create(args: CreateArgs, formatter: &Formatter) -> ExitCode {
+    let policy = match resolve_policy_input(args.policy.as_deref(), args.policy_json.as_deref()) {
+        Ok(policy) => policy,
+        Err(error) => {
+            formatter.error(&error);
+            return ExitCode::UsageError;
+        }
+    };
+
     let client = match get_admin_client(&args.alias, formatter) {
         Ok(c) => c,
         Err(code) => return code,
-    };
-
-    // Read policy if provided
-    let policy = if let Some(policy_path) = &args.policy {
-        match std::fs::read_to_string(policy_path) {
-            Ok(content) => Some(content),
-            Err(e) => {
-                formatter.error(&format!(
-                    "Failed to read policy file '{}': {e}",
-                    policy_path
-                ));
-                return ExitCode::UsageError;
-            }
-        }
-    } else {
-        None
     };
 
     let request = build_create_service_account_request(&args, policy);
@@ -313,19 +313,12 @@ fn should_retry_with_default_expiry(args: &CreateArgs, error: &rc_core::Error) -
 }
 
 async fn execute_update(args: UpdateArgs, formatter: &Formatter) -> ExitCode {
-    let policy = if let Some(policy_path) = &args.policy {
-        match std::fs::read_to_string(policy_path) {
-            Ok(content) => Some(content),
-            Err(e) => {
-                formatter.error(&format!(
-                    "Failed to read policy file '{}': {e}",
-                    policy_path
-                ));
-                return ExitCode::UsageError;
-            }
+    let policy = match resolve_policy_input(args.policy.as_deref(), args.policy_json.as_deref()) {
+        Ok(policy) => policy,
+        Err(error) => {
+            formatter.error(&error);
+            return ExitCode::UsageError;
         }
-    } else {
-        None
     };
 
     let request = build_update_service_account_request(&args, policy);
@@ -367,6 +360,27 @@ async fn execute_update(args: UpdateArgs, formatter: &Formatter) -> ExitCode {
             formatter.error(&format!("Failed to update service account: {e}"));
             ExitCode::GeneralError
         }
+    }
+}
+
+fn resolve_policy_input(
+    policy_path: Option<&str>,
+    policy_json: Option<&str>,
+) -> Result<Option<String>, String> {
+    match (policy_path, policy_json) {
+        (Some(_), Some(_)) => Err("--policy and --policy-json cannot be used together".to_string()),
+        (Some(path), None) => std::fs::read_to_string(path)
+            .map(Some)
+            .map_err(|error| format!("Failed to read policy file '{path}': {error}")),
+        (None, Some(policy)) => {
+            let value: serde_json::Value = serde_json::from_str(policy)
+                .map_err(|error| format!("Policy JSON is not valid JSON: {error}"))?;
+            if !value.is_object() {
+                return Err("Policy JSON must be a JSON object".to_string());
+            }
+            Ok(Some(policy.to_string()))
+        }
+        (None, None) => Ok(None),
     }
 }
 
@@ -496,6 +510,7 @@ mod tests {
             name: None,
             description: None,
             policy: None,
+            policy_json: None,
             expiry: None,
         };
 
@@ -513,6 +528,7 @@ mod tests {
             name: Some("manual-name".to_string()),
             description: Some("demo".to_string()),
             policy: None,
+            policy_json: None,
             expiry: Some("2030-01-01T00:00:00Z".to_string()),
         };
 
@@ -524,6 +540,22 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_policy_input_accepts_inline_json_object() {
+        let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        let resolved = resolve_policy_input(None, Some(policy)).expect("resolve inline policy");
+
+        assert_eq!(resolved.as_deref(), Some(policy));
+    }
+
+    #[test]
+    fn test_resolve_policy_input_rejects_non_object_json() {
+        let error = resolve_policy_input(None, Some(r#"["s3:GetObject"]"#))
+            .expect_err("policy must be a JSON object");
+
+        assert_eq!(error, "Policy JSON must be a JSON object");
+    }
+
+    #[test]
     fn test_build_update_request_keeps_only_explicit_fields() {
         let args = UpdateArgs {
             alias: "local".to_string(),
@@ -532,6 +564,7 @@ mod tests {
             name: Some("automation-key".to_string()),
             description: Some("Updated description".to_string()),
             policy: Some("policy.json".to_string()),
+            policy_json: None,
             expiry: None,
             status: Some("enabled".to_string()),
         };
@@ -564,6 +597,7 @@ mod tests {
             name: None,
             description: None,
             policy: None,
+            policy_json: None,
             expiry: None,
             status: None,
         };
@@ -581,6 +615,7 @@ mod tests {
             name: None,
             description: None,
             policy: None,
+            policy_json: None,
             expiry: None,
         };
         let error = rc_core::Error::InvalidPath("missing field `expiration`".to_string());
@@ -596,6 +631,7 @@ mod tests {
             name: None,
             description: None,
             policy: None,
+            policy_json: None,
             expiry: Some("2030-01-01T00:00:00Z".to_string()),
         };
         let error = rc_core::Error::InvalidPath("missing field `expiration`".to_string());

--- a/crates/cli/tests/admin_service_account.rs
+++ b/crates/cli/tests/admin_service_account.rs
@@ -9,6 +9,66 @@ use std::time::Duration;
 use admin_support::{rc_binary, rc_host_alias, start_admin_test_server};
 
 #[test]
+fn service_account_create_accepts_inline_policy_json() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(
+        r#"{"credentials":{"accessKey":"service-key","secretKey":"service-secret"}}"#,
+    );
+    let policy = r#"{"Version":"2012-10-17","Statement":[]}"#;
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "service-account",
+            "create",
+            "myalias",
+            "service-key",
+            "service-secret",
+            "--policy-json",
+            policy,
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "PUT");
+    assert_eq!(request.target, "/rustfs/admin/v3/add-service-accounts");
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn service_account_create_rejects_invalid_inline_policy_json() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "service-account",
+            "create",
+            "myalias",
+            "service-key",
+            "service-secret",
+            "--policy-json",
+            "{not-json}",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Policy JSON is not valid JSON"));
+}
+
+#[test]
 fn service_account_update_dispatches_to_update_endpoint() {
     let config_dir = tempfile::tempdir().expect("create config dir");
     let policy_dir = tempfile::tempdir().expect("create policy dir");

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -757,7 +757,13 @@ fn nested_subcommand_help_contract() {
         HelpCase {
             args: &["admin", "service-account", "create"],
             usage: "Usage: rc admin service-account create [OPTIONS] <ALIAS> <ACCESS_KEY> <SECRET_KEY>",
-            expected_tokens: &["--name", "--description", "--policy", "--expiry"],
+            expected_tokens: &[
+                "--name",
+                "--description",
+                "--policy",
+                "--policy-json",
+                "--expiry",
+            ],
         },
         HelpCase {
             args: &["admin", "service-account", "update"],
@@ -767,6 +773,7 @@ fn nested_subcommand_help_contract() {
                 "--name",
                 "--description",
                 "--policy",
+                "--policy-json",
                 "--expiry",
                 "--status",
             ],


### PR DESCRIPTION
## Related issue

Closes #259

## Background

Service account policies currently require a temporary JSON file passed through `--policy`. Infrastructure automation that already generates the policy as JSON must write and clean up that file before invoking `rc`.

## Design

Keep `--policy` as the existing file-path input and add an explicit `--policy-json` literal input. This avoids ambiguous content-versus-path detection, preserves MinIO-compatible file behavior, and follows the common CLI pattern of separating literal and file sources.

The two options are mutually exclusive.

## Solution

- Add `--policy-json <JSON>` to service account create and update commands.
- Parse and validate inline policy JSON before alias resolution or network access.
- Require the inline document to have a JSON object at its top level.
- Preserve the original JSON string when sending the admin API request.
- Keep the existing `--policy <FILE>` behavior unchanged.
- Add unit, CLI integration, help-contract, and README coverage.

## User impact

Automation can pass generated policy documents directly without creating temporary files:

```bash
rc admin service-account create local/ SAKEY SASECRET \
  --policy-json '{"Version":"2012-10-17","Statement":[]}'
```

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
