### PR TITLE
feat(admin): classify RustFS diagnostic capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ name = "rustfs-cli"
 version = "0.1.24"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "clap_complete",
  "comfy-table",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -62,6 +62,7 @@ integration = []
 golden = []
 
 [dev-dependencies]
+async-trait.workspace = true
 tempfile.workspace = true
 insta.workspace = true
 jsonschema.workspace = true

--- a/crates/cli/src/commands/admin/capabilities.rs
+++ b/crates/cli/src/commands/admin/capabilities.rs
@@ -1,0 +1,514 @@
+//! Runtime capability discovery command.
+
+use clap::Args;
+use rc_core::Error;
+use rc_core::admin::{CapabilityApi, CapabilityAvailability, CapabilityReport};
+use serde::Serialize;
+
+use super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+/// Inspect the effective RustFS Admin API capabilities.
+#[derive(Args, Debug)]
+pub struct CapabilitiesArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Bypass the in-process capability cache
+    #[arg(long)]
+    pub refresh: bool,
+}
+
+/// Execute runtime capability discovery.
+pub async fn execute(args: CapabilitiesArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_with_api(args.refresh, &client, formatter).await
+}
+
+async fn execute_with_api(
+    refresh: bool,
+    api: &dyn CapabilityApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    match api.discover_capabilities(refresh).await {
+        Ok(report) => {
+            if formatter.is_json() {
+                formatter.json(&success_output(&report));
+            } else {
+                print_report(&report, formatter);
+            }
+            ExitCode::Success
+        }
+        Err(error) => emit_capability_error(&error, "Failed to discover capabilities", formatter),
+    }
+}
+
+fn emit_capability_error(error: &Error, context: &str, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    let message = format!("{context}: {error}");
+    if formatter.is_json() {
+        formatter.json_error(&error_output(error, code, message));
+    } else {
+        formatter.error_with_code(code, &message);
+    }
+    code
+}
+
+fn print_report(report: &CapabilityReport, formatter: &Formatter) {
+    for line in report_lines(report, formatter) {
+        formatter.println(&line);
+    }
+}
+
+fn report_lines(report: &CapabilityReport, formatter: &Formatter) -> Vec<String> {
+    let version = formatter.sanitize_text(report.server_version.as_deref().unwrap_or("unknown"));
+    let mut lines = vec![
+        format!("RustFS capabilities ({version})"),
+        String::new(),
+        "CAPABILITY                         STATUS             REASON".to_string(),
+    ];
+    for capability in &report.capabilities {
+        let name = formatter.sanitize_text(&capability.name);
+        let reason = formatter.sanitize_text(capability.reason.as_deref().unwrap_or("-"));
+        lines.push(format!(
+            "{:<34} {:<18} {}",
+            name, capability.availability, reason
+        ));
+    }
+
+    if !report.extensions.is_empty() {
+        lines.push(String::new());
+        lines.push(format!("Extensions: {}", report.extensions.len()));
+    }
+
+    lines
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesSuccessOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: CapabilitiesData,
+    meta: CapabilitiesMeta,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesData {
+    server: &'static str,
+    api_version: Option<&'static str>,
+    capabilities: Vec<CapabilityOutput>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilityOutput {
+    name: String,
+    scope: &'static str,
+    support: &'static str,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesMeta {
+    server_version: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: CapabilityErrorOutput,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+enum CapabilityErrorOutput {
+    Unsupported(UnsupportedCapabilityError),
+    Standard(StandardCapabilityError),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct UnsupportedCapabilityError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    capability: &'static str,
+    server: Option<String>,
+    suggestion: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct StandardCapabilityError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    suggestion: Option<&'static str>,
+}
+
+fn success_output(report: &CapabilityReport) -> CapabilitiesSuccessOutput {
+    let api_version = !report.capabilities.iter().any(|capability| {
+        capability.name == "admin.runtime-capabilities"
+            && capability.availability == CapabilityAvailability::VersionGated
+    });
+    let capabilities = report
+        .capabilities
+        .iter()
+        .map(|capability| CapabilityOutput {
+            name: capability.name.clone(),
+            scope: capability_scope(&capability.name),
+            support: capability_support(capability.availability),
+            reason: capability.reason.clone(),
+        })
+        .collect();
+
+    CapabilitiesSuccessOutput {
+        schema_version: 3,
+        output_type: "capabilities",
+        status: "success",
+        data: CapabilitiesData {
+            server: "rustfs",
+            api_version: api_version.then_some("v4"),
+            capabilities,
+        },
+        meta: CapabilitiesMeta {
+            server_version: report.server_version.clone(),
+        },
+    }
+}
+
+fn capability_scope(name: &str) -> &'static str {
+    if name.starts_with("runtime.") {
+        "runtime"
+    } else if name.starts_with("admin.") {
+        "admin"
+    } else {
+        "server"
+    }
+}
+
+const fn capability_support(availability: CapabilityAvailability) -> &'static str {
+    match availability {
+        CapabilityAvailability::Available => "supported",
+        CapabilityAvailability::Stubbed => "stub",
+        CapabilityAvailability::Unsupported => "unsupported",
+        CapabilityAvailability::Disabled => "disabled",
+        CapabilityAvailability::VersionGated => "unsupported",
+        CapabilityAvailability::PermissionDenied | CapabilityAvailability::Unknown => "unknown",
+    }
+}
+
+fn error_output(error: &Error, code: ExitCode, message: String) -> CapabilitiesErrorOutput {
+    let error = if matches!(error, Error::UnsupportedFeature(_)) {
+        CapabilityErrorOutput::Unsupported(UnsupportedCapabilityError {
+            error_type: "unsupported_feature",
+            message,
+            retryable: false,
+            capability: "runtime_capabilities",
+            server: None,
+            suggestion: Some("Upgrade RustFS or retry after verifying server capability support."),
+        })
+    } else {
+        let (error_type, retryable, suggestion) = standard_error_metadata(code);
+        CapabilityErrorOutput::Standard(StandardCapabilityError {
+            error_type,
+            message,
+            retryable,
+            suggestion,
+        })
+    };
+
+    CapabilitiesErrorOutput {
+        schema_version: 3,
+        output_type: "capabilities",
+        status: "error",
+        error,
+    }
+}
+
+const fn standard_error_metadata(code: ExitCode) -> (&'static str, bool, Option<&'static str>) {
+    match code {
+        ExitCode::UsageError => (
+            "usage_error",
+            false,
+            Some("Run the command with --help and verify its arguments."),
+        ),
+        ExitCode::NetworkError => (
+            "network_error",
+            true,
+            Some("Verify the endpoint and network connectivity, then retry."),
+        ),
+        ExitCode::AuthError => (
+            "auth_error",
+            false,
+            Some("Verify the alias credentials and ServerInfoAdminAction permission."),
+        ),
+        ExitCode::NotFound => (
+            "not_found",
+            false,
+            Some("Verify that the alias and server endpoint exist."),
+        ),
+        ExitCode::Conflict => (
+            "conflict",
+            false,
+            Some("Review the server state and retry."),
+        ),
+        ExitCode::Interrupted => (
+            "interrupted",
+            true,
+            Some("Retry the command if capability discovery is still needed."),
+        ),
+        ExitCode::Success | ExitCode::GeneralError | ExitCode::UnsupportedFeature => {
+            ("general_error", false, None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use jsonschema::Validator;
+    use rc_core::Result;
+    use rc_core::admin::{
+        CapabilityAvailability, CapabilityEntry, ClusterSnapshotMetadata, ExtensionMetadata,
+    };
+    use serde_json::Value;
+    use std::path::Path;
+
+    use super::*;
+    use crate::output::OutputConfig;
+
+    const SUCCESS_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/runtime_success.json");
+    const VERSION_GATED_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/version_gated.json");
+    const RUNTIME_UNSUPPORTED_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/runtime_unsupported.json");
+    const AUTH_ERROR_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/auth_error.json");
+
+    struct StubCapabilityApi {
+        result: Result<CapabilityReport>,
+    }
+
+    #[async_trait]
+    impl CapabilityApi for StubCapabilityApi {
+        async fn discover_capabilities(&self, _refresh: bool) -> Result<CapabilityReport> {
+            match &self.result {
+                Ok(report) => Ok(report.clone()),
+                Err(Error::Auth(message)) => Err(Error::Auth(message.clone())),
+                Err(Error::UnsupportedFeature(message)) => {
+                    Err(Error::UnsupportedFeature(message.clone()))
+                }
+                Err(error) => Err(Error::General(error.to_string())),
+            }
+        }
+    }
+
+    fn report() -> CapabilityReport {
+        CapabilityReport {
+            server_version: Some("1.0.0-beta.10".to_string()),
+            runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+            extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+            cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+            capabilities: vec![CapabilityEntry {
+                name: "runtime.observability".to_string(),
+                availability: CapabilityAvailability::Available,
+                reason: None,
+            }],
+            extensions: Vec::<ExtensionMetadata>::new(),
+            cluster: ClusterSnapshotMetadata {
+                summary: None,
+                runtime_capabilities_path: None,
+                extensions_catalog_path: None,
+            },
+        }
+    }
+
+    fn output_v3_validator() -> Validator {
+        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("schemas/output_v3.json");
+        let schema = std::fs::read_to_string(&schema_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+        let schema: Value = serde_json::from_str(&schema).expect("output v3 schema should parse");
+        jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+    }
+
+    fn assert_valid_v3(value: &Value) {
+        let validator = output_v3_validator();
+        let errors = validator
+            .iter_errors(value)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            errors.is_empty(),
+            "capability output must satisfy output v3:\n{}",
+            errors.join("\n")
+        );
+    }
+
+    fn golden(contents: &str) -> Value {
+        serde_json::from_str(contents).expect("capability golden fixture should parse")
+    }
+
+    #[tokio::test]
+    async fn command_returns_success_for_discovery_report() {
+        let formatter = Formatter::new(OutputConfig {
+            quiet: true,
+            ..Default::default()
+        });
+        let api = StubCapabilityApi {
+            result: Ok(report()),
+        };
+
+        assert_eq!(
+            execute_with_api(false, &api, &formatter).await,
+            ExitCode::Success
+        );
+    }
+
+    #[tokio::test]
+    async fn command_preserves_permission_denial_exit_code() {
+        let formatter = Formatter::new(OutputConfig {
+            json: true,
+            ..Default::default()
+        });
+        let api = StubCapabilityApi {
+            result: Err(Error::Auth("Access denied".to_string())),
+        };
+
+        assert_eq!(
+            execute_with_api(false, &api, &formatter).await,
+            ExitCode::AuthError
+        );
+    }
+
+    #[tokio::test]
+    async fn command_preserves_unsupported_feature_exit_code() {
+        let formatter = Formatter::new(OutputConfig {
+            json: true,
+            ..Default::default()
+        });
+        let api = StubCapabilityApi {
+            result: Err(Error::UnsupportedFeature("NotImplemented".to_string())),
+        };
+
+        assert_eq!(
+            execute_with_api(false, &api, &formatter).await,
+            ExitCode::UnsupportedFeature
+        );
+    }
+
+    #[test]
+    fn success_json_uses_capabilities_output_v3_contract() {
+        let value = serde_json::to_value(success_output(&report()))
+            .expect("capability success output should serialize");
+
+        assert_eq!(value, golden(SUCCESS_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn version_gated_json_is_a_v3_unsupported_capability() {
+        let mut report = report();
+        report.capabilities = vec![CapabilityEntry {
+            name: "admin.runtime-capabilities".to_string(),
+            availability: CapabilityAvailability::VersionGated,
+            reason: Some("Admin API v4 is unavailable".to_string()),
+        }];
+        let value = serde_json::to_value(success_output(&report))
+            .expect("version-gated output should serialize");
+
+        assert_eq!(value["data"]["api_version"], Value::Null);
+        assert_eq!(value["data"]["capabilities"][0]["support"], "unsupported");
+        assert_eq!(value, golden(VERSION_GATED_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn runtime_unsupported_json_is_distinct_from_a_stub() {
+        let mut report = report();
+        report.capabilities = vec![CapabilityEntry {
+            name: "runtime.memory-sampling".to_string(),
+            availability: CapabilityAvailability::Unsupported,
+            reason: Some("not available on this platform".to_string()),
+        }];
+        let value = serde_json::to_value(success_output(&report))
+            .expect("runtime unsupported output should serialize");
+
+        assert_eq!(value["data"]["api_version"], "v4");
+        assert_eq!(value["data"]["capabilities"][0]["support"], "unsupported");
+        assert_ne!(value["data"]["capabilities"][0]["support"], "stub");
+        assert_eq!(value, golden(RUNTIME_UNSUPPORTED_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn discovery_error_json_uses_capabilities_output_v3_contract() {
+        let error = Error::Auth("Access denied".to_string());
+        let value = serde_json::to_value(error_output(
+            &error,
+            ExitCode::AuthError,
+            format!("Failed to discover capabilities: {error}"),
+        ))
+        .expect("capability error output should serialize");
+
+        assert_eq!(value["schema_version"], 3);
+        assert_eq!(value["type"], "capabilities");
+        assert_eq!(value["status"], "error");
+        assert_eq!(value["error"]["type"], "auth_error");
+        assert_eq!(value["error"]["retryable"], false);
+        assert_eq!(value, golden(AUTH_ERROR_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn unsupported_error_json_uses_specialized_v3_contract() {
+        let error = Error::UnsupportedFeature("NotImplemented".to_string());
+        let value = serde_json::to_value(error_output(
+            &error,
+            ExitCode::UnsupportedFeature,
+            format!("Failed to discover capabilities: {error}"),
+        ))
+        .expect("unsupported capability error should serialize");
+
+        assert_eq!(value["error"]["type"], "unsupported_feature");
+        assert_eq!(value["error"]["capability"], "runtime_capabilities");
+        assert_eq!(value["error"]["server"], Value::Null);
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn table_output_sanitizes_server_controlled_strings() {
+        let mut report = report();
+        report.server_version = Some("beta.10\n\u{1b}[31m".to_string());
+        report.capabilities[0].name = "runtime.bad\nname\u{1b}[2J".to_string();
+        report.capabilities[0].reason = Some("line one\r\nline two\u{1b}[0m".to_string());
+        let formatter = Formatter::new(OutputConfig {
+            no_color: true,
+            ..Default::default()
+        });
+
+        let lines = report_lines(&report, &formatter);
+
+        assert!(lines.iter().all(|line| !line.contains('\u{1b}')));
+        assert!(lines.iter().all(|line| !line.contains('\r')));
+        assert!(lines.iter().all(|line| !line.contains('\n')));
+        assert!(lines.iter().any(|line| line.contains("beta.10\\n\\u{1b}")));
+        assert!(lines.iter().any(|line| line.contains("runtime.bad\\nname")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("line one\\r\\nline two"))
+        );
+    }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -4,6 +4,7 @@
 //! service accounts, and cluster operations through the RustFS Admin API.
 
 mod access_key;
+mod capabilities;
 mod decommission;
 mod expand;
 mod group;
@@ -27,6 +28,9 @@ use rc_s3::AdminClient;
 /// Admin subcommands for IAM and cluster management
 #[derive(Subcommand, Debug)]
 pub enum AdminCommands {
+    /// Discover effective RustFS runtime capabilities
+    Capabilities(capabilities::CapabilitiesArgs),
+
     /// Display cluster information (servers, disks, usage)
     #[command(subcommand)]
     Info(info::InfoCommands),
@@ -85,6 +89,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
     let formatter = Formatter::new(output_config);
 
     match cmd {
+        AdminCommands::Capabilities(args) => capabilities::execute(args, &formatter).await,
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
         AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,
@@ -171,6 +176,19 @@ mod tests {
                 assert_eq!(args.alias, "local");
                 assert!(args.offline);
                 assert!(args.healing);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_capabilities_refresh() {
+        let cli = TestCli::parse_from(["rc", "capabilities", "local", "--refresh"]);
+
+        match cli.command {
+            AdminCommands::Capabilities(args) => {
+                assert_eq!(args.alias, "local");
+                assert!(args.refresh);
             }
             _ => panic!("Unexpected command parsing result"),
         }

--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -471,6 +471,14 @@ impl Formatter {
         }
     }
 
+    /// Output a pre-built JSON error to stderr.
+    pub fn json_error<T: Serialize>(&self, value: &T) {
+        match serde_json::to_string_pretty(value) {
+            Ok(json) => eprintln!("{json}"),
+            Err(e) => eprintln!("Error serializing output: {e}"),
+        }
+    }
+
     /// Print a line of text (respects quiet mode)
     pub fn println(&self, message: &str) {
         if self.config.quiet {

--- a/crates/cli/tests/admin_capabilities.rs
+++ b/crates/cli/tests/admin_capabilities.rs
@@ -1,0 +1,198 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_sequence_test_server};
+use jsonschema::Validator;
+use serde_json::Value;
+
+const INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const RUNTIME_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+
+fn output_v3_validator() -> Validator {
+    let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("schemas/output_v3.json");
+    let schema = std::fs::read_to_string(&schema_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+    let schema: Value = serde_json::from_str(&schema).expect("output v3 schema should parse");
+    jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+}
+
+fn assert_valid_v3(value: &Value) {
+    let validator = output_v3_validator();
+    let errors = validator
+        .iter_errors(value)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "capability output must satisfy output v3:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn capabilities_json_success_satisfies_output_v3() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["data"]["api_version"], "v4");
+    let memory_sampling = value["data"]["capabilities"]
+        .as_array()
+        .expect("capabilities should be an array")
+        .iter()
+        .find(|capability| capability["name"] == "runtime.memory-sampling")
+        .expect("runtime memory sampling capability");
+    assert_eq!(memory_sampling["support"], "unsupported");
+    assert_ne!(memory_sampling["support"], "stub");
+    assert_valid_v3(&value);
+
+    for expected in [
+        "/rustfs/admin/v3/info",
+        "/rustfs/admin/v4/runtime/capabilities",
+        "/rustfs/admin/v4/extensions/catalog",
+        "/rustfs/admin/v4/cluster/snapshot",
+    ] {
+        let request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured admin request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.target, expected);
+    }
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_json_version_gate_satisfies_output_v3() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        (
+            "404 Not Found",
+            r#"{"code":"NotImplemented","message":"route body must not override HTTP 404"}"#,
+        ),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["data"]["api_version"], Value::Null);
+    assert_eq!(value["data"]["capabilities"][0]["support"], "unsupported");
+    assert_valid_v3(&value);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_json_http_501_reports_stub_support() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        (
+            "501 Not Implemented",
+            r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+        ),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["data"]["api_version"], "v4");
+    assert_eq!(value["data"]["capabilities"][0]["support"], "stub");
+    assert_eq!(
+        value["data"]["capabilities"][0]["reason"],
+        "route is not implemented"
+    );
+    assert_valid_v3(&value);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_json_auth_error_satisfies_output_v3() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        (
+            "403 Forbidden",
+            r#"{"code":"NotImplemented","message":"Access denied"}"#,
+        ),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(
+        output.stdout.is_empty(),
+        "errors must not be written to stdout"
+    );
+    let value: Value = serde_json::from_slice(&output.stderr).expect("stderr should be JSON");
+    assert_eq!(value["error"]["type"], "auth_error");
+    assert_valid_v3(&value);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_missing_alias_keeps_top_level_error_contract() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "missing"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(5));
+    let value: Value = serde_json::from_slice(&output.stderr).expect("stderr should be JSON");
+    assert!(value.get("schema_version").is_none());
+    assert_eq!(value["details"]["type"], "not_found");
+}

--- a/crates/cli/tests/admin_support/mod.rs
+++ b/crates/cli/tests/admin_support/mod.rs
@@ -58,6 +58,9 @@ fn read_admin_request(stream: &mut TcpStream) -> CapturedAdminRequest {
     CapturedAdminRequest { method, target }
 }
 
+// Each integration-test binary compiles this shared module independently, so a
+// helper used by one binary can legitimately be unused by another.
+#[allow(dead_code)]
 pub fn start_admin_test_server(
     response_body: &'static str,
 ) -> (String, Receiver<CapturedAdminRequest>, JoinHandle<()>) {
@@ -93,6 +96,49 @@ pub fn start_admin_test_server(
         stream
             .write_all(response.as_bytes())
             .expect("write admin response");
+    });
+
+    (endpoint, receiver, handle)
+}
+
+#[allow(dead_code)]
+pub fn start_admin_sequence_test_server(
+    responses: Vec<(&'static str, &'static str)>,
+) -> (String, Receiver<CapturedAdminRequest>, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind admin test server");
+    listener
+        .set_nonblocking(true)
+        .expect("set admin test server nonblocking");
+    let endpoint = format!("http://{}", listener.local_addr().expect("server address"));
+    let (sender, receiver) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        for (response_status, response_body) in responses {
+            let deadline = Instant::now() + Duration::from_secs(120);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(accepted) => break accepted,
+                    Err(e) if e.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(e) => panic!("accept admin request: {e}"),
+                }
+            };
+            stream
+                .set_nonblocking(false)
+                .expect("set admin request stream blocking");
+            let request = read_admin_request(&mut stream);
+            sender.send(request).expect("send captured request");
+
+            let response = format!(
+                "HTTP/1.1 {response_status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write admin response");
+        }
     });
 
     (endpoint, receiver, handle)

--- a/crates/cli/tests/fixtures/output_v3/capabilities/auth_error.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/auth_error.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "error",
+  "error": {
+    "type": "auth_error",
+    "message": "Failed to discover capabilities: Authentication failed: Access denied",
+    "retryable": false,
+    "suggestion": "Verify the alias credentials and ServerInfoAdminAction permission."
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/capabilities/runtime_success.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/runtime_success.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "success",
+  "data": {
+    "server": "rustfs",
+    "api_version": "v4",
+    "capabilities": [
+      {
+        "name": "runtime.observability",
+        "scope": "runtime",
+        "support": "supported",
+        "reason": null
+      }
+    ]
+  },
+  "meta": {
+    "server_version": "1.0.0-beta.10"
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/capabilities/runtime_unsupported.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/runtime_unsupported.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "success",
+  "data": {
+    "server": "rustfs",
+    "api_version": "v4",
+    "capabilities": [
+      {
+        "name": "runtime.memory-sampling",
+        "scope": "runtime",
+        "support": "unsupported",
+        "reason": "not available on this platform"
+      }
+    ]
+  },
+  "meta": {
+    "server_version": "1.0.0-beta.10"
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/capabilities/version_gated.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/version_gated.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "success",
+  "data": {
+    "server": "rustfs",
+    "api_version": null,
+    "capabilities": [
+      {
+        "name": "admin.runtime-capabilities",
+        "scope": "admin",
+        "support": "unsupported",
+        "reason": "Admin API v4 is unavailable"
+      }
+    ]
+  },
+  "meta": {
+    "server_version": "1.0.0-beta.10"
+  }
+}

--- a/crates/core/src/admin/capabilities.rs
+++ b/crates/core/src/admin/capabilities.rs
@@ -1,0 +1,202 @@
+//! Runtime capability discovery contracts for the RustFS Admin API.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Effective availability of an Admin API capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityAvailability {
+    Available,
+    Stubbed,
+    Unsupported,
+    Disabled,
+    VersionGated,
+    PermissionDenied,
+    Unknown,
+}
+
+impl fmt::Display for CapabilityAvailability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Available => "available",
+            Self::Stubbed => "stubbed",
+            Self::Unsupported => "unsupported",
+            Self::Disabled => "disabled",
+            Self::VersionGated => "version-gated",
+            Self::PermissionDenied => "permission-denied",
+            Self::Unknown => "unknown",
+        };
+        formatter.write_str(value)
+    }
+}
+
+/// RustFS capability state returned by runtime snapshot endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityState {
+    Supported,
+    Unsupported,
+    Disabled,
+    Unknown,
+}
+
+/// A typed status from a RustFS runtime snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilityStatus {
+    pub state: RuntimeCapabilityState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RuntimeCapabilityStatus {
+    /// Convert the server contract into an effective client availability.
+    pub const fn availability(&self) -> CapabilityAvailability {
+        match self.state {
+            RuntimeCapabilityState::Supported => CapabilityAvailability::Available,
+            RuntimeCapabilityState::Unsupported => CapabilityAvailability::Unsupported,
+            RuntimeCapabilityState::Disabled => CapabilityAvailability::Disabled,
+            RuntimeCapabilityState::Unknown => CapabilityAvailability::Unknown,
+        }
+    }
+}
+
+/// Summary fields provided by `/v4/runtime/capabilities`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilitiesSummary {
+    pub observability: RuntimeCapabilityStatus,
+    pub userspace_profiling: RuntimeCapabilityStatus,
+    pub memory_sampling: RuntimeCapabilityStatus,
+    pub platform: RuntimeCapabilityStatus,
+    pub topology: RuntimeCapabilityStatus,
+    pub cluster_snapshot: RuntimeCapabilityStatus,
+}
+
+/// Typed subset of the RustFS runtime capability response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeCapabilitiesSnapshot {
+    pub summary: RuntimeCapabilitiesSummary,
+    pub cluster_snapshot_path: String,
+    pub cluster_snapshot_summary: Option<RuntimeCapabilityStatus>,
+    pub topology_status: RuntimeCapabilityStatus,
+    #[serde(default)]
+    pub observability: serde_json::Value,
+    #[serde(default)]
+    pub workload_admission: serde_json::Value,
+    #[serde(default)]
+    pub topology: Option<serde_json::Value>,
+}
+
+/// Extension metadata advertised by RustFS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionMetadata {
+    pub schema_version: String,
+    pub extension_id: String,
+    pub display_name: String,
+    pub provider: String,
+    pub version: String,
+    pub kind: String,
+    pub disabled_by_default: bool,
+}
+
+/// Typed subset of `/v4/extensions/catalog`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExtensionsCatalog {
+    pub extensions: Vec<ExtensionMetadata>,
+    #[serde(default)]
+    pub runtime_capabilities: serde_json::Value,
+    #[serde(default)]
+    pub cluster_snapshot: serde_json::Value,
+    #[serde(default)]
+    pub external_plugin_flow: serde_json::Value,
+}
+
+/// Typed summary returned inside a cluster snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClusterSnapshotSummary {
+    pub runtime: RuntimeCapabilityStatus,
+    pub topology: RuntimeCapabilityStatus,
+    pub membership: RuntimeCapabilityStatus,
+    pub peer_health: RuntimeCapabilityStatus,
+    pub rpc_boundary: RuntimeCapabilityStatus,
+    pub observability: RuntimeCapabilityStatus,
+    pub workload_admission: RuntimeCapabilityStatus,
+    pub actionable_pressure: RuntimeCapabilityStatus,
+}
+
+/// Metadata from `/v4/cluster/snapshot` without exposing server internals.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClusterSnapshotMetadata {
+    pub summary: Option<ClusterSnapshotSummary>,
+    pub runtime_capabilities_path: Option<String>,
+    pub extensions_catalog_path: Option<String>,
+}
+
+/// One normalized capability row shown by the CLI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityEntry {
+    pub name: String,
+    pub availability: CapabilityAvailability,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Aggregate capability discovery result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CapabilityReport {
+    pub server_version: Option<String>,
+    pub runtime_path: String,
+    pub extensions_path: String,
+    pub cluster_snapshot_path: String,
+    pub capabilities: Vec<CapabilityEntry>,
+    pub extensions: Vec<ExtensionMetadata>,
+    pub cluster: ClusterSnapshotMetadata,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_states_map_without_overstating_support() {
+        let status = |state| RuntimeCapabilityStatus {
+            state,
+            reason: None,
+        };
+
+        assert_eq!(
+            status(RuntimeCapabilityState::Supported).availability(),
+            CapabilityAvailability::Available
+        );
+        assert_eq!(
+            status(RuntimeCapabilityState::Unsupported).availability(),
+            CapabilityAvailability::Unsupported
+        );
+        assert_eq!(
+            status(RuntimeCapabilityState::Disabled).availability(),
+            CapabilityAvailability::Disabled
+        );
+        assert_eq!(
+            status(RuntimeCapabilityState::Unknown).availability(),
+            CapabilityAvailability::Unknown
+        );
+    }
+
+    #[test]
+    fn availability_has_stable_machine_readable_values() {
+        assert_eq!(
+            serde_json::to_string(&CapabilityAvailability::VersionGated)
+                .expect("availability should serialize"),
+            "\"version-gated\""
+        );
+        assert_eq!(
+            CapabilityAvailability::PermissionDenied.to_string(),
+            "permission-denied"
+        );
+        assert_eq!(
+            serde_json::to_string(&CapabilityAvailability::Unsupported)
+                .expect("availability should serialize"),
+            "\"unsupported\""
+        );
+    }
+}

--- a/crates/core/src/admin/capabilities.rs
+++ b/crates/core/src/admin/capabilities.rs
@@ -141,6 +141,95 @@ pub struct CapabilityEntry {
     pub reason: Option<String>,
 }
 
+/// A diagnostic operation whose support must be known before it is invoked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticCapability {
+    HealthSnapshot,
+    ClusterSnapshot,
+    ExtensionsCatalog,
+    DriveObservations,
+    ClientDevnull,
+    InspectArchive,
+    ObjectSpeedtest,
+    NetworkSpeedtest,
+    SiteSpeedtest,
+    SiteReplicationNetperf,
+}
+
+impl DiagnosticCapability {
+    /// All diagnostic capabilities in stable display order.
+    pub const ALL: [Self; 10] = [
+        Self::HealthSnapshot,
+        Self::ClusterSnapshot,
+        Self::ExtensionsCatalog,
+        Self::DriveObservations,
+        Self::ClientDevnull,
+        Self::InspectArchive,
+        Self::ObjectSpeedtest,
+        Self::NetworkSpeedtest,
+        Self::SiteSpeedtest,
+        Self::SiteReplicationNetperf,
+    ];
+
+    /// Stable machine-readable capability name.
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::HealthSnapshot => "admin.diagnostics.health-snapshot",
+            Self::ClusterSnapshot => "admin.diagnostics.cluster-snapshot",
+            Self::ExtensionsCatalog => "admin.diagnostics.extensions-catalog",
+            Self::DriveObservations => "admin.diagnostics.drive-observations",
+            Self::ClientDevnull => "admin.diagnostics.client-devnull",
+            Self::InspectArchive => "admin.diagnostics.inspect-archive",
+            Self::ObjectSpeedtest => "admin.diagnostics.object-speedtest",
+            Self::NetworkSpeedtest => "admin.diagnostics.network-speedtest",
+            Self::SiteSpeedtest => "admin.diagnostics.site-speedtest",
+            Self::SiteReplicationNetperf => "admin.site-replication.netperf",
+        }
+    }
+}
+
+/// Error returned when a diagnostic operation is not explicitly available.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticCapabilityGuardError {
+    capability: DiagnosticCapability,
+    availability: CapabilityAvailability,
+    reason: Option<String>,
+}
+
+impl DiagnosticCapabilityGuardError {
+    /// Diagnostic operation rejected by the guard.
+    pub const fn capability(&self) -> DiagnosticCapability {
+        self.capability
+    }
+
+    /// Effective support classification that caused the rejection.
+    pub const fn availability(&self) -> CapabilityAvailability {
+        self.availability
+    }
+
+    /// Server or client explanation for the classification, when available.
+    pub fn reason(&self) -> Option<&str> {
+        self.reason.as_deref()
+    }
+}
+
+impl fmt::Display for DiagnosticCapabilityGuardError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "diagnostic capability '{}' is {}",
+            self.capability.name(),
+            self.availability
+        )?;
+        if let Some(reason) = &self.reason {
+            write!(formatter, ": {reason}")?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for DiagnosticCapabilityGuardError {}
+
 /// Aggregate capability discovery result.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CapabilityReport {
@@ -153,9 +242,56 @@ pub struct CapabilityReport {
     pub cluster: ClusterSnapshotMetadata,
 }
 
+impl CapabilityReport {
+    /// Find a normalized capability by its stable machine-readable name.
+    pub fn capability(&self, name: &str) -> Option<&CapabilityEntry> {
+        self.capabilities.iter().find(|entry| entry.name == name)
+    }
+
+    /// Require explicit availability before invoking a diagnostic operation.
+    ///
+    /// Missing entries and every non-available state fail closed. This prevents
+    /// route presence or placeholder HTTP success responses from being treated
+    /// as proof that an active diagnostic is implemented.
+    pub fn require_diagnostic_capability(
+        &self,
+        capability: DiagnosticCapability,
+    ) -> Result<&CapabilityEntry, DiagnosticCapabilityGuardError> {
+        match self.capability(capability.name()) {
+            Some(entry) if entry.availability == CapabilityAvailability::Available => Ok(entry),
+            Some(entry) => Err(DiagnosticCapabilityGuardError {
+                capability,
+                availability: entry.availability,
+                reason: entry.reason.clone(),
+            }),
+            None => Err(DiagnosticCapabilityGuardError {
+                capability,
+                availability: CapabilityAvailability::Unknown,
+                reason: None,
+            }),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn report(capabilities: Vec<CapabilityEntry>) -> CapabilityReport {
+        CapabilityReport {
+            server_version: Some("1.0.0-beta.10".to_string()),
+            runtime_path: "/v4/runtime/capabilities".to_string(),
+            extensions_path: "/v4/extensions/catalog".to_string(),
+            cluster_snapshot_path: "/v4/cluster/snapshot".to_string(),
+            capabilities,
+            extensions: Vec::new(),
+            cluster: ClusterSnapshotMetadata {
+                summary: None,
+                runtime_capabilities_path: None,
+                extensions_catalog_path: None,
+            },
+        }
+    }
 
     #[test]
     fn runtime_states_map_without_overstating_support() {
@@ -198,5 +334,73 @@ mod tests {
                 .expect("availability should serialize"),
             "\"unsupported\""
         );
+    }
+
+    #[test]
+    fn diagnostic_capability_names_are_stable_and_unique() {
+        let names = DiagnosticCapability::ALL.map(DiagnosticCapability::name);
+
+        assert_eq!(names.len(), 10);
+        assert_eq!(names[0], "admin.diagnostics.health-snapshot");
+        assert_eq!(names[9], "admin.site-replication.netperf");
+        for (index, name) in names.iter().enumerate() {
+            assert!(!names[..index].contains(name), "duplicate name: {name}");
+        }
+    }
+
+    #[test]
+    fn diagnostic_guard_allows_only_available_capabilities() {
+        let capability = DiagnosticCapability::HealthSnapshot;
+        let report = report(vec![CapabilityEntry {
+            name: capability.name().to_string(),
+            availability: CapabilityAvailability::Available,
+            reason: Some("Pinned server contract".to_string()),
+        }]);
+
+        let entry = report
+            .require_diagnostic_capability(capability)
+            .expect("available diagnostics should pass the guard");
+
+        assert_eq!(entry.name, capability.name());
+    }
+
+    #[test]
+    fn diagnostic_guard_preserves_non_available_states() {
+        let capability = DiagnosticCapability::ObjectSpeedtest;
+        let blocked_states = [
+            CapabilityAvailability::Stubbed,
+            CapabilityAvailability::Unsupported,
+            CapabilityAvailability::Disabled,
+            CapabilityAvailability::VersionGated,
+            CapabilityAvailability::PermissionDenied,
+            CapabilityAvailability::Unknown,
+        ];
+
+        for availability in blocked_states {
+            let report = report(vec![CapabilityEntry {
+                name: capability.name().to_string(),
+                availability,
+                reason: Some("Server classification".to_string()),
+            }]);
+            let error = report
+                .require_diagnostic_capability(capability)
+                .expect_err("non-available diagnostics must fail closed");
+
+            assert_eq!(error.capability(), capability);
+            assert_eq!(error.availability(), availability);
+            assert_eq!(error.reason(), Some("Server classification"));
+        }
+    }
+
+    #[test]
+    fn diagnostic_guard_treats_missing_entries_as_unknown() {
+        let capability = DiagnosticCapability::NetworkSpeedtest;
+        let error = report(Vec::new())
+            .require_diagnostic_capability(capability)
+            .expect_err("missing diagnostic classifications must fail closed");
+
+        assert_eq!(error.capability(), capability);
+        assert_eq!(error.availability(), CapabilityAvailability::Unknown);
+        assert_eq!(error.reason(), None);
     }
 }

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -3,11 +3,17 @@
 //! This module provides the AdminApi trait and types for managing
 //! IAM users, policies, groups, service accounts, and cluster operations.
 
+mod capabilities;
 mod cluster;
 mod site;
 pub mod tier;
 mod types;
 
+pub use capabilities::{
+    CapabilityAvailability, CapabilityEntry, CapabilityReport, ClusterSnapshotMetadata,
+    ClusterSnapshotSummary, ExtensionMetadata, ExtensionsCatalog, RuntimeCapabilitiesSnapshot,
+    RuntimeCapabilitiesSummary, RuntimeCapabilityState, RuntimeCapabilityStatus,
+};
 pub use cluster::{
     BackendInfo, BackendType, BucketsInfo, ClusterInfo, DecommissionPoolStatus, DecommissionStatus,
     DiskInfo, HealDriveInfo, HealDriveInfos, HealResultItem, HealRuntimeState, HealScanMode,
@@ -254,6 +260,13 @@ pub trait AdminApi: Send + Sync {
 
     /// Remove sites from the site replication cluster
     async fn site_replication_remove(&self, spec: &SiteRemoveSpec) -> Result<serde_json::Value>;
+}
+
+/// Read-only RustFS runtime capability discovery.
+#[async_trait]
+pub trait CapabilityApi: Send + Sync {
+    /// Discover capabilities, bypassing the process cache when `refresh` is true.
+    async fn discover_capabilities(&self, refresh: bool) -> Result<CapabilityReport>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -11,8 +11,9 @@ mod types;
 
 pub use capabilities::{
     CapabilityAvailability, CapabilityEntry, CapabilityReport, ClusterSnapshotMetadata,
-    ClusterSnapshotSummary, ExtensionMetadata, ExtensionsCatalog, RuntimeCapabilitiesSnapshot,
-    RuntimeCapabilitiesSummary, RuntimeCapabilityState, RuntimeCapabilityStatus,
+    ClusterSnapshotSummary, DiagnosticCapability, DiagnosticCapabilityGuardError,
+    ExtensionMetadata, ExtensionsCatalog, RuntimeCapabilitiesSnapshot, RuntimeCapabilitiesSummary,
+    RuntimeCapabilityState, RuntimeCapabilityStatus,
 };
 pub use cluster::{
     BackendInfo, BackendType, BucketsInfo, ClusterInfo, DecommissionPoolStatus, DecommissionStatus,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -12,12 +12,13 @@ use aws_sigv4::sign::v4;
 use rc_core::admin::{
     AccessKeyInfo, AdminApi, BucketQuota, CapabilityApi, CapabilityAvailability, CapabilityEntry,
     CapabilityReport, ClusterInfo, ClusterSnapshotMetadata, ClusterSnapshotSummary,
-    CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus, ExtensionsCatalog,
-    Group, GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus,
-    HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
-    RebalanceStartResult, RebalanceStatus, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus,
-    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
-    SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
+    CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus, DiagnosticCapability,
+    ExtensionsCatalog, Group, GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest,
+    HealStatus, HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus,
+    PoolTarget, RebalanceStartResult, RebalanceStatus, RuntimeCapabilitiesSnapshot,
+    RuntimeCapabilityStatus, ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult,
+    SiteRemoveSpec, SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest,
+    User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -1059,12 +1060,18 @@ fn version_gated_entry(name: &str, reason: &str) -> CapabilityEntry {
 
 fn version_gated_report(server_version: Option<String>) -> CapabilityReport {
     let reason = "RustFS Admin API v4 capability discovery is not available on this server version";
+    let mut capabilities = vec![version_gated_entry("admin.runtime-capabilities", reason)];
+    add_uniform_diagnostic_capabilities(
+        &mut capabilities,
+        CapabilityAvailability::VersionGated,
+        reason,
+    );
     CapabilityReport {
         server_version,
         runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
         extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
         cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
-        capabilities: vec![version_gated_entry("admin.runtime-capabilities", reason)],
+        capabilities,
         extensions: Vec::new(),
         cluster: ClusterSnapshotMetadata {
             summary: None,
@@ -1075,16 +1082,25 @@ fn version_gated_report(server_version: Option<String>) -> CapabilityReport {
 }
 
 fn stubbed_report(server_version: Option<String>, reason: String) -> CapabilityReport {
+    let diagnostic_reason = format!(
+        "Diagnostic support cannot be classified because runtime capability discovery is stubbed: {reason}"
+    );
+    let mut capabilities = vec![CapabilityEntry {
+        name: "admin.runtime-capabilities".to_string(),
+        availability: CapabilityAvailability::Stubbed,
+        reason: Some(reason),
+    }];
+    add_uniform_diagnostic_capabilities(
+        &mut capabilities,
+        CapabilityAvailability::Unknown,
+        &diagnostic_reason,
+    );
     CapabilityReport {
         server_version,
         runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
         extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
         cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
-        capabilities: vec![CapabilityEntry {
-            name: "admin.runtime-capabilities".to_string(),
-            availability: CapabilityAvailability::Stubbed,
-            reason: Some(reason),
-        }],
+        capabilities,
         extensions: Vec::new(),
         cluster: ClusterSnapshotMetadata {
             summary: None,
@@ -1095,7 +1111,12 @@ fn stubbed_report(server_version: Option<String>, reason: String) -> CapabilityR
 }
 
 fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<CapabilityEntry>) {
-    if !version.is_some_and(|version| version.contains("1.0.0-beta.10")) {
+    if !is_rustfs_beta10(version) {
+        add_uniform_diagnostic_capabilities(
+            capabilities,
+            CapabilityAvailability::Unknown,
+            "No pinned diagnostic capability contract is available for this server version",
+        );
         return;
     }
 
@@ -1127,6 +1148,117 @@ fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<C
             reason: Some(reason.to_string()),
         });
     }
+
+    add_beta10_diagnostic_capabilities(capabilities);
+}
+
+fn is_rustfs_beta10(version: Option<&str>) -> bool {
+    version.is_some_and(|version| {
+        version == "1.0.0-beta.10"
+            || version
+                .strip_prefix("1.0.0-beta.10+")
+                .is_some_and(|metadata| !metadata.is_empty())
+    })
+}
+
+fn add_uniform_diagnostic_capabilities(
+    capabilities: &mut Vec<CapabilityEntry>,
+    availability: CapabilityAvailability,
+    reason: &str,
+) {
+    capabilities.extend(
+        DiagnosticCapability::ALL
+            .into_iter()
+            .map(|capability| CapabilityEntry {
+                name: capability.name().to_string(),
+                availability,
+                reason: Some(reason.to_string()),
+            }),
+    );
+}
+
+fn add_beta10_diagnostic_capabilities(capabilities: &mut Vec<CapabilityEntry>) {
+    for (capability, availability, reason) in [
+        (
+            DiagnosticCapability::HealthSnapshot,
+            CapabilityAvailability::Available,
+            "RustFS beta.10 provides a detailed health snapshot implementation",
+        ),
+        (
+            DiagnosticCapability::DriveObservations,
+            CapabilityAvailability::Available,
+            "RustFS beta.10 provides drive storage observations",
+        ),
+        (
+            DiagnosticCapability::ClientDevnull,
+            CapabilityAvailability::Available,
+            "RustFS beta.10 implements client devnull throughput measurement",
+        ),
+        (
+            DiagnosticCapability::InspectArchive,
+            CapabilityAvailability::Unsupported,
+            "RustFS beta.10 inspect-data returns reconstructed object bytes, not an inspection archive",
+        ),
+        (
+            DiagnosticCapability::ObjectSpeedtest,
+            CapabilityAvailability::Stubbed,
+            "RustFS beta.10 returns placeholder object speedtest results",
+        ),
+        (
+            DiagnosticCapability::NetworkSpeedtest,
+            CapabilityAvailability::Stubbed,
+            "RustFS beta.10 returns placeholder network speedtest results",
+        ),
+        (
+            DiagnosticCapability::SiteSpeedtest,
+            CapabilityAvailability::Stubbed,
+            "RustFS beta.10 returns placeholder site speedtest results",
+        ),
+        (
+            DiagnosticCapability::SiteReplicationNetperf,
+            CapabilityAvailability::Stubbed,
+            "RustFS beta.10 site-replication netperf does not perform a peer network measurement",
+        ),
+    ] {
+        capabilities.push(CapabilityEntry {
+            name: capability.name().to_string(),
+            availability,
+            reason: Some(reason.to_string()),
+        });
+    }
+
+    mirror_diagnostic_route(
+        capabilities,
+        DiagnosticCapability::ClusterSnapshot,
+        "admin.cluster-snapshot-route",
+    );
+    mirror_diagnostic_route(
+        capabilities,
+        DiagnosticCapability::ExtensionsCatalog,
+        "admin.extensions-catalog",
+    );
+}
+
+fn mirror_diagnostic_route(
+    capabilities: &mut Vec<CapabilityEntry>,
+    diagnostic: DiagnosticCapability,
+    route_capability_name: &str,
+) {
+    let route_state = capabilities
+        .iter()
+        .find(|capability| capability.name == route_capability_name)
+        .map(|capability| (capability.availability, capability.reason.clone()));
+    let (availability, reason) = route_state.unwrap_or_else(|| {
+        (
+            CapabilityAvailability::Unknown,
+            Some("The diagnostic route was not classified during discovery".to_string()),
+        )
+    });
+    capabilities.push(CapabilityEntry {
+        name: diagnostic.name().to_string(),
+        availability,
+        reason,
+    });
 }
 
 #[async_trait]
@@ -1894,6 +2026,7 @@ mod tests {
     }
 
     const CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+    const UNKNOWN_CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.11","drives":[]}]}}"#;
     const RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
     const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[{"schema_version":"rustfs.extension-schema.v1","extension_id":"ops.diagnostics","display_name":"Operations Diagnostics","provider":"rustfs","version":"1","kind":"ops_diagnostics","runtime":{"api_version":"v1","boundary":"builtin"},"capabilities":[],"disabled_by_default":false}],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
     const CLUSTER_SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
@@ -1941,6 +2074,81 @@ mod tests {
             assert!(report.capabilities.iter().any(|capability| {
                 capability.name == name
                     && capability.availability == CapabilityAvailability::Stubbed
+            }));
+        }
+        for name in [
+            "admin.diagnostics.health-snapshot",
+            "admin.diagnostics.cluster-snapshot",
+            "admin.diagnostics.extensions-catalog",
+            "admin.diagnostics.drive-observations",
+            "admin.diagnostics.client-devnull",
+        ] {
+            assert!(report.capabilities.iter().any(|capability| {
+                capability.name == name
+                    && capability.availability == CapabilityAvailability::Available
+            }));
+        }
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == "admin.diagnostics.inspect-archive"
+                && capability.availability == CapabilityAvailability::Unsupported
+        }));
+        for name in [
+            "admin.diagnostics.object-speedtest",
+            "admin.diagnostics.network-speedtest",
+            "admin.diagnostics.site-speedtest",
+            "admin.site-replication.netperf",
+        ] {
+            assert!(report.capabilities.iter().any(|capability| {
+                capability.name == name
+                    && capability.availability == CapabilityAvailability::Stubbed
+            }));
+        }
+
+        let targets = (0..4)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            vec![
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_fails_closed_for_unknown_server_versions() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", UNKNOWN_CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("capability discovery should succeed");
+
+        for name in [
+            "admin.diagnostics.health-snapshot",
+            "admin.diagnostics.cluster-snapshot",
+            "admin.diagnostics.extensions-catalog",
+            "admin.diagnostics.drive-observations",
+            "admin.diagnostics.client-devnull",
+            "admin.diagnostics.inspect-archive",
+            "admin.diagnostics.object-speedtest",
+            "admin.diagnostics.network-speedtest",
+            "admin.diagnostics.site-speedtest",
+            "admin.site-replication.netperf",
+        ] {
+            assert!(report.capabilities.iter().any(|capability| {
+                capability.name == name
+                    && capability.availability == CapabilityAvailability::Unknown
             }));
         }
 
@@ -2073,10 +2281,11 @@ mod tests {
             .await
             .expect("v4 absence should produce a report");
 
-        assert_eq!(report.capabilities.len(), 1);
-        assert_eq!(
-            report.capabilities[0].availability,
-            CapabilityAvailability::VersionGated
+        assert_eq!(report.capabilities.len(), 11);
+        assert!(
+            report.capabilities.iter().all(|capability| {
+                capability.availability == CapabilityAvailability::VersionGated
+            })
         );
         assert_eq!(
             receiver.recv().expect("info request").target,
@@ -2105,14 +2314,21 @@ mod tests {
             .await
             .expect("an explicit stub response should produce a report");
 
-        assert_eq!(report.capabilities.len(), 1);
-        assert_eq!(
-            report.capabilities[0].availability,
-            CapabilityAvailability::Stubbed
-        );
-        assert_eq!(
-            report.capabilities[0].reason.as_deref(),
-            Some("route is not implemented")
+        assert_eq!(report.capabilities.len(), 11);
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == "admin.runtime-capabilities"
+                && capability.availability == CapabilityAvailability::Stubbed
+                && capability.reason.as_deref() == Some("route is not implemented")
+        }));
+        assert!(
+            report
+                .capabilities
+                .iter()
+                .filter(|capability| {
+                    capability.name.starts_with("admin.diagnostics.")
+                        || capability.name == "admin.site-replication.netperf"
+                })
+                .all(|capability| capability.availability == CapabilityAvailability::Unknown)
         );
         assert_eq!(
             receiver.recv().expect("info request").target,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -10,12 +10,14 @@ use aws_sigv4::http_request::{
 };
 use aws_sigv4::sign::v4;
 use rc_core::admin::{
-    AccessKeyInfo, AdminApi, BucketQuota, ClusterInfo, CreateServiceAccountRequest,
-    DecommissionPoolStatus, DecommissionStatus, Group, GroupStatus, HealRuntimeState, HealScanMode,
-    HealStartRequest, HealStatus, HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo,
-    PoolStatus, PoolTarget, RebalanceStartResult, RebalanceStatus, ServiceAccount,
-    ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec, SiteStatusOptions,
-    UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
+    AccessKeyInfo, AdminApi, BucketQuota, CapabilityApi, CapabilityAvailability, CapabilityEntry,
+    CapabilityReport, ClusterInfo, ClusterSnapshotMetadata, ClusterSnapshotSummary,
+    CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus, ExtensionsCatalog,
+    Group, GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus,
+    HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
+    RebalanceStartResult, RebalanceStatus, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus,
+    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
+    SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -23,7 +25,53 @@ use reqwest::{Client, Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CapabilityCacheKey {
+    endpoint: String,
+    region: String,
+    credential_fingerprint: String,
+    transport_security_fingerprint: String,
+}
+
+static CAPABILITY_CACHE: OnceLock<Mutex<HashMap<CapabilityCacheKey, CapabilityReport>>> =
+    OnceLock::new();
+
+fn capability_cache() -> &'static Mutex<HashMap<CapabilityCacheKey, CapabilityReport>> {
+    CAPABILITY_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn transport_security_fingerprint(
+    insecure: bool,
+    ca_bundle: Option<&[u8]>,
+    client_cert: Option<&[u8]>,
+    client_key: Option<&[u8]>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"rc-admin-capability-cache-transport-v1\0");
+    hasher.update(b"native-roots-enabled\0webpki-roots-enabled\0");
+    hasher.update([u8::from(insecure)]);
+
+    for (label, input) in [
+        (b"ca-bundle".as_slice(), ca_bundle),
+        (b"client-certificate".as_slice(), client_cert),
+        (b"client-private-key".as_slice(), client_key),
+    ] {
+        hasher.update(label);
+        hasher.update([0]);
+        match input {
+            Some(bytes) => {
+                hasher.update([1]);
+                hasher.update(Sha256::digest(bytes));
+            }
+            None => hasher.update([0]),
+        }
+    }
+
+    hex::encode(hasher.finalize())
+}
 
 /// Admin API client for RustFS servers
 pub struct AdminClient {
@@ -33,6 +81,7 @@ pub struct AdminClient {
     secret_key: String,
     region: String,
     anonymous: bool,
+    transport_security_fingerprint: String,
 }
 
 impl AdminClient {
@@ -55,7 +104,7 @@ impl AdminClient {
                 .read_timeout(Duration::from_millis(timeout.read_ms));
         }
 
-        if let Some(bundle_path) = alias.ca_bundle.as_deref() {
+        let ca_bundle_pem = if let Some(bundle_path) = alias.ca_bundle.as_deref() {
             let pem = std::fs::read(bundle_path).map_err(|e| {
                 Error::Network(format!("Failed to read CA bundle '{bundle_path}': {e}"))
             })?;
@@ -69,12 +118,15 @@ impl AdminClient {
             for cert in certs {
                 builder = builder.add_root_certificate(cert);
             }
-        }
+            Some(pem)
+        } else {
+            None
+        };
 
-        if let (Some(cert_path), Some(key_path)) =
+        let client_identity_pem = if let (Some(cert_path), Some(key_path)) =
             (alias.client_cert.as_deref(), alias.client_key.as_deref())
         {
-            let mut identity_pem = std::fs::read(cert_path).map_err(|e| {
+            let cert_pem = std::fs::read(cert_path).map_err(|e| {
                 Error::Network(format!(
                     "Failed to read client certificate '{cert_path}': {e}"
                 ))
@@ -82,13 +134,28 @@ impl AdminClient {
             let key_pem = std::fs::read(key_path).map_err(|e| {
                 Error::Network(format!("Failed to read client key '{key_path}': {e}"))
             })?;
+            let mut identity_pem = cert_pem.clone();
             identity_pem.extend_from_slice(b"\n");
             identity_pem.extend_from_slice(&key_pem);
             let identity = reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
                 Error::Network(format!("Invalid client certificate/key identity: {e}"))
             })?;
             builder = builder.use_rustls_tls().identity(identity);
-        }
+            Some((cert_pem, key_pem))
+        } else {
+            None
+        };
+
+        let transport_security_fingerprint = transport_security_fingerprint(
+            alias.insecure,
+            ca_bundle_pem.as_deref(),
+            client_identity_pem
+                .as_ref()
+                .map(|(certificate, _)| certificate.as_slice()),
+            client_identity_pem
+                .as_ref()
+                .map(|(_, private_key)| private_key.as_slice()),
+        );
 
         let http_client = builder
             .build()
@@ -101,12 +168,17 @@ impl AdminClient {
             secret_key: alias.secret_key.clone(),
             region: alias.region.clone(),
             anonymous: alias.anonymous,
+            transport_security_fingerprint,
         })
     }
 
     /// Build the base URL for admin API
     fn admin_url(&self, path: &str) -> String {
         format!("{}/rustfs/admin/v3{}", self.endpoint, path)
+    }
+
+    fn admin_v4_url(&self, path: &str) -> String {
+        format!("{}/rustfs/admin/v4{}", self.endpoint, path)
     }
 
     /// Calculate SHA256 hash of the body
@@ -209,8 +281,26 @@ impl AdminClient {
         query: Option<&[(&str, &str)]>,
         body: Option<&[u8]>,
     ) -> Result<T> {
-        let mut url = self.admin_url(path);
+        self.request_url(method, self.admin_url(path), query, body)
+            .await
+    }
 
+    async fn request_v4<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: Method,
+        path: &str,
+    ) -> Result<T> {
+        self.request_url(method, self.admin_v4_url(path), None, None)
+            .await
+    }
+
+    async fn request_url<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: Method,
+        mut url: String,
+        query: Option<&[(&str, &str)]>,
+        body: Option<&[u8]>,
+    ) -> Result<T> {
         if let Some(q) = query {
             let query_string: String = q
                 .iter()
@@ -335,14 +425,67 @@ impl AdminClient {
 
     /// Map HTTP status codes to appropriate errors
     fn map_error(&self, status: StatusCode, body: &str) -> Error {
+        if matches!(status, StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED) {
+            return Error::Auth(body.to_string());
+        }
+
+        // Route absence is authoritative even when a proxy or compatibility layer returns a
+        // stale structured error body. Capability discovery relies on 404 to identify servers
+        // that predate the Admin API v4 route.
+        if status == StatusCode::NOT_FOUND {
+            return Error::NotFound(body.to_string());
+        }
+
+        let structured_error = parse_admin_error(body);
+        if status == StatusCode::NOT_IMPLEMENTED
+            || structured_error
+                .as_ref()
+                .is_some_and(|error| error.code.as_deref() == Some("NotImplemented"))
+        {
+            return Error::UnsupportedFeature(
+                structured_error
+                    .and_then(|error| error.message)
+                    .unwrap_or_else(|| body.to_string()),
+            );
+        }
+
+        if structured_error
+            .as_ref()
+            .is_some_and(AdminErrorResponse::is_missing_credentials)
+        {
+            return Error::Auth(body.to_string());
+        }
+
         match status {
-            StatusCode::NOT_FOUND => Error::NotFound(body.to_string()),
-            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => Error::Auth(body.to_string()),
             StatusCode::CONFLICT => Error::Conflict(body.to_string()),
             StatusCode::BAD_REQUEST => Error::General(format!("Bad request: {body}")),
             _ => Error::Network(format!("HTTP {}: {}", status.as_u16(), body)),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct AdminErrorResponse {
+    #[serde(default, alias = "Code")]
+    code: Option<String>,
+    #[serde(default, alias = "Message")]
+    message: Option<String>,
+}
+
+impl AdminErrorResponse {
+    fn is_missing_credentials(&self) -> bool {
+        self.code.as_deref() == Some("InvalidRequest")
+            && matches!(
+                self.message.as_deref().map(str::trim),
+                Some("get cred failed" | "authentication required" | "missing credentials")
+            )
+    }
+}
+
+fn parse_admin_error(body: &str) -> Option<AdminErrorResponse> {
+    serde_json::from_str(body)
+        .ok()
+        .or_else(|| quick_xml::de::from_str(body).ok())
 }
 
 /// Response wrapper for user list
@@ -707,6 +850,296 @@ struct ServerInfoResponse {
 #[derive(Debug, Deserialize)]
 struct PoolStatusResponse {
     pool: PoolStatus,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClusterSnapshotResponse {
+    snapshot: Option<ClusterSnapshotPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClusterSnapshotPayload {
+    summary: ClusterSnapshotSummary,
+    runtime_capabilities_path: String,
+    extensions_catalog_path: String,
+}
+
+impl AdminClient {
+    fn capability_cache_key(&self) -> CapabilityCacheKey {
+        let mut hasher = Sha256::new();
+        if self.anonymous {
+            hasher.update(b"anonymous");
+        } else {
+            hasher.update(b"authenticated\0");
+            hasher.update(self.access_key.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(self.secret_key.as_bytes());
+        }
+
+        CapabilityCacheKey {
+            endpoint: self.endpoint.clone(),
+            region: self.region.clone(),
+            credential_fingerprint: hex::encode(hasher.finalize()),
+            transport_security_fingerprint: self.transport_security_fingerprint.clone(),
+        }
+    }
+
+    fn cached_capabilities(&self) -> Result<Option<CapabilityReport>> {
+        capability_cache()
+            .lock()
+            .map(|cache| cache.get(&self.capability_cache_key()).cloned())
+            .map_err(|_| Error::General("Capability cache lock is poisoned".to_string()))
+    }
+
+    fn store_capabilities(&self, report: &CapabilityReport) -> Result<()> {
+        capability_cache()
+            .lock()
+            .map_err(|_| Error::General("Capability cache lock is poisoned".to_string()))?
+            .insert(self.capability_cache_key(), report.clone());
+        Ok(())
+    }
+
+    async fn discover_capabilities_uncached(&self) -> Result<CapabilityReport> {
+        let cluster_info = self.cluster_info().await?;
+        let server_version = cluster_info.servers.as_ref().and_then(|servers| {
+            servers
+                .iter()
+                .map(|server| server.version.trim())
+                .find(|version| !version.is_empty())
+                .map(str::to_string)
+        });
+
+        let runtime = match self
+            .request_v4::<RuntimeCapabilitiesSnapshot>(Method::GET, "/runtime/capabilities")
+            .await
+        {
+            Ok(runtime) => runtime,
+            Err(Error::NotFound(_)) => {
+                return Ok(version_gated_report(server_version));
+            }
+            Err(Error::UnsupportedFeature(reason)) => {
+                return Ok(stubbed_report(server_version, reason));
+            }
+            Err(error) => return Err(error),
+        };
+
+        let mut capabilities = runtime_summary_entries(&runtime);
+        let extensions = match self
+            .request_v4::<ExtensionsCatalog>(Method::GET, "/extensions/catalog")
+            .await
+        {
+            Ok(catalog) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.extensions-catalog".to_string(),
+                    availability: CapabilityAvailability::Available,
+                    reason: None,
+                });
+                catalog.extensions
+            }
+            Err(Error::NotFound(_)) => {
+                capabilities.push(version_gated_entry(
+                    "admin.extensions-catalog",
+                    "The extensions catalog route is not available on this server version",
+                ));
+                Vec::new()
+            }
+            Err(Error::UnsupportedFeature(reason)) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.extensions-catalog".to_string(),
+                    availability: CapabilityAvailability::Stubbed,
+                    reason: Some(reason),
+                });
+                Vec::new()
+            }
+            Err(error) => return Err(error),
+        };
+
+        let cluster = match self
+            .request_v4::<ClusterSnapshotResponse>(Method::GET, "/cluster/snapshot")
+            .await
+        {
+            Ok(response) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.cluster-snapshot-route".to_string(),
+                    availability: CapabilityAvailability::Available,
+                    reason: response
+                        .snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.summary.runtime.reason.clone()),
+                });
+                response.snapshot.map_or(
+                    ClusterSnapshotMetadata {
+                        summary: None,
+                        runtime_capabilities_path: None,
+                        extensions_catalog_path: None,
+                    },
+                    |snapshot| ClusterSnapshotMetadata {
+                        summary: Some(snapshot.summary),
+                        runtime_capabilities_path: Some(snapshot.runtime_capabilities_path),
+                        extensions_catalog_path: Some(snapshot.extensions_catalog_path),
+                    },
+                )
+            }
+            Err(Error::NotFound(_)) => {
+                capabilities.push(version_gated_entry(
+                    "admin.cluster-snapshot-route",
+                    "The cluster snapshot route is not available on this server version",
+                ));
+                ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                }
+            }
+            Err(Error::UnsupportedFeature(reason)) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.cluster-snapshot-route".to_string(),
+                    availability: CapabilityAvailability::Stubbed,
+                    reason: Some(reason),
+                });
+                ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                }
+            }
+            Err(error) => return Err(error),
+        };
+
+        add_known_server_capabilities(server_version.as_deref(), &mut capabilities);
+        capabilities.sort_by(|left, right| left.name.cmp(&right.name));
+
+        Ok(CapabilityReport {
+            server_version,
+            runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+            extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+            cluster_snapshot_path: runtime.cluster_snapshot_path,
+            capabilities,
+            extensions,
+            cluster,
+        })
+    }
+}
+
+fn runtime_summary_entries(runtime: &RuntimeCapabilitiesSnapshot) -> Vec<CapabilityEntry> {
+    [
+        ("runtime.observability", &runtime.summary.observability),
+        (
+            "runtime.userspace-profiling",
+            &runtime.summary.userspace_profiling,
+        ),
+        ("runtime.memory-sampling", &runtime.summary.memory_sampling),
+        ("runtime.platform", &runtime.summary.platform),
+        ("runtime.topology", &runtime.summary.topology),
+        (
+            "runtime.cluster-snapshot",
+            &runtime.summary.cluster_snapshot,
+        ),
+    ]
+    .into_iter()
+    .map(|(name, status)| capability_entry(name, status))
+    .collect()
+}
+
+fn capability_entry(name: &str, status: &RuntimeCapabilityStatus) -> CapabilityEntry {
+    CapabilityEntry {
+        name: name.to_string(),
+        availability: status.availability(),
+        reason: status.reason.clone(),
+    }
+}
+
+fn version_gated_entry(name: &str, reason: &str) -> CapabilityEntry {
+    CapabilityEntry {
+        name: name.to_string(),
+        availability: CapabilityAvailability::VersionGated,
+        reason: Some(reason.to_string()),
+    }
+}
+
+fn version_gated_report(server_version: Option<String>) -> CapabilityReport {
+    let reason = "RustFS Admin API v4 capability discovery is not available on this server version";
+    CapabilityReport {
+        server_version,
+        runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+        extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+        cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+        capabilities: vec![version_gated_entry("admin.runtime-capabilities", reason)],
+        extensions: Vec::new(),
+        cluster: ClusterSnapshotMetadata {
+            summary: None,
+            runtime_capabilities_path: None,
+            extensions_catalog_path: None,
+        },
+    }
+}
+
+fn stubbed_report(server_version: Option<String>, reason: String) -> CapabilityReport {
+    CapabilityReport {
+        server_version,
+        runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+        extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+        cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+        capabilities: vec![CapabilityEntry {
+            name: "admin.runtime-capabilities".to_string(),
+            availability: CapabilityAvailability::Stubbed,
+            reason: Some(reason),
+        }],
+        extensions: Vec::new(),
+        cluster: ClusterSnapshotMetadata {
+            summary: None,
+            runtime_capabilities_path: None,
+            extensions_catalog_path: None,
+        },
+    }
+}
+
+fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<CapabilityEntry>) {
+    if !version.is_some_and(|version| version.contains("1.0.0-beta.10")) {
+        return;
+    }
+
+    for (name, reason) in [
+        (
+            "admin.batch",
+            "RustFS beta.10 registers batch routes without a scheduler or worker",
+        ),
+        (
+            "admin.ldap-mutation",
+            "RustFS beta.10 returns NotImplemented for LDAP mutations",
+        ),
+        (
+            "admin.logs",
+            "RustFS beta.10 exposes keepalive only and has no live log buffer",
+        ),
+        (
+            "admin.trace",
+            "RustFS beta.10 has no trace subscriber implementation",
+        ),
+        (
+            "admin.update",
+            "RustFS beta.10 accepts update requests without applying an update",
+        ),
+    ] {
+        capabilities.push(CapabilityEntry {
+            name: name.to_string(),
+            availability: CapabilityAvailability::Stubbed,
+            reason: Some(reason.to_string()),
+        });
+    }
+}
+
+#[async_trait]
+impl CapabilityApi for AdminClient {
+    async fn discover_capabilities(&self, refresh: bool) -> Result<CapabilityReport> {
+        if !refresh && let Some(report) = self.cached_capabilities()? {
+            return Ok(report);
+        }
+
+        let report = self.discover_capabilities_uncached().await?;
+        self.store_capabilities(&report)?;
+        Ok(report)
+    }
 }
 
 #[async_trait]
@@ -1387,6 +1820,35 @@ mod tests {
         (endpoint, receiver, handle)
     }
 
+    fn start_admin_sequence_server(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (
+        String,
+        mpsc::Receiver<CapturedAdminRequest>,
+        thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+
+        let handle = thread::spawn(move || {
+            for (response_status, response_body) in responses {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let request = read_admin_request(&mut stream);
+                sender.send(request).expect("send captured request");
+                let response = format!(
+                    "HTTP/1.1 {response_status}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write HTTP response");
+            }
+        });
+
+        (endpoint, receiver, handle)
+    }
+
     fn admin_client_for_endpoint(endpoint: &str) -> AdminClient {
         let alias = Alias::new("test", endpoint, "access", "secret");
         AdminClient::new(&alias).expect("admin client should build")
@@ -1429,6 +1891,422 @@ mod tests {
             client.admin_url("/list-users"),
             "http://localhost:9000/rustfs/admin/v3/list-users"
         );
+    }
+
+    const CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+    const RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+    const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[{"schema_version":"rustfs.extension-schema.v1","extension_id":"ops.diagnostics","display_name":"Operations Diagnostics","provider":"rustfs","version":"1","kind":"ops_diagnostics","runtime":{"api_version":"v1","boundary":"builtin"},"capabilities":[],"disabled_by_default":false}],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+    const CLUSTER_SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+
+    #[tokio::test]
+    async fn capability_discovery_uses_v4_routes_and_classifies_beta10_stubs() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("capability discovery should succeed");
+        let second_client = admin_client_for_endpoint(&endpoint);
+        let cached = second_client
+            .discover_capabilities(false)
+            .await
+            .expect("process-shared cached discovery should succeed");
+
+        assert_eq!(cached, report);
+        assert_eq!(report.server_version.as_deref(), Some("1.0.0-beta.10"));
+        assert_eq!(report.extensions.len(), 1);
+        assert!(report.cluster.summary.is_some());
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == "runtime.userspace-profiling"
+                && capability.availability == CapabilityAvailability::Disabled
+        }));
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == "runtime.memory-sampling"
+                && capability.availability == CapabilityAvailability::Unsupported
+                && capability.reason.as_deref() == Some("not available on this platform")
+        }));
+        for name in [
+            "admin.batch",
+            "admin.ldap-mutation",
+            "admin.logs",
+            "admin.trace",
+            "admin.update",
+        ] {
+            assert!(report.capabilities.iter().any(|capability| {
+                capability.name == name
+                    && capability.availability == CapabilityAvailability::Stubbed
+            }));
+        }
+
+        let targets = (0..4)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            vec![
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_refreshes_process_shared_cache() {
+        let responses = vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ];
+        let (endpoint, receiver, handle) = start_admin_sequence_server(responses);
+        let first_client = admin_client_for_endpoint(&endpoint);
+        first_client
+            .discover_capabilities(false)
+            .await
+            .expect("initial discovery should succeed");
+
+        let second_client = admin_client_for_endpoint(&endpoint);
+        second_client
+            .discover_capabilities(true)
+            .await
+            .expect("refresh should bypass the process-shared cache");
+
+        let targets = (0..8)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            [
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+            .repeat(2)
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_cache_isolates_tls_contexts_and_refreshes_within_each_context() {
+        let response_set = [
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ];
+        let responses = response_set.repeat(3);
+        let (endpoint, receiver, handle) = start_admin_sequence_server(responses);
+
+        let strict_client = admin_client_for_endpoint(&endpoint);
+        strict_client
+            .discover_capabilities(false)
+            .await
+            .expect("strict TLS context discovery should succeed");
+
+        let mut insecure_alias = Alias::new("test", &endpoint, "access", "secret");
+        insecure_alias.insecure = true;
+        let insecure_client =
+            AdminClient::new(&insecure_alias).expect("insecure admin client should build");
+        assert_ne!(
+            strict_client.capability_cache_key(),
+            insecure_client.capability_cache_key()
+        );
+        insecure_client
+            .discover_capabilities(false)
+            .await
+            .expect("a different TLS context must not reuse the strict cache entry");
+
+        let second_insecure_client =
+            AdminClient::new(&insecure_alias).expect("second insecure client should build");
+        second_insecure_client
+            .discover_capabilities(false)
+            .await
+            .expect("the same TLS context should reuse its cache entry");
+        second_insecure_client
+            .discover_capabilities(true)
+            .await
+            .expect("refresh should bypass the matching TLS context cache entry");
+
+        let targets = (0..12)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            [
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+            .repeat(3)
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_404_takes_precedence_over_not_implemented_body() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            (
+                "404 Not Found",
+                r#"{"code":"NotImplemented","message":"route body must not override HTTP 404"}"#,
+            ),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("v4 absence should produce a report");
+
+        assert_eq!(report.capabilities.len(), 1);
+        assert_eq!(
+            report.capabilities[0].availability,
+            CapabilityAvailability::VersionGated
+        );
+        assert_eq!(
+            receiver.recv().expect("info request").target,
+            "/rustfs/admin/v3/info"
+        );
+        assert_eq!(
+            receiver.recv().expect("runtime request").target,
+            "/rustfs/admin/v4/runtime/capabilities"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_reports_http_501_as_stubbed() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            (
+                "501 Not Implemented",
+                r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+            ),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("an explicit stub response should produce a report");
+
+        assert_eq!(report.capabilities.len(), 1);
+        assert_eq!(
+            report.capabilities[0].availability,
+            CapabilityAvailability::Stubbed
+        );
+        assert_eq!(
+            report.capabilities[0].reason.as_deref(),
+            Some("route is not implemented")
+        );
+        assert_eq!(
+            receiver.recv().expect("info request").target,
+            "/rustfs/admin/v3/info"
+        );
+        assert_eq!(
+            receiver.recv().expect("runtime request").target,
+            "/rustfs/admin/v4/runtime/capabilities"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_does_not_misclassify_permission_denial() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("403 Forbidden", r#"{"code":"AccessDenied"}"#),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let error = client
+            .discover_capabilities(false)
+            .await
+            .expect_err("permission denial should fail discovery");
+
+        assert!(matches!(error, Error::Auth(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_maps_rustfs_missing_credentials_to_auth() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            (
+                "400 Bad Request",
+                "<Error><Code>InvalidRequest</Code><Message>get cred failed</Message></Error>",
+            ),
+        ]);
+        let client = anonymous_admin_client_for_endpoint(&endpoint);
+
+        let error = client
+            .discover_capabilities(false)
+            .await
+            .expect_err("RustFS missing credentials should fail discovery");
+
+        assert!(matches!(error, Error::Auth(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_rejects_malformed_runtime_response() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", r#"{"summary":{}}"#),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let error = client
+            .discover_capabilities(false)
+            .await
+            .expect_err("malformed response should fail discovery");
+
+        assert!(matches!(error, Error::Json(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[test]
+    fn not_implemented_admin_error_maps_to_unsupported_feature() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::NOT_IMPLEMENTED,
+            r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+        );
+
+        assert!(matches!(error, Error::UnsupportedFeature(_)));
+    }
+
+    #[test]
+    fn structured_not_implemented_code_maps_to_unsupported_feature() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::BAD_REQUEST,
+            "<Error><Code>NotImplemented</Code><Message>stub route</Message></Error>",
+        );
+
+        assert!(matches!(error, Error::UnsupportedFeature(message) if message == "stub route"));
+    }
+
+    #[test]
+    fn permission_status_takes_precedence_over_not_implemented_code() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::FORBIDDEN,
+            r#"{"code":"NotImplemented","message":"Access denied"}"#,
+        );
+
+        assert!(matches!(error, Error::Auth(_)));
+    }
+
+    #[test]
+    fn not_found_status_takes_precedence_over_not_implemented_code() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::NOT_FOUND,
+            r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+        );
+
+        assert!(matches!(error, Error::NotFound(_)));
+    }
+
+    #[test]
+    fn unstructured_not_implemented_text_does_not_change_error_class() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::BAD_REQUEST,
+            "A proxy says NotImplemented but provides no structured error code",
+        );
+
+        assert!(matches!(error, Error::General(_)));
+    }
+
+    #[test]
+    fn rustfs_missing_credentials_invalid_request_maps_to_auth() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        for body in [
+            "<Error><Code>InvalidRequest</Code><Message>get cred failed</Message></Error>",
+            r#"{"Code":"InvalidRequest","Message":"authentication required"}"#,
+        ] {
+            let error = client.map_error(StatusCode::BAD_REQUEST, body);
+            assert!(matches!(error, Error::Auth(_)));
+        }
+    }
+
+    #[test]
+    fn capability_cache_key_is_credential_scoped_without_plaintext_secrets() {
+        let first = admin_client_for_endpoint("http://localhost:9000");
+        let mut alias = Alias::new(
+            "test",
+            "http://localhost:9000",
+            "different-access",
+            "different-secret",
+        );
+        alias.region = first.region.clone();
+        let second = AdminClient::new(&alias).expect("admin client should build");
+
+        let first_key = first.capability_cache_key();
+        let second_key = second.capability_cache_key();
+        assert_ne!(first_key, second_key);
+        assert!(!first_key.credential_fingerprint.contains("secret"));
+        assert!(
+            !second_key
+                .credential_fingerprint
+                .contains("different-secret")
+        );
+    }
+
+    #[test]
+    fn transport_security_fingerprint_covers_tls_and_mtls_inputs_without_leaking_them() {
+        let baseline = transport_security_fingerprint(false, None, None, None);
+        let insecure = transport_security_fingerprint(true, None, None, None);
+        let custom_ca = transport_security_fingerprint(false, Some(b"private-ca-root"), None, None);
+        let client_identity = transport_security_fingerprint(
+            false,
+            Some(b"private-ca-root"),
+            Some(b"client-certificate"),
+            Some(b"PRIVATE-KEY-MARKER"),
+        );
+        let different_key = transport_security_fingerprint(
+            false,
+            Some(b"private-ca-root"),
+            Some(b"client-certificate"),
+            Some(b"DIFFERENT-PRIVATE-KEY"),
+        );
+
+        assert_ne!(baseline, insecure);
+        assert_ne!(baseline, custom_ca);
+        assert_ne!(custom_ca, client_identity);
+        assert_ne!(client_identity, different_key);
+        for fingerprint in [
+            baseline,
+            insecure,
+            custom_ca,
+            client_identity,
+            different_key,
+        ] {
+            assert_eq!(fingerprint.len(), 64);
+            assert!(
+                fingerprint
+                    .chars()
+                    .all(|character| character.is_ascii_hexdigit())
+            );
+            assert!(!fingerprint.contains("PRIVATE-KEY-MARKER"));
+            assert!(!fingerprint.contains("private-ca-root"));
+        }
     }
 
     #[test]

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -69,6 +69,7 @@
         "scope": { "type": "string", "minLength": 1 },
         "support": {
           "type": "string",
+          "description": "Effective support: unsupported is a server-declared runtime state or version gate, while stub is reserved for registered but unimplemented routes.",
           "enum": ["supported", "unsupported", "stub", "disabled", "unknown"]
         },
         "reason": { "$ref": "#/definitions/nullableString" }


### PR DESCRIPTION
## Related issue

Closes rustfs/backlog#1403
Parent: rustfs/backlog#1383
Roadmap: rustfs/backlog#1361

## Background and user impact

RustFS 1.0.0-beta.10 registers several diagnostic routes that are placeholders rather than real measurements. Route presence and HTTP 200 responses are therefore not sufficient evidence of support. Without probe-specific truth, rc could advertise or execute object, network, site, or site-replication performance tests that return misleading success.

The existing /v3/inspect-data endpoint also returns reconstructed object bytes and is not an inspect archive.

## Root cause

Runtime discovery exposed broad server capabilities but did not normalize individual diagnostic probe states or provide a reusable fail-closed guard. Unknown future server versions could not be distinguished safely from the pinned beta.10 contract.

## Solution

- Add 10 stable diagnostic capability names.
- Classify the pinned beta.10 contract:
  - available: health, cluster snapshot, extensions catalog, drive observations, and client-devnull
  - unsupported: inspect archive
  - stubbed: object, network, site, and site-replication netperf
- Mirror cluster and extension availability from their actual read-only discovery requests.
- Treat unknown future versions as unknown and missing v4 discovery as version-gated.
- Preserve permission-denied, disabled, unsupported, stubbed, version-gated, and unknown states.
- Add a reusable CapabilityReport guard that permits only explicitly available diagnostics.
- Verify discovery never executes an active diagnostic or speed-test request.

## Validation

Passed locally at exact head f6e9316b9adffb41fc7485ee4bf337d81c5d5ccd:

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace

Focused rc-core and rc-s3 capability tests also pass.

## Review notes

This PR is intentionally stacked on rustfs/cli#268 because it extends runtime capability discovery and output schema v3 foundations. It adds no diagnostic command and performs no active probe. Unknown versions remain fail-closed until a server-owned per-probe contract is available through rustfs/backlog#1402.

## BREAKING process

BREAKING marker for the stacked exact-head workflow: temporary validation against main includes protected command-reference/schema changes from prerequisite PRs #266 and #268. This #1403 diff against its true #268 base changes only capability core/S3 code and does not independently modify a protected file. The prerequisite output-v3 stack carries its documented additive contract and migration boundary.