### PR TITLE
feat(rc-admin)!: add safe server configuration management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2817,6 +2817,7 @@ name = "rustfs-cli"
 version = "0.1.24"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "clap_complete",
  "comfy-table",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -62,6 +62,7 @@ integration = []
 golden = []
 
 [dev-dependencies]
+async-trait.workspace = true
 tempfile.workspace = true
 insta.workspace = true
 jsonschema.workspace = true

--- a/crates/cli/src/commands/admin/capabilities.rs
+++ b/crates/cli/src/commands/admin/capabilities.rs
@@ -1,0 +1,514 @@
+//! Runtime capability discovery command.
+
+use clap::Args;
+use rc_core::Error;
+use rc_core::admin::{CapabilityApi, CapabilityAvailability, CapabilityReport};
+use serde::Serialize;
+
+use super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+/// Inspect the effective RustFS Admin API capabilities.
+#[derive(Args, Debug)]
+pub struct CapabilitiesArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Bypass the in-process capability cache
+    #[arg(long)]
+    pub refresh: bool,
+}
+
+/// Execute runtime capability discovery.
+pub async fn execute(args: CapabilitiesArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_with_api(args.refresh, &client, formatter).await
+}
+
+async fn execute_with_api(
+    refresh: bool,
+    api: &dyn CapabilityApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    match api.discover_capabilities(refresh).await {
+        Ok(report) => {
+            if formatter.is_json() {
+                formatter.json(&success_output(&report));
+            } else {
+                print_report(&report, formatter);
+            }
+            ExitCode::Success
+        }
+        Err(error) => emit_capability_error(&error, "Failed to discover capabilities", formatter),
+    }
+}
+
+fn emit_capability_error(error: &Error, context: &str, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    let message = format!("{context}: {error}");
+    if formatter.is_json() {
+        formatter.json_error(&error_output(error, code, message));
+    } else {
+        formatter.error_with_code(code, &message);
+    }
+    code
+}
+
+fn print_report(report: &CapabilityReport, formatter: &Formatter) {
+    for line in report_lines(report, formatter) {
+        formatter.println(&line);
+    }
+}
+
+fn report_lines(report: &CapabilityReport, formatter: &Formatter) -> Vec<String> {
+    let version = formatter.sanitize_text(report.server_version.as_deref().unwrap_or("unknown"));
+    let mut lines = vec![
+        format!("RustFS capabilities ({version})"),
+        String::new(),
+        "CAPABILITY                         STATUS             REASON".to_string(),
+    ];
+    for capability in &report.capabilities {
+        let name = formatter.sanitize_text(&capability.name);
+        let reason = formatter.sanitize_text(capability.reason.as_deref().unwrap_or("-"));
+        lines.push(format!(
+            "{:<34} {:<18} {}",
+            name, capability.availability, reason
+        ));
+    }
+
+    if !report.extensions.is_empty() {
+        lines.push(String::new());
+        lines.push(format!("Extensions: {}", report.extensions.len()));
+    }
+
+    lines
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesSuccessOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: CapabilitiesData,
+    meta: CapabilitiesMeta,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesData {
+    server: &'static str,
+    api_version: Option<&'static str>,
+    capabilities: Vec<CapabilityOutput>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilityOutput {
+    name: String,
+    scope: &'static str,
+    support: &'static str,
+    reason: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesMeta {
+    server_version: Option<String>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct CapabilitiesErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: CapabilityErrorOutput,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+enum CapabilityErrorOutput {
+    Unsupported(UnsupportedCapabilityError),
+    Standard(StandardCapabilityError),
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct UnsupportedCapabilityError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    capability: &'static str,
+    server: Option<String>,
+    suggestion: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct StandardCapabilityError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    suggestion: Option<&'static str>,
+}
+
+fn success_output(report: &CapabilityReport) -> CapabilitiesSuccessOutput {
+    let api_version = !report.capabilities.iter().any(|capability| {
+        capability.name == "admin.runtime-capabilities"
+            && capability.availability == CapabilityAvailability::VersionGated
+    });
+    let capabilities = report
+        .capabilities
+        .iter()
+        .map(|capability| CapabilityOutput {
+            name: capability.name.clone(),
+            scope: capability_scope(&capability.name),
+            support: capability_support(capability.availability),
+            reason: capability.reason.clone(),
+        })
+        .collect();
+
+    CapabilitiesSuccessOutput {
+        schema_version: 3,
+        output_type: "capabilities",
+        status: "success",
+        data: CapabilitiesData {
+            server: "rustfs",
+            api_version: api_version.then_some("v4"),
+            capabilities,
+        },
+        meta: CapabilitiesMeta {
+            server_version: report.server_version.clone(),
+        },
+    }
+}
+
+fn capability_scope(name: &str) -> &'static str {
+    if name.starts_with("runtime.") {
+        "runtime"
+    } else if name.starts_with("admin.") {
+        "admin"
+    } else {
+        "server"
+    }
+}
+
+const fn capability_support(availability: CapabilityAvailability) -> &'static str {
+    match availability {
+        CapabilityAvailability::Available => "supported",
+        CapabilityAvailability::Stubbed => "stub",
+        CapabilityAvailability::Unsupported => "unsupported",
+        CapabilityAvailability::Disabled => "disabled",
+        CapabilityAvailability::VersionGated => "unsupported",
+        CapabilityAvailability::PermissionDenied | CapabilityAvailability::Unknown => "unknown",
+    }
+}
+
+fn error_output(error: &Error, code: ExitCode, message: String) -> CapabilitiesErrorOutput {
+    let error = if matches!(error, Error::UnsupportedFeature(_)) {
+        CapabilityErrorOutput::Unsupported(UnsupportedCapabilityError {
+            error_type: "unsupported_feature",
+            message,
+            retryable: false,
+            capability: "runtime_capabilities",
+            server: None,
+            suggestion: Some("Upgrade RustFS or retry after verifying server capability support."),
+        })
+    } else {
+        let (error_type, retryable, suggestion) = standard_error_metadata(code);
+        CapabilityErrorOutput::Standard(StandardCapabilityError {
+            error_type,
+            message,
+            retryable,
+            suggestion,
+        })
+    };
+
+    CapabilitiesErrorOutput {
+        schema_version: 3,
+        output_type: "capabilities",
+        status: "error",
+        error,
+    }
+}
+
+const fn standard_error_metadata(code: ExitCode) -> (&'static str, bool, Option<&'static str>) {
+    match code {
+        ExitCode::UsageError => (
+            "usage_error",
+            false,
+            Some("Run the command with --help and verify its arguments."),
+        ),
+        ExitCode::NetworkError => (
+            "network_error",
+            true,
+            Some("Verify the endpoint and network connectivity, then retry."),
+        ),
+        ExitCode::AuthError => (
+            "auth_error",
+            false,
+            Some("Verify the alias credentials and ServerInfoAdminAction permission."),
+        ),
+        ExitCode::NotFound => (
+            "not_found",
+            false,
+            Some("Verify that the alias and server endpoint exist."),
+        ),
+        ExitCode::Conflict => (
+            "conflict",
+            false,
+            Some("Review the server state and retry."),
+        ),
+        ExitCode::Interrupted => (
+            "interrupted",
+            true,
+            Some("Retry the command if capability discovery is still needed."),
+        ),
+        ExitCode::Success | ExitCode::GeneralError | ExitCode::UnsupportedFeature => {
+            ("general_error", false, None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use jsonschema::Validator;
+    use rc_core::Result;
+    use rc_core::admin::{
+        CapabilityAvailability, CapabilityEntry, ClusterSnapshotMetadata, ExtensionMetadata,
+    };
+    use serde_json::Value;
+    use std::path::Path;
+
+    use super::*;
+    use crate::output::OutputConfig;
+
+    const SUCCESS_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/runtime_success.json");
+    const VERSION_GATED_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/version_gated.json");
+    const RUNTIME_UNSUPPORTED_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/runtime_unsupported.json");
+    const AUTH_ERROR_GOLDEN: &str =
+        include_str!("../../../tests/fixtures/output_v3/capabilities/auth_error.json");
+
+    struct StubCapabilityApi {
+        result: Result<CapabilityReport>,
+    }
+
+    #[async_trait]
+    impl CapabilityApi for StubCapabilityApi {
+        async fn discover_capabilities(&self, _refresh: bool) -> Result<CapabilityReport> {
+            match &self.result {
+                Ok(report) => Ok(report.clone()),
+                Err(Error::Auth(message)) => Err(Error::Auth(message.clone())),
+                Err(Error::UnsupportedFeature(message)) => {
+                    Err(Error::UnsupportedFeature(message.clone()))
+                }
+                Err(error) => Err(Error::General(error.to_string())),
+            }
+        }
+    }
+
+    fn report() -> CapabilityReport {
+        CapabilityReport {
+            server_version: Some("1.0.0-beta.10".to_string()),
+            runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+            extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+            cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+            capabilities: vec![CapabilityEntry {
+                name: "runtime.observability".to_string(),
+                availability: CapabilityAvailability::Available,
+                reason: None,
+            }],
+            extensions: Vec::<ExtensionMetadata>::new(),
+            cluster: ClusterSnapshotMetadata {
+                summary: None,
+                runtime_capabilities_path: None,
+                extensions_catalog_path: None,
+            },
+        }
+    }
+
+    fn output_v3_validator() -> Validator {
+        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("schemas/output_v3.json");
+        let schema = std::fs::read_to_string(&schema_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+        let schema: Value = serde_json::from_str(&schema).expect("output v3 schema should parse");
+        jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+    }
+
+    fn assert_valid_v3(value: &Value) {
+        let validator = output_v3_validator();
+        let errors = validator
+            .iter_errors(value)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        assert!(
+            errors.is_empty(),
+            "capability output must satisfy output v3:\n{}",
+            errors.join("\n")
+        );
+    }
+
+    fn golden(contents: &str) -> Value {
+        serde_json::from_str(contents).expect("capability golden fixture should parse")
+    }
+
+    #[tokio::test]
+    async fn command_returns_success_for_discovery_report() {
+        let formatter = Formatter::new(OutputConfig {
+            quiet: true,
+            ..Default::default()
+        });
+        let api = StubCapabilityApi {
+            result: Ok(report()),
+        };
+
+        assert_eq!(
+            execute_with_api(false, &api, &formatter).await,
+            ExitCode::Success
+        );
+    }
+
+    #[tokio::test]
+    async fn command_preserves_permission_denial_exit_code() {
+        let formatter = Formatter::new(OutputConfig {
+            json: true,
+            ..Default::default()
+        });
+        let api = StubCapabilityApi {
+            result: Err(Error::Auth("Access denied".to_string())),
+        };
+
+        assert_eq!(
+            execute_with_api(false, &api, &formatter).await,
+            ExitCode::AuthError
+        );
+    }
+
+    #[tokio::test]
+    async fn command_preserves_unsupported_feature_exit_code() {
+        let formatter = Formatter::new(OutputConfig {
+            json: true,
+            ..Default::default()
+        });
+        let api = StubCapabilityApi {
+            result: Err(Error::UnsupportedFeature("NotImplemented".to_string())),
+        };
+
+        assert_eq!(
+            execute_with_api(false, &api, &formatter).await,
+            ExitCode::UnsupportedFeature
+        );
+    }
+
+    #[test]
+    fn success_json_uses_capabilities_output_v3_contract() {
+        let value = serde_json::to_value(success_output(&report()))
+            .expect("capability success output should serialize");
+
+        assert_eq!(value, golden(SUCCESS_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn version_gated_json_is_a_v3_unsupported_capability() {
+        let mut report = report();
+        report.capabilities = vec![CapabilityEntry {
+            name: "admin.runtime-capabilities".to_string(),
+            availability: CapabilityAvailability::VersionGated,
+            reason: Some("Admin API v4 is unavailable".to_string()),
+        }];
+        let value = serde_json::to_value(success_output(&report))
+            .expect("version-gated output should serialize");
+
+        assert_eq!(value["data"]["api_version"], Value::Null);
+        assert_eq!(value["data"]["capabilities"][0]["support"], "unsupported");
+        assert_eq!(value, golden(VERSION_GATED_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn runtime_unsupported_json_is_distinct_from_a_stub() {
+        let mut report = report();
+        report.capabilities = vec![CapabilityEntry {
+            name: "runtime.memory-sampling".to_string(),
+            availability: CapabilityAvailability::Unsupported,
+            reason: Some("not available on this platform".to_string()),
+        }];
+        let value = serde_json::to_value(success_output(&report))
+            .expect("runtime unsupported output should serialize");
+
+        assert_eq!(value["data"]["api_version"], "v4");
+        assert_eq!(value["data"]["capabilities"][0]["support"], "unsupported");
+        assert_ne!(value["data"]["capabilities"][0]["support"], "stub");
+        assert_eq!(value, golden(RUNTIME_UNSUPPORTED_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn discovery_error_json_uses_capabilities_output_v3_contract() {
+        let error = Error::Auth("Access denied".to_string());
+        let value = serde_json::to_value(error_output(
+            &error,
+            ExitCode::AuthError,
+            format!("Failed to discover capabilities: {error}"),
+        ))
+        .expect("capability error output should serialize");
+
+        assert_eq!(value["schema_version"], 3);
+        assert_eq!(value["type"], "capabilities");
+        assert_eq!(value["status"], "error");
+        assert_eq!(value["error"]["type"], "auth_error");
+        assert_eq!(value["error"]["retryable"], false);
+        assert_eq!(value, golden(AUTH_ERROR_GOLDEN));
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn unsupported_error_json_uses_specialized_v3_contract() {
+        let error = Error::UnsupportedFeature("NotImplemented".to_string());
+        let value = serde_json::to_value(error_output(
+            &error,
+            ExitCode::UnsupportedFeature,
+            format!("Failed to discover capabilities: {error}"),
+        ))
+        .expect("unsupported capability error should serialize");
+
+        assert_eq!(value["error"]["type"], "unsupported_feature");
+        assert_eq!(value["error"]["capability"], "runtime_capabilities");
+        assert_eq!(value["error"]["server"], Value::Null);
+        assert_valid_v3(&value);
+    }
+
+    #[test]
+    fn table_output_sanitizes_server_controlled_strings() {
+        let mut report = report();
+        report.server_version = Some("beta.10\n\u{1b}[31m".to_string());
+        report.capabilities[0].name = "runtime.bad\nname\u{1b}[2J".to_string();
+        report.capabilities[0].reason = Some("line one\r\nline two\u{1b}[0m".to_string());
+        let formatter = Formatter::new(OutputConfig {
+            no_color: true,
+            ..Default::default()
+        });
+
+        let lines = report_lines(&report, &formatter);
+
+        assert!(lines.iter().all(|line| !line.contains('\u{1b}')));
+        assert!(lines.iter().all(|line| !line.contains('\r')));
+        assert!(lines.iter().all(|line| !line.contains('\n')));
+        assert!(lines.iter().any(|line| line.contains("beta.10\\n\\u{1b}")));
+        assert!(lines.iter().any(|line| line.contains("runtime.bad\\nname")));
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("line one\\r\\nline two"))
+        );
+    }
+}

--- a/crates/cli/src/commands/admin/config.rs
+++ b/crates/cli/src/commands/admin/config.rs
@@ -1,0 +1,1131 @@
+//! RustFS server configuration commands with client-side preflight planning.
+
+use clap::{Args, Subcommand};
+use rc_core::Error;
+use rc_core::admin::{
+    ConfigApi, ConfigDiff, ConfigDocument, ConfigHistoryEntry, ModuleSwitches,
+    config_document_fields, config_import_diff, config_mutation_diff, redact_config_document,
+    validate_config_directive, validate_config_import,
+};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+
+use super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+#[derive(Subcommand, Debug)]
+#[command(disable_help_subcommand = true)]
+pub enum ConfigCommands {
+    /// Read a subsystem or target configuration
+    Get(GetArgs),
+    /// Set one or more keys after showing a preflight diff
+    Set(SetArgs),
+    /// Delete a target or selected keys after showing a preflight diff
+    Delete(DeleteArgs),
+    /// Show server-provided configuration help
+    Help(HelpArgs),
+    /// List configuration mutation history
+    History(HistoryArgs),
+    /// Replace configuration from a history entry
+    Restore(RestoreArgs),
+    /// Export the full server configuration to a file
+    Export(ExportArgs),
+    /// Replace the full server configuration from a file
+    Import(ImportArgs),
+    /// Inspect or update event notification and audit module switches
+    #[command(name = "module-switch", subcommand)]
+    ModuleSwitch(ModuleSwitchCommands),
+}
+
+#[derive(Args, Debug)]
+pub struct GetArgs {
+    pub alias: String,
+    pub selector: String,
+}
+
+#[derive(Args, Debug)]
+pub struct SetArgs {
+    pub alias: String,
+    pub scope: String,
+    #[arg(required = true)]
+    pub assignments: Vec<String>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct DeleteArgs {
+    pub alias: String,
+    pub scope: String,
+    pub keys: Vec<String>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct HelpArgs {
+    pub alias: String,
+    pub subsystem: Option<String>,
+    pub key: Option<String>,
+    #[arg(long)]
+    pub env: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct HistoryArgs {
+    pub alias: String,
+    #[arg(long, default_value_t = 10, value_parser = parse_positive_usize)]
+    pub count: usize,
+}
+
+#[derive(Args, Debug)]
+pub struct RestoreArgs {
+    pub alias: String,
+    pub restore_id: String,
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm replacement of the complete server configuration
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ExportArgs {
+    pub alias: String,
+    #[arg(long)]
+    pub file: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct ImportArgs {
+    pub alias: String,
+    #[arg(long)]
+    pub file: PathBuf,
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm replacement of the complete server configuration
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ModuleSwitchCommands {
+    Get(ModuleSwitchGetArgs),
+    Set(ModuleSwitchSetArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ModuleSwitchGetArgs {
+    pub alias: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ModuleSwitchSetArgs {
+    pub alias: String,
+    #[arg(long, value_parser = parse_on_off)]
+    pub notify: Option<bool>,
+    #[arg(long, value_parser = parse_on_off)]
+    pub audit: Option<bool>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+fn parse_on_off(value: &str) -> Result<bool, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "on" | "true" => Ok(true),
+        "off" | "false" => Ok(false),
+        _ => Err("expected on or off".to_string()),
+    }
+}
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| "expected a positive integer".to_string())?;
+    if parsed == 0 {
+        return Err("expected a positive integer".to_string());
+    }
+    Ok(parsed)
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigOutput<T> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: AdminOperationsData<T>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperationsData<T> {
+    operations: Vec<AdminOperation<T>>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperation<T> {
+    operation: &'static str,
+    resource: &'static str,
+    state: &'static str,
+    operation_id: Option<String>,
+    changed: bool,
+    result: T,
+}
+
+#[derive(Debug, Serialize)]
+struct OperationData<T> {
+    operation: &'static str,
+    result: T,
+}
+
+#[derive(Debug, Serialize)]
+struct MutationData {
+    operation: &'static str,
+    dry_run: bool,
+    applied_dynamically: Option<bool>,
+    diff: ConfigDiff,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExportData {
+    operation: &'static str,
+    path: String,
+    redacted: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct HistoryOutputEntry {
+    restore_id: String,
+    create_time: String,
+    data: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SwitchDiff {
+    notify_before: bool,
+    notify_after: bool,
+    audit_before: bool,
+    audit_after: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: ConfigErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ConfigErrorDetail {
+    Unsupported {
+        #[serde(rename = "type")]
+        error_type: &'static str,
+        message: String,
+        retryable: bool,
+        capability: &'static str,
+        server: Option<&'static str>,
+        suggestion: Option<&'static str>,
+    },
+    Standard {
+        #[serde(rename = "type")]
+        error_type: &'static str,
+        message: String,
+        retryable: bool,
+        suggestion: Option<&'static str>,
+    },
+}
+
+const RESTORE_SAFETY_WARNING: &str = "RustFS rebuilds the complete configuration from this history document; unrelated current values are removed. This unsafe server behavior is tracked by rustfs/backlog#1398.";
+
+pub async fn execute(command: ConfigCommands, formatter: &Formatter) -> ExitCode {
+    let alias = command.alias();
+    let client = match get_admin_client(alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_with_api(command, &client, formatter).await
+}
+
+impl ConfigCommands {
+    fn alias(&self) -> &str {
+        match self {
+            Self::Get(args) => &args.alias,
+            Self::Set(args) => &args.alias,
+            Self::Delete(args) => &args.alias,
+            Self::Help(args) => &args.alias,
+            Self::History(args) => &args.alias,
+            Self::Restore(args) => &args.alias,
+            Self::Export(args) => &args.alias,
+            Self::Import(args) => &args.alias,
+            Self::ModuleSwitch(ModuleSwitchCommands::Get(args)) => &args.alias,
+            Self::ModuleSwitch(ModuleSwitchCommands::Set(args)) => &args.alias,
+        }
+    }
+}
+
+async fn execute_with_api(
+    command: ConfigCommands,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    let result = match command {
+        ConfigCommands::Get(args) => get(args, api, formatter).await,
+        ConfigCommands::Set(args) => set(args, api, formatter).await,
+        ConfigCommands::Delete(args) => delete(args, api, formatter).await,
+        ConfigCommands::Help(args) => help(args, api, formatter).await,
+        ConfigCommands::History(args) => history(args, api, formatter).await,
+        ConfigCommands::Restore(args) => restore(args, api, formatter).await,
+        ConfigCommands::Export(args) => export(args, api, formatter).await,
+        ConfigCommands::Import(args) => import(args, api, formatter).await,
+        ConfigCommands::ModuleSwitch(command) => module_switch(command, api, formatter).await,
+    };
+    match result {
+        Ok(()) => ExitCode::Success,
+        Err(error) => emit_error(&error, formatter),
+    }
+}
+
+async fn get(args: GetArgs, api: &dyn ConfigApi, formatter: &Formatter) -> rc_core::Result<()> {
+    validate_selector(&args.selector)?;
+    let document = api.get_config(&args.selector).await?;
+    let content = redact_config_document(&document.content);
+    output(
+        formatter,
+        false,
+        OperationData {
+            operation: "config.get",
+            result: &content,
+        },
+        || formatter.println(&content),
+    );
+    Ok(())
+}
+
+async fn set(args: SetArgs, api: &dyn ConfigApi, formatter: &Formatter) -> rc_core::Result<()> {
+    let directive = format!("{} {}", args.scope, args.assignments.join(" "));
+    validate_config_directive(&directive, false)?;
+    validate_server_keys(api, &args.scope, &args.assignments).await?;
+    let current = api.get_config(&args.scope).await?;
+    let diff = config_mutation_diff(&current.content, &directive, false)?;
+    let applied = if args.dry_run {
+        None
+    } else {
+        Some(api.set_config(&directive).await?.applied_dynamically)
+    };
+    emit_mutation("config.set", args.dry_run, applied, diff, None, formatter);
+    Ok(())
+}
+
+async fn delete(
+    args: DeleteArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    let directive = if args.keys.is_empty() {
+        args.scope.clone()
+    } else {
+        format!("{} {}", args.scope, args.keys.join(" "))
+    };
+    validate_config_directive(&directive, true)?;
+    validate_server_keys(api, &args.scope, &args.keys).await?;
+    let current = api.get_config(&args.scope).await?;
+    let diff = config_mutation_diff(&current.content, &directive, true)?;
+    let applied = if args.dry_run {
+        None
+    } else {
+        Some(api.delete_config(&directive).await?.applied_dynamically)
+    };
+    emit_mutation(
+        "config.delete",
+        args.dry_run,
+        applied,
+        diff,
+        None,
+        formatter,
+    );
+    Ok(())
+}
+
+async fn help(args: HelpArgs, api: &dyn ConfigApi, formatter: &Formatter) -> rc_core::Result<()> {
+    let result = api
+        .config_help(args.subsystem.as_deref(), args.key.as_deref(), args.env)
+        .await?;
+    output(
+        formatter,
+        false,
+        OperationData {
+            operation: "config.help",
+            result: &result,
+        },
+        || {
+            formatter.println(&format!("{}: {}", result.subsystem, result.description));
+            for key in &result.keys {
+                formatter.println(&format!(
+                    "{} ({}) - {}",
+                    key.key, key.value_type, key.description
+                ));
+            }
+        },
+    );
+    Ok(())
+}
+
+async fn history(
+    args: HistoryArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    let entries = api
+        .config_history(args.count)
+        .await?
+        .into_iter()
+        .map(redact_history_entry)
+        .collect::<Vec<_>>();
+    output(
+        formatter,
+        false,
+        OperationData {
+            operation: "config.history",
+            result: &entries,
+        },
+        || {
+            for entry in &entries {
+                formatter.println(&format!("{} {}", entry.restore_id, entry.create_time));
+                if let Some(data) = &entry.data {
+                    formatter.println(data);
+                }
+            }
+        },
+    );
+    Ok(())
+}
+
+async fn restore(
+    args: RestoreArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    validate_restore_id(&args.restore_id)?;
+    if !args.dry_run && !args.yes {
+        return Err(Error::Config(
+            "Restore replaces the complete server configuration; pass --yes to confirm".to_string(),
+        ));
+    }
+    let history = api.config_history(1000).await?;
+    let document = history
+        .iter()
+        .find(|entry| entry.restore_id == args.restore_id)
+        .and_then(|entry| entry.data.as_deref())
+        .ok_or_else(|| {
+            Error::NotFound("Configuration history entry has no restorable data".to_string())
+        })?;
+    validate_config_directive(document, false)?;
+    let current = api.get_full_config().await?;
+    let diff = config_import_diff(&current.content, document)?;
+    if !args.dry_run {
+        api.restore_config(&args.restore_id).await?;
+    }
+    emit_mutation(
+        "config.restore",
+        args.dry_run,
+        None,
+        diff,
+        Some(RESTORE_SAFETY_WARNING),
+        formatter,
+    );
+    Ok(())
+}
+
+async fn export(
+    args: ExportArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    let document = api.get_full_config().await?;
+    let content = redact_config_document(&document.content);
+    write_private_file(&args.file, content.as_bytes())?;
+    let data = ExportData {
+        operation: "config.export",
+        path: args.file.display().to_string(),
+        redacted: true,
+    };
+    output(formatter, false, data, || {
+        formatter.success(&format!(
+            "Configuration exported to {}",
+            args.file.display()
+        ));
+    });
+    Ok(())
+}
+
+async fn import(
+    args: ImportArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    if !args.dry_run && !args.yes {
+        return Err(Error::Config(
+            "Import replaces the complete server configuration; pass --yes to confirm".to_string(),
+        ));
+    }
+    let content = std::fs::read_to_string(&args.file).map_err(|error| {
+        Error::Io(std::io::Error::new(
+            error.kind(),
+            format!("failed to read configuration import: {error}"),
+        ))
+    })?;
+    validate_config_directive(&content, false)?;
+    validate_config_import(&content)?;
+    validate_server_document(api, &content).await?;
+    let current = api.get_full_config().await?;
+    let diff = config_import_diff(&current.content, &content)?;
+    if !args.dry_run {
+        api.import_config(&ConfigDocument { content }).await?;
+    }
+    emit_mutation(
+        "config.import",
+        args.dry_run,
+        None,
+        diff,
+        Some("Import replaces the complete server configuration."),
+        formatter,
+    );
+    Ok(())
+}
+
+async fn module_switch(
+    command: ModuleSwitchCommands,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    match command {
+        ModuleSwitchCommands::Get(_) => {
+            let switches = api.get_module_switches().await?;
+            output(
+                formatter,
+                false,
+                OperationData {
+                    operation: "config.module-switch.get",
+                    result: &switches,
+                },
+                || print_switches(&switches, formatter),
+            );
+        }
+        ModuleSwitchCommands::Set(args) => {
+            if args.notify.is_none() && args.audit.is_none() {
+                return Err(Error::Config(
+                    "At least one of --notify or --audit is required".to_string(),
+                ));
+            }
+            let current = api.get_module_switches().await?;
+            let requested = requested_switches(&current, args.notify, args.audit);
+            let diff = SwitchDiff {
+                notify_before: current.notify_enabled,
+                notify_after: requested.notify_enabled,
+                audit_before: current.audit_enabled,
+                audit_after: requested.audit_enabled,
+            };
+            if !args.dry_run {
+                api.set_module_switches(&requested).await?;
+            }
+            output(
+                formatter,
+                !args.dry_run
+                    && (diff.notify_before != diff.notify_after
+                        || diff.audit_before != diff.audit_after),
+                OperationData {
+                    operation: "config.module-switch.set",
+                    result: &diff,
+                },
+                || {
+                    formatter.println(&format!(
+                        "notify: {} -> {}; audit: {} -> {}{}",
+                        diff.notify_before,
+                        diff.notify_after,
+                        diff.audit_before,
+                        diff.audit_after,
+                        if args.dry_run { " (dry-run)" } else { "" }
+                    ));
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn output<T: Serialize>(formatter: &Formatter, changed: bool, data: T, human: impl FnOnce()) {
+    if formatter.is_json() {
+        formatter.json(&ConfigOutput {
+            schema_version: 3,
+            output_type: "admin_operations",
+            status: "success",
+            data: AdminOperationsData {
+                operations: vec![AdminOperation {
+                    operation: "server-config",
+                    resource: "rustfs-server-configuration",
+                    state: "succeeded",
+                    operation_id: None,
+                    changed,
+                    result: data,
+                }],
+            },
+        });
+    } else {
+        human();
+    }
+}
+
+fn emit_mutation(
+    operation: &'static str,
+    dry_run: bool,
+    applied_dynamically: Option<bool>,
+    diff: ConfigDiff,
+    warning: Option<&'static str>,
+    formatter: &Formatter,
+) {
+    let data = MutationData {
+        operation,
+        dry_run,
+        applied_dynamically,
+        diff,
+        warning,
+    };
+    let changed = !dry_run && !data.diff.changes.is_empty();
+    output(formatter, changed, &data, || {
+        if let Some(warning) = warning {
+            formatter.warning(warning);
+        }
+        formatter.println(if dry_run {
+            "Preflight diff:"
+        } else {
+            "Applied diff:"
+        });
+        for change in &data.diff.changes {
+            formatter.println(&format!(
+                "{} {}: {} -> {}",
+                change.scope,
+                change.key,
+                change.before.as_deref().unwrap_or("<unset>"),
+                change.after.as_deref().unwrap_or("<unset>")
+            ));
+        }
+        if data.diff.changes.is_empty() {
+            formatter.println("No changes.");
+        }
+    });
+}
+
+fn redact_history_entry(entry: ConfigHistoryEntry) -> HistoryOutputEntry {
+    HistoryOutputEntry {
+        restore_id: entry.restore_id,
+        create_time: entry.create_time,
+        data: entry.data.map(|data| redact_config_document(&data)),
+    }
+}
+
+fn validate_selector(selector: &str) -> rc_core::Result<()> {
+    validate_config_directive(selector, true)
+}
+
+fn validate_restore_id(restore_id: &str) -> rc_core::Result<()> {
+    if restore_id.is_empty()
+        || !restore_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        return Err(Error::Config(
+            "Invalid configuration restore ID".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn validate_server_keys(
+    api: &dyn ConfigApi,
+    scope: &str,
+    tokens: &[String],
+) -> rc_core::Result<()> {
+    let subsystem = scope.split_once(':').map_or(scope, |(value, _)| value);
+    if tokens.is_empty() {
+        api.config_help(Some(subsystem), None, false).await?;
+        return Ok(());
+    }
+    for token in tokens {
+        let key = token.split_once('=').map_or(token.as_str(), |(key, _)| key);
+        api.config_help(Some(subsystem), Some(key), false).await?;
+    }
+    Ok(())
+}
+
+async fn validate_server_document(api: &dyn ConfigApi, document: &str) -> rc_core::Result<()> {
+    for (subsystem, key) in config_document_fields(document)? {
+        api.config_help(Some(&subsystem), Some(&key), false).await?;
+    }
+    Ok(())
+}
+
+fn print_switches(switches: &ModuleSwitches, formatter: &Formatter) {
+    formatter.println(&format!(
+        "notify: {} (source: {}, persisted: {})",
+        switches.notify_enabled, switches.notify_source, switches.persisted_notify_enabled
+    ));
+    formatter.println(&format!(
+        "audit: {} (source: {}, persisted: {})",
+        switches.audit_enabled, switches.audit_source, switches.persisted_audit_enabled
+    ));
+}
+
+fn requested_switches(
+    current: &ModuleSwitches,
+    notify: Option<bool>,
+    audit: Option<bool>,
+) -> ModuleSwitches {
+    let mut requested = current.clone();
+    requested.notify_enabled = notify.unwrap_or(current.persisted_notify_enabled);
+    requested.audit_enabled = audit.unwrap_or(current.persisted_audit_enabled);
+    requested
+}
+
+fn write_private_file(path: &Path, contents: &[u8]) -> rc_core::Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    use std::io::Write;
+    file.write_all(contents)?;
+    Ok(())
+}
+
+fn emit_error(error: &Error, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    if formatter.is_json() {
+        let detail = if matches!(error, Error::UnsupportedFeature(_)) {
+            ConfigErrorDetail::Unsupported {
+                error_type: "unsupported_feature",
+                message: error.to_string(),
+                retryable: false,
+                capability: "admin.server-configuration",
+                server: Some("rustfs"),
+                suggestion: Some("Verify the RustFS server version and advertised capabilities."),
+            }
+        } else {
+            let (error_type, retryable, suggestion) = config_error_metadata(code);
+            ConfigErrorDetail::Standard {
+                error_type,
+                message: error.to_string(),
+                retryable,
+                suggestion,
+            }
+        };
+        formatter.json_error(&ConfigErrorOutput {
+            schema_version: 3,
+            output_type: "admin_operations",
+            status: "error",
+            error: detail,
+        });
+    } else {
+        formatter.error_with_code(code, &error.to_string());
+    }
+    code
+}
+
+const fn config_error_metadata(code: ExitCode) -> (&'static str, bool, Option<&'static str>) {
+    match code {
+        ExitCode::UsageError => (
+            "usage_error",
+            false,
+            Some("Review the command arguments and server configuration help."),
+        ),
+        ExitCode::NetworkError => (
+            "network_error",
+            true,
+            Some("Verify the server endpoint and retry."),
+        ),
+        ExitCode::AuthError => (
+            "auth_error",
+            false,
+            Some("Verify the alias credentials and ConfigUpdate permission."),
+        ),
+        ExitCode::NotFound => (
+            "not_found",
+            false,
+            Some("Verify the requested subsystem, target, or history identifier."),
+        ),
+        ExitCode::Conflict => (
+            "conflict",
+            false,
+            Some("Refresh the configuration and retry the preflight."),
+        ),
+        ExitCode::Interrupted => ("interrupted", true, Some("Retry the operation.")),
+        ExitCode::Success | ExitCode::GeneralError | ExitCode::UnsupportedFeature => {
+            ("general_error", false, None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestApi {
+        mutations: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl ConfigApi for TestApi {
+        async fn get_config(&self, _selector: &str) -> rc_core::Result<ConfigDocument> {
+            Ok(ConfigDocument {
+                content: "scanner speed=default cycle=10".to_string(),
+            })
+        }
+
+        async fn get_full_config(&self) -> rc_core::Result<ConfigDocument> {
+            Ok(ConfigDocument {
+                content:
+                    "scanner speed=default cycle=10\nidentity_openid client_secret=super-secret"
+                        .to_string(),
+            })
+        }
+
+        async fn set_config(
+            &self,
+            _directive: &str,
+        ) -> rc_core::Result<rc_core::admin::ConfigMutationResult> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(rc_core::admin::ConfigMutationResult {
+                applied_dynamically: true,
+            })
+        }
+
+        async fn delete_config(
+            &self,
+            _directive: &str,
+        ) -> rc_core::Result<rc_core::admin::ConfigMutationResult> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(rc_core::admin::ConfigMutationResult {
+                applied_dynamically: false,
+            })
+        }
+
+        async fn config_help(
+            &self,
+            _subsystem: Option<&str>,
+            _key: Option<&str>,
+            _env_only: bool,
+        ) -> rc_core::Result<rc_core::admin::ConfigHelp> {
+            Ok(rc_core::admin::ConfigHelp {
+                subsystem: "scanner".to_string(),
+                description: "scanner".to_string(),
+                multiple_targets: false,
+                keys: Vec::new(),
+            })
+        }
+
+        async fn config_history(&self, _count: usize) -> rc_core::Result<Vec<ConfigHistoryEntry>> {
+            Ok(vec![ConfigHistoryEntry {
+                restore_id: "restore-1".to_string(),
+                create_time: "2026-07-21T00:00:00Z".to_string(),
+                data: Some("scanner speed=fast".to_string()),
+            }])
+        }
+
+        async fn restore_config(&self, _restore_id: &str) -> rc_core::Result<()> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn import_config(&self, _document: &ConfigDocument) -> rc_core::Result<()> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn get_module_switches(&self) -> rc_core::Result<ModuleSwitches> {
+            Ok(ModuleSwitches {
+                notify_enabled: false,
+                audit_enabled: false,
+                persisted_notify_enabled: false,
+                persisted_audit_enabled: false,
+                notify_source: "console".to_string(),
+                audit_source: "console".to_string(),
+            })
+        }
+
+        async fn set_module_switches(
+            &self,
+            switches: &ModuleSwitches,
+        ) -> rc_core::Result<ModuleSwitches> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(switches.clone())
+        }
+    }
+
+    fn test_formatter() -> Formatter {
+        Formatter::new(crate::output::OutputConfig {
+            json: false,
+            no_color: true,
+            no_progress: true,
+            quiet: true,
+        })
+    }
+
+    #[tokio::test]
+    async fn set_dry_run_does_not_mutate() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["speed=fast".to_string()],
+                dry_run: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn set_success_mutates_once() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["speed=fast".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_set_returns_usage_without_mutation() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["speed".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::UsageError);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_success_and_invalid_input_have_distinct_exit_codes() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let success = execute_with_api(
+            ConfigCommands::Delete(DeleteArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                keys: vec!["speed".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        let invalid = execute_with_api(
+            ConfigCommands::Delete(DeleteArgs {
+                alias: "local".to_string(),
+                scope: ":bad".to_string(),
+                keys: Vec::new(),
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(success, ExitCode::Success);
+        assert_eq!(invalid, ExitCode::UsageError);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn confirmed_restore_mutates_once() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let code = execute_with_api(
+            ConfigCommands::Restore(RestoreArgs {
+                alias: "local".to_string(),
+                restore_id: "restore-1".to_string(),
+                dry_run: false,
+                yes: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn import_requires_confirmation_before_file_access() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let code = execute_with_api(
+            ConfigCommands::Import(ImportArgs {
+                alias: "local".to_string(),
+                file: PathBuf::from("missing-secret-config"),
+                dry_run: false,
+                yes: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::UsageError);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn confirmed_import_mutates_once() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("config.txt");
+        std::fs::write(&path, "scanner speed=fast").expect("write import file");
+        let code = execute_with_api(
+            ConfigCommands::Import(ImportArgs {
+                alias: "local".to_string(),
+                file: path,
+                dry_run: false,
+                yes: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn module_switch_dry_run_and_apply_have_distinct_mutation_counts() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let dry_run = execute_with_api(
+            ConfigCommands::ModuleSwitch(ModuleSwitchCommands::Set(ModuleSwitchSetArgs {
+                alias: "local".to_string(),
+                notify: Some(true),
+                audit: None,
+                dry_run: true,
+            })),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        let applied = execute_with_api(
+            ConfigCommands::ModuleSwitch(ModuleSwitchCommands::Set(ModuleSwitchSetArgs {
+                alias: "local".to_string(),
+                notify: Some(true),
+                audit: None,
+                dry_run: false,
+            })),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(dry_run, ExitCode::Success);
+        assert_eq!(applied, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn export_refuses_to_overwrite_an_existing_file() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("config.txt");
+        std::fs::write(&path, "existing").expect("create existing file");
+
+        let error = write_private_file(&path, b"replacement")
+            .expect_err("export must not overwrite an existing file");
+        assert_eq!(error.exit_code(), ExitCode::GeneralError.as_i32());
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read existing file"),
+            "existing"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_always_redacts_secret_values() {
+        let api = TestApi {
+            mutations: AtomicUsize::new(0),
+        };
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("config.txt");
+
+        let code = execute_with_api(
+            ConfigCommands::Export(ExportArgs {
+                alias: "local".to_string(),
+                file: path.clone(),
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::Success);
+        let content = std::fs::read_to_string(path).expect("read exported configuration");
+        assert!(content.contains("*redacted*"));
+        assert!(!content.contains("super-secret"));
+    }
+
+    #[test]
+    fn partial_module_switch_update_preserves_persisted_values() {
+        let current = ModuleSwitches {
+            notify_enabled: true,
+            audit_enabled: false,
+            persisted_notify_enabled: false,
+            persisted_audit_enabled: true,
+            notify_source: "environment".to_string(),
+            audit_source: "environment".to_string(),
+        };
+
+        let requested = requested_switches(&current, Some(true), None);
+
+        assert!(requested.notify_enabled);
+        assert!(requested.audit_enabled);
+    }
+
+    #[test]
+    fn restore_warning_links_known_server_safety_limitation() {
+        assert!(RESTORE_SAFETY_WARNING.contains("rustfs/backlog#1398"));
+        assert!(RESTORE_SAFETY_WARNING.contains("unrelated current values are removed"));
+    }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -4,6 +4,7 @@
 //! service accounts, and cluster operations through the RustFS Admin API.
 
 mod access_key;
+mod capabilities;
 mod decommission;
 mod expand;
 mod group;
@@ -27,6 +28,9 @@ use rc_s3::AdminClient;
 /// Admin subcommands for IAM and cluster management
 #[derive(Subcommand, Debug)]
 pub enum AdminCommands {
+    /// Discover effective RustFS runtime capabilities
+    Capabilities(capabilities::CapabilitiesArgs),
+
     /// Display cluster information (servers, disks, usage)
     #[command(subcommand)]
     Info(info::InfoCommands),
@@ -85,6 +89,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
     let formatter = Formatter::new(output_config);
 
     match cmd {
+        AdminCommands::Capabilities(args) => capabilities::execute(args, &formatter).await,
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
         AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,
@@ -171,6 +176,19 @@ mod tests {
                 assert_eq!(args.alias, "local");
                 assert!(args.offline);
                 assert!(args.healing);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_capabilities_refresh() {
+        let cli = TestCli::parse_from(["rc", "capabilities", "local", "--refresh"]);
+
+        match cli.command {
+            AdminCommands::Capabilities(args) => {
+                assert_eq!(args.alias, "local");
+                assert!(args.refresh);
             }
             _ => panic!("Unexpected command parsing result"),
         }

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -5,6 +5,7 @@
 
 mod access_key;
 mod capabilities;
+mod config;
 mod decommission;
 mod expand;
 mod group;
@@ -30,6 +31,10 @@ use rc_s3::AdminClient;
 pub enum AdminCommands {
     /// Discover effective RustFS runtime capabilities
     Capabilities(capabilities::CapabilitiesArgs),
+
+    /// Manage RustFS server configuration
+    #[command(subcommand)]
+    Config(config::ConfigCommands),
 
     /// Display cluster information (servers, disks, usage)
     #[command(subcommand)]
@@ -90,6 +95,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
 
     match cmd {
         AdminCommands::Capabilities(args) => capabilities::execute(args, &formatter).await,
+        AdminCommands::Config(config_cmd) => config::execute(config_cmd, &formatter).await,
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
         AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,
@@ -189,6 +195,42 @@ mod tests {
             AdminCommands::Capabilities(args) => {
                 assert_eq!(args.alias, "local");
                 assert!(args.refresh);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_config_set_dry_run() {
+        let cli = TestCli::parse_from([
+            "rc",
+            "config",
+            "set",
+            "local",
+            "scanner",
+            "speed=fast",
+            "--dry-run",
+        ]);
+
+        match cli.command {
+            AdminCommands::Config(config::ConfigCommands::Set(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.scope, "scanner");
+                assert_eq!(args.assignments, vec!["speed=fast"]);
+                assert!(args.dry_run);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_config_restore_confirmation() {
+        let cli = TestCli::parse_from(["rc", "config", "restore", "local", "restore-123", "--yes"]);
+
+        match cli.command {
+            AdminCommands::Config(config::ConfigCommands::Restore(args)) => {
+                assert_eq!(args.restore_id, "restore-123");
+                assert!(args.yes);
             }
             _ => panic!("Unexpected command parsing result"),
         }

--- a/crates/cli/src/output/formatter.rs
+++ b/crates/cli/src/output/formatter.rs
@@ -471,6 +471,14 @@ impl Formatter {
         }
     }
 
+    /// Output a pre-built JSON error to stderr.
+    pub fn json_error<T: Serialize>(&self, value: &T) {
+        match serde_json::to_string_pretty(value) {
+            Ok(json) => eprintln!("{json}"),
+            Err(e) => eprintln!("Error serializing output: {e}"),
+        }
+    }
+
     /// Print a line of text (respects quiet mode)
     pub fn println(&self, message: &str) {
         if self.config.quiet {

--- a/crates/cli/tests/admin_capabilities.rs
+++ b/crates/cli/tests/admin_capabilities.rs
@@ -1,0 +1,198 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_sequence_test_server};
+use jsonschema::Validator;
+use serde_json::Value;
+
+const INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const RUNTIME_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+
+fn output_v3_validator() -> Validator {
+    let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("schemas/output_v3.json");
+    let schema = std::fs::read_to_string(&schema_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+    let schema: Value = serde_json::from_str(&schema).expect("output v3 schema should parse");
+    jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+}
+
+fn assert_valid_v3(value: &Value) {
+    let validator = output_v3_validator();
+    let errors = validator
+        .iter_errors(value)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "capability output must satisfy output v3:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn capabilities_json_success_satisfies_output_v3() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["data"]["api_version"], "v4");
+    let memory_sampling = value["data"]["capabilities"]
+        .as_array()
+        .expect("capabilities should be an array")
+        .iter()
+        .find(|capability| capability["name"] == "runtime.memory-sampling")
+        .expect("runtime memory sampling capability");
+    assert_eq!(memory_sampling["support"], "unsupported");
+    assert_ne!(memory_sampling["support"], "stub");
+    assert_valid_v3(&value);
+
+    for expected in [
+        "/rustfs/admin/v3/info",
+        "/rustfs/admin/v4/runtime/capabilities",
+        "/rustfs/admin/v4/extensions/catalog",
+        "/rustfs/admin/v4/cluster/snapshot",
+    ] {
+        let request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured admin request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.target, expected);
+    }
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_json_version_gate_satisfies_output_v3() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        (
+            "404 Not Found",
+            r#"{"code":"NotImplemented","message":"route body must not override HTTP 404"}"#,
+        ),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["data"]["api_version"], Value::Null);
+    assert_eq!(value["data"]["capabilities"][0]["support"], "unsupported");
+    assert_valid_v3(&value);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_json_http_501_reports_stub_support() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        (
+            "501 Not Implemented",
+            r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+        ),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["data"]["api_version"], "v4");
+    assert_eq!(value["data"]["capabilities"][0]["support"], "stub");
+    assert_eq!(
+        value["data"]["capabilities"][0]["reason"],
+        "route is not implemented"
+    );
+    assert_valid_v3(&value);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_json_auth_error_satisfies_output_v3() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        (
+            "403 Forbidden",
+            r#"{"code":"NotImplemented","message":"Access denied"}"#,
+        ),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(4));
+    assert!(
+        output.stdout.is_empty(),
+        "errors must not be written to stdout"
+    );
+    let value: Value = serde_json::from_slice(&output.stderr).expect("stderr should be JSON");
+    assert_eq!(value["error"]["type"], "auth_error");
+    assert_valid_v3(&value);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn capabilities_missing_alias_keeps_top_level_error_contract() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "capabilities", "missing"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(5));
+    let value: Value = serde_json::from_slice(&output.stderr).expect("stderr should be JSON");
+    assert!(value.get("schema_version").is_none());
+    assert_eq!(value["details"]["type"], "not_found");
+}

--- a/crates/cli/tests/admin_config.rs
+++ b/crates/cli/tests/admin_config.rs
@@ -1,0 +1,265 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{
+    rc_binary, rc_host_alias, start_admin_sequence_test_server, start_admin_test_server,
+};
+
+const SCANNER_HELP: &str = r#"{"subSys":"scanner","description":"scanner settings","multipleTargets":false,"keysHelp":[{"key":"speed","type":"string","description":"scanner speed","optional":true,"multipleTargets":false}]}"#;
+
+fn run(args: &[&str], endpoint: &str, config_dir: &tempfile::TempDir) -> std::process::Output {
+    Command::new(rc_binary())
+        .args(args)
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(endpoint))
+        .output()
+        .expect("run rc command")
+}
+
+fn assert_valid_v3(value: &serde_json::Value) {
+    let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("schemas/output_v3.json");
+    let schema = std::fs::read_to_string(&schema_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+    let schema: serde_json::Value =
+        serde_json::from_str(&schema).expect("output v3 schema should parse");
+    let validator = jsonschema::validator_for(&schema).expect("output v3 schema should compile");
+    let errors = validator
+        .iter_errors(value)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "config output must satisfy output v3:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn config_get_defensively_redacts_server_output() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_test_server("identity_openid client_id=console client_secret=server-secret");
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "get",
+            "myalias",
+            "identity_openid",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    assert!(stdout.contains("*redacted*"));
+    assert!(!stdout.contains("server-secret"));
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "admin_operations");
+    assert_eq!(value["data"]["operations"][0]["changed"], false);
+    assert_valid_v3(&value);
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured request");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/get-config-kv?key=identity_openid"
+    );
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_history_redacts_secret_bearing_data() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(
+        r#"[{"RestoreID":"restore-1","CreateTime":"2026-07-21T00:00:00Z","Data":"identity_openid client_secret=history-secret"}]"#,
+    );
+
+    let output = run(
+        &[
+            "--json", "admin", "config", "history", "myalias", "--count", "5",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    assert!(stdout.contains("*redacted*"));
+    assert!(!stdout.contains("history-secret"));
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured request");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/list-config-history-kv?count=5"
+    );
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_set_dry_run_never_sends_mutation() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", SCANNER_HELP),
+        ("200 OK", "scanner speed=default"),
+    ]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "set",
+            "myalias",
+            "scanner",
+            "speed=fast",
+            "--dry-run",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let first = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("help request");
+    let second = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("config request");
+    assert_eq!(first.method, "GET");
+    assert!(first.target.starts_with("/rustfs/admin/v3/help-config-kv?"));
+    assert_eq!(second.method, "GET");
+    assert_eq!(second.target, "/rustfs/admin/v3/get-config-kv?key=scanner");
+    assert!(receiver.recv_timeout(Duration::from_millis(100)).is_err());
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_set_success_has_read_preflight_before_mutation() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", SCANNER_HELP),
+        ("200 OK", "scanner speed=default"),
+        ("200 OK", ""),
+    ]);
+
+    let output = run(
+        &["admin", "config", "set", "myalias", "scanner", "speed=fast"],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let requests = (0..3)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured request")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[1].method, "GET");
+    assert_eq!(requests[2].method, "PUT");
+    assert_eq!(requests[2].target, "/rustfs/admin/v3/set-config-kv");
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_access_denial_never_echoes_submitted_secret() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![(
+        "403 Forbidden",
+        r#"{"message":"server echoed submitted-secret in a forbidden response"}"#,
+    )]);
+
+    let output = run(
+        &[
+            "admin",
+            "config",
+            "set",
+            "myalias",
+            "identity_openid",
+            "client_secret=submitted-secret",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    assert!(!stderr.contains("submitted-secret"));
+    assert!(stderr.contains("denied configuration access"));
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn unsupported_module_switch_has_deterministic_exit_code() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) =
+        start_admin_sequence_test_server(vec![("404 Not Found", r#"{"message":"missing route"}"#)]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "module-switch",
+            "get",
+            "myalias",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert_eq!(output.status.code(), Some(7));
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    assert!(stderr.contains("does not advertise module switch operations"));
+    let value: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert_valid_v3(&value);
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn restore_requires_confirmation_without_contacting_server() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args(["admin", "config", "restore", "myalias", "restore-1"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_myalias",
+            "http://ACCESS_KEY:SECRET_KEY@127.0.0.1:1",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("pass --yes"));
+}

--- a/crates/cli/tests/admin_support/mod.rs
+++ b/crates/cli/tests/admin_support/mod.rs
@@ -58,6 +58,9 @@ fn read_admin_request(stream: &mut TcpStream) -> CapturedAdminRequest {
     CapturedAdminRequest { method, target }
 }
 
+// Each integration-test binary compiles this shared module independently, so a
+// helper used by one binary can legitimately be unused by another.
+#[allow(dead_code)]
 pub fn start_admin_test_server(
     response_body: &'static str,
 ) -> (String, Receiver<CapturedAdminRequest>, JoinHandle<()>) {
@@ -93,6 +96,49 @@ pub fn start_admin_test_server(
         stream
             .write_all(response.as_bytes())
             .expect("write admin response");
+    });
+
+    (endpoint, receiver, handle)
+}
+
+#[allow(dead_code)]
+pub fn start_admin_sequence_test_server(
+    responses: Vec<(&'static str, &'static str)>,
+) -> (String, Receiver<CapturedAdminRequest>, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind admin test server");
+    listener
+        .set_nonblocking(true)
+        .expect("set admin test server nonblocking");
+    let endpoint = format!("http://{}", listener.local_addr().expect("server address"));
+    let (sender, receiver) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        for (response_status, response_body) in responses {
+            let deadline = Instant::now() + Duration::from_secs(120);
+            let (mut stream, _) = loop {
+                match listener.accept() {
+                    Ok(accepted) => break accepted,
+                    Err(e) if e.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(e) => panic!("accept admin request: {e}"),
+                }
+            };
+            stream
+                .set_nonblocking(false)
+                .expect("set admin request stream blocking");
+            let request = read_admin_request(&mut stream);
+            sender.send(request).expect("send captured request");
+
+            let response = format!(
+                "HTTP/1.1 {response_status}\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                response_body.len(),
+                response_body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write admin response");
+        }
     });
 
     (endpoint, receiver, handle)

--- a/crates/cli/tests/fixtures/output_v3/capabilities/auth_error.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/auth_error.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "error",
+  "error": {
+    "type": "auth_error",
+    "message": "Failed to discover capabilities: Authentication failed: Access denied",
+    "retryable": false,
+    "suggestion": "Verify the alias credentials and ServerInfoAdminAction permission."
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/capabilities/runtime_success.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/runtime_success.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "success",
+  "data": {
+    "server": "rustfs",
+    "api_version": "v4",
+    "capabilities": [
+      {
+        "name": "runtime.observability",
+        "scope": "runtime",
+        "support": "supported",
+        "reason": null
+      }
+    ]
+  },
+  "meta": {
+    "server_version": "1.0.0-beta.10"
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/capabilities/runtime_unsupported.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/runtime_unsupported.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "success",
+  "data": {
+    "server": "rustfs",
+    "api_version": "v4",
+    "capabilities": [
+      {
+        "name": "runtime.memory-sampling",
+        "scope": "runtime",
+        "support": "unsupported",
+        "reason": "not available on this platform"
+      }
+    ]
+  },
+  "meta": {
+    "server_version": "1.0.0-beta.10"
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/capabilities/version_gated.json
+++ b/crates/cli/tests/fixtures/output_v3/capabilities/version_gated.json
@@ -1,0 +1,20 @@
+{
+  "schema_version": 3,
+  "type": "capabilities",
+  "status": "success",
+  "data": {
+    "server": "rustfs",
+    "api_version": null,
+    "capabilities": [
+      {
+        "name": "admin.runtime-capabilities",
+        "scope": "admin",
+        "support": "unsupported",
+        "reason": "Admin API v4 is unavailable"
+      }
+    ]
+  },
+  "meta": {
+    "server_version": "1.0.0-beta.10"
+  }
+}

--- a/crates/core/src/admin/capabilities.rs
+++ b/crates/core/src/admin/capabilities.rs
@@ -1,0 +1,202 @@
+//! Runtime capability discovery contracts for the RustFS Admin API.
+
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Effective availability of an Admin API capability.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityAvailability {
+    Available,
+    Stubbed,
+    Unsupported,
+    Disabled,
+    VersionGated,
+    PermissionDenied,
+    Unknown,
+}
+
+impl fmt::Display for CapabilityAvailability {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let value = match self {
+            Self::Available => "available",
+            Self::Stubbed => "stubbed",
+            Self::Unsupported => "unsupported",
+            Self::Disabled => "disabled",
+            Self::VersionGated => "version-gated",
+            Self::PermissionDenied => "permission-denied",
+            Self::Unknown => "unknown",
+        };
+        formatter.write_str(value)
+    }
+}
+
+/// RustFS capability state returned by runtime snapshot endpoints.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCapabilityState {
+    Supported,
+    Unsupported,
+    Disabled,
+    Unknown,
+}
+
+/// A typed status from a RustFS runtime snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilityStatus {
+    pub state: RuntimeCapabilityState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl RuntimeCapabilityStatus {
+    /// Convert the server contract into an effective client availability.
+    pub const fn availability(&self) -> CapabilityAvailability {
+        match self.state {
+            RuntimeCapabilityState::Supported => CapabilityAvailability::Available,
+            RuntimeCapabilityState::Unsupported => CapabilityAvailability::Unsupported,
+            RuntimeCapabilityState::Disabled => CapabilityAvailability::Disabled,
+            RuntimeCapabilityState::Unknown => CapabilityAvailability::Unknown,
+        }
+    }
+}
+
+/// Summary fields provided by `/v4/runtime/capabilities`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeCapabilitiesSummary {
+    pub observability: RuntimeCapabilityStatus,
+    pub userspace_profiling: RuntimeCapabilityStatus,
+    pub memory_sampling: RuntimeCapabilityStatus,
+    pub platform: RuntimeCapabilityStatus,
+    pub topology: RuntimeCapabilityStatus,
+    pub cluster_snapshot: RuntimeCapabilityStatus,
+}
+
+/// Typed subset of the RustFS runtime capability response.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RuntimeCapabilitiesSnapshot {
+    pub summary: RuntimeCapabilitiesSummary,
+    pub cluster_snapshot_path: String,
+    pub cluster_snapshot_summary: Option<RuntimeCapabilityStatus>,
+    pub topology_status: RuntimeCapabilityStatus,
+    #[serde(default)]
+    pub observability: serde_json::Value,
+    #[serde(default)]
+    pub workload_admission: serde_json::Value,
+    #[serde(default)]
+    pub topology: Option<serde_json::Value>,
+}
+
+/// Extension metadata advertised by RustFS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtensionMetadata {
+    pub schema_version: String,
+    pub extension_id: String,
+    pub display_name: String,
+    pub provider: String,
+    pub version: String,
+    pub kind: String,
+    pub disabled_by_default: bool,
+}
+
+/// Typed subset of `/v4/extensions/catalog`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExtensionsCatalog {
+    pub extensions: Vec<ExtensionMetadata>,
+    #[serde(default)]
+    pub runtime_capabilities: serde_json::Value,
+    #[serde(default)]
+    pub cluster_snapshot: serde_json::Value,
+    #[serde(default)]
+    pub external_plugin_flow: serde_json::Value,
+}
+
+/// Typed summary returned inside a cluster snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ClusterSnapshotSummary {
+    pub runtime: RuntimeCapabilityStatus,
+    pub topology: RuntimeCapabilityStatus,
+    pub membership: RuntimeCapabilityStatus,
+    pub peer_health: RuntimeCapabilityStatus,
+    pub rpc_boundary: RuntimeCapabilityStatus,
+    pub observability: RuntimeCapabilityStatus,
+    pub workload_admission: RuntimeCapabilityStatus,
+    pub actionable_pressure: RuntimeCapabilityStatus,
+}
+
+/// Metadata from `/v4/cluster/snapshot` without exposing server internals.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ClusterSnapshotMetadata {
+    pub summary: Option<ClusterSnapshotSummary>,
+    pub runtime_capabilities_path: Option<String>,
+    pub extensions_catalog_path: Option<String>,
+}
+
+/// One normalized capability row shown by the CLI.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityEntry {
+    pub name: String,
+    pub availability: CapabilityAvailability,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Aggregate capability discovery result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CapabilityReport {
+    pub server_version: Option<String>,
+    pub runtime_path: String,
+    pub extensions_path: String,
+    pub cluster_snapshot_path: String,
+    pub capabilities: Vec<CapabilityEntry>,
+    pub extensions: Vec<ExtensionMetadata>,
+    pub cluster: ClusterSnapshotMetadata,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_states_map_without_overstating_support() {
+        let status = |state| RuntimeCapabilityStatus {
+            state,
+            reason: None,
+        };
+
+        assert_eq!(
+            status(RuntimeCapabilityState::Supported).availability(),
+            CapabilityAvailability::Available
+        );
+        assert_eq!(
+            status(RuntimeCapabilityState::Unsupported).availability(),
+            CapabilityAvailability::Unsupported
+        );
+        assert_eq!(
+            status(RuntimeCapabilityState::Disabled).availability(),
+            CapabilityAvailability::Disabled
+        );
+        assert_eq!(
+            status(RuntimeCapabilityState::Unknown).availability(),
+            CapabilityAvailability::Unknown
+        );
+    }
+
+    #[test]
+    fn availability_has_stable_machine_readable_values() {
+        assert_eq!(
+            serde_json::to_string(&CapabilityAvailability::VersionGated)
+                .expect("availability should serialize"),
+            "\"version-gated\""
+        );
+        assert_eq!(
+            CapabilityAvailability::PermissionDenied.to_string(),
+            "permission-denied"
+        );
+        assert_eq!(
+            serde_json::to_string(&CapabilityAvailability::Unsupported)
+                .expect("availability should serialize"),
+            "\"unsupported\""
+        );
+    }
+}

--- a/crates/core/src/admin/configuration.rs
+++ b/crates/core/src/admin/configuration.rs
@@ -1,0 +1,477 @@
+//! Safe contracts and planning helpers for RustFS server configuration.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::{Error, Result};
+
+/// A server configuration document. Its contents are intentionally omitted from debug output.
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct ConfigDocument {
+    pub content: String,
+}
+
+impl std::fmt::Debug for ConfigDocument {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConfigDocument")
+            .field("content", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct ConfigHistoryEntry {
+    #[serde(rename = "RestoreID")]
+    pub restore_id: String,
+    #[serde(rename = "CreateTime")]
+    pub create_time: String,
+    #[serde(rename = "Data", default)]
+    pub data: Option<String>,
+}
+
+impl std::fmt::Debug for ConfigHistoryEntry {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConfigHistoryEntry")
+            .field("restore_id", &self.restore_id)
+            .field("create_time", &self.create_time)
+            .field("data", &self.data.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigHelp {
+    #[serde(rename = "subSys")]
+    pub subsystem: String,
+    pub description: String,
+    #[serde(rename = "multipleTargets")]
+    pub multiple_targets: bool,
+    #[serde(rename = "keysHelp")]
+    pub keys: Vec<ConfigHelpEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigHelpEntry {
+    pub key: String,
+    #[serde(rename = "type")]
+    pub value_type: String,
+    pub description: String,
+    pub optional: bool,
+    #[serde(rename = "multipleTargets")]
+    pub multiple_targets: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigMutationResult {
+    pub applied_dynamically: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModuleSwitches {
+    pub notify_enabled: bool,
+    pub audit_enabled: bool,
+    pub persisted_notify_enabled: bool,
+    pub persisted_audit_enabled: bool,
+    pub notify_source: String,
+    pub audit_source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfigChange {
+    pub scope: String,
+    pub key: String,
+    pub before: Option<String>,
+    pub after: Option<String>,
+    pub sensitive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfigDiff {
+    pub changes: Vec<ConfigChange>,
+    pub replaces_full_config: bool,
+}
+
+/// RustFS Admin API configuration operations.
+#[async_trait]
+pub trait ConfigApi: Send + Sync {
+    async fn get_config(&self, selector: &str) -> Result<ConfigDocument>;
+    async fn get_full_config(&self) -> Result<ConfigDocument>;
+    async fn set_config(&self, directive: &str) -> Result<ConfigMutationResult>;
+    async fn delete_config(&self, directive: &str) -> Result<ConfigMutationResult>;
+    async fn config_help(
+        &self,
+        subsystem: Option<&str>,
+        key: Option<&str>,
+        env_only: bool,
+    ) -> Result<ConfigHelp>;
+    async fn config_history(&self, count: usize) -> Result<Vec<ConfigHistoryEntry>>;
+    async fn restore_config(&self, restore_id: &str) -> Result<()>;
+    async fn import_config(&self, document: &ConfigDocument) -> Result<()>;
+    async fn get_module_switches(&self) -> Result<ModuleSwitches>;
+    async fn set_module_switches(&self, switches: &ModuleSwitches) -> Result<ModuleSwitches>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedDirective {
+    scope: String,
+    entries: Vec<(String, Option<String>)>,
+}
+
+fn tokenize(line: &str) -> Result<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for character in line.chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            } else {
+                current.push(character);
+            }
+        } else {
+            match character {
+                '\'' | '"' => quote = Some(character),
+                value if value.is_whitespace() => {
+                    if !current.is_empty() {
+                        tokens.push(std::mem::take(&mut current));
+                    }
+                }
+                _ => current.push(character),
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return Err(Error::Config(
+            "Configuration contains an unterminated quoted value".to_string(),
+        ));
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    Ok(tokens)
+}
+
+fn valid_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "_-.:".contains(character))
+}
+
+fn parse_directives(input: &str, allow_bare_keys: bool) -> Result<Vec<ParsedDirective>> {
+    let mut directives = Vec::new();
+    for line in input.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let tokens = tokenize(line)?;
+        let Some(scope) = tokens.first() else {
+            continue;
+        };
+        if !valid_name(scope) || scope.starts_with(':') || scope.ends_with(':') {
+            return Err(Error::Config("Invalid configuration scope".to_string()));
+        }
+
+        let mut entries = Vec::new();
+        for token in tokens.iter().skip(1) {
+            let (key, value) = match token.split_once('=') {
+                Some((key, value)) => (key, Some(value.to_string())),
+                None if allow_bare_keys => (token.as_str(), None),
+                None => {
+                    return Err(Error::Config(
+                        "Configuration assignments must use key=value syntax".to_string(),
+                    ));
+                }
+            };
+            if !valid_name(key) || key.contains(':') {
+                return Err(Error::Config("Invalid configuration key".to_string()));
+            }
+            entries.push((key.to_string(), value));
+        }
+        directives.push(ParsedDirective {
+            scope: scope.to_string(),
+            entries,
+        });
+    }
+    if directives.is_empty() {
+        return Err(Error::Config(
+            "Configuration document must include at least one directive".to_string(),
+        ));
+    }
+    Ok(directives)
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.trim().to_ascii_lowercase();
+    key.contains("secret")
+        || key.contains("password")
+        || key == "token"
+        || key.ends_with("_token")
+        || key == "client_key"
+        || key.ends_with("_client_key")
+        || key == "private_key"
+        || key.ends_with("_private_key")
+        || key == "credential"
+        || key.ends_with("_credential")
+}
+
+fn redacted_value(key: &str, value: &str) -> String {
+    if is_sensitive_key(key) && !value.is_empty() {
+        "*redacted*".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn document_map(input: &str, allow_bare_keys: bool) -> Result<BTreeMap<(String, String), String>> {
+    let mut values = BTreeMap::new();
+    for directive in parse_directives(input, allow_bare_keys)? {
+        for (key, value) in directive.entries {
+            if let Some(value) = value {
+                values.insert((directive.scope.clone(), key), value);
+            }
+        }
+    }
+    Ok(values)
+}
+
+/// Validate the syntax accepted by the RustFS config mutation endpoints.
+pub fn validate_config_directive(input: &str, allow_bare_keys: bool) -> Result<()> {
+    parse_directives(input, allow_bare_keys).map(|_| ())
+}
+
+/// Return subsystem/key pairs without exposing configuration values.
+pub fn config_document_fields(input: &str) -> Result<Vec<(String, String)>> {
+    let mut fields = Vec::new();
+    for directive in parse_directives(input, false)? {
+        let subsystem = directive
+            .scope
+            .split_once(':')
+            .map_or(directive.scope.as_str(), |(value, _)| value)
+            .to_string();
+        for (key, _) in directive.entries {
+            fields.push((subsystem.clone(), key));
+        }
+    }
+    Ok(fields)
+}
+
+/// Reject redacted placeholders before a full replacement can overwrite live secrets.
+pub fn validate_config_import(input: &str) -> Result<()> {
+    for directive in parse_directives(input, false)? {
+        for (key, value) in directive.entries {
+            if is_sensitive_key(&key) && value.as_deref() == Some("*redacted*") {
+                return Err(Error::Config(
+                    "Redacted secret placeholders cannot be imported".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Redact secret-bearing fields in a RustFS line-oriented configuration document.
+pub fn redact_config_document(input: &str) -> String {
+    let Ok(directives) = parse_directives(input, true) else {
+        return "<redacted invalid configuration>".to_string();
+    };
+    directives
+        .into_iter()
+        .map(|directive| {
+            let entries = directive
+                .entries
+                .into_iter()
+                .map(|(key, value)| match value {
+                    Some(value) => format!(
+                        "{key}=\"{}\"",
+                        escape_config_value(&redacted_value(&key, &value))
+                    ),
+                    None => key,
+                })
+                .collect::<Vec<_>>();
+            if entries.is_empty() {
+                directive.scope
+            } else {
+                format!("{} {}", directive.scope, entries.join(" "))
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn escape_config_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn change(
+    scope: String,
+    key: String,
+    before: Option<String>,
+    after: Option<String>,
+) -> ConfigChange {
+    let sensitive = is_sensitive_key(&key);
+    let before = before.map(|value| redacted_value(&key, &value));
+    let after = after.map(|value| redacted_value(&key, &value));
+    ConfigChange {
+        scope,
+        key,
+        before,
+        after,
+        sensitive,
+    }
+}
+
+/// Build a client-side preflight diff for a set or delete mutation.
+pub fn config_mutation_diff(current: &str, directive: &str, delete: bool) -> Result<ConfigDiff> {
+    let current_values = document_map(current, false)?;
+    let directives = parse_directives(directive, delete)?;
+    let mut changes = Vec::new();
+
+    for directive in directives {
+        if delete && directive.entries.is_empty() {
+            for ((scope, key), before) in current_values
+                .iter()
+                .filter(|((scope, _), _)| scope == &directive.scope)
+            {
+                changes.push(change(
+                    scope.clone(),
+                    key.clone(),
+                    Some(before.clone()),
+                    None,
+                ));
+            }
+            continue;
+        }
+
+        for (key, after) in directive.entries {
+            let before = current_values
+                .get(&(directive.scope.clone(), key.clone()))
+                .cloned();
+            if delete {
+                if before.is_some() {
+                    changes.push(change(directive.scope.clone(), key, before, None));
+                }
+            } else if before != after {
+                changes.push(change(directive.scope.clone(), key, before, after));
+            }
+        }
+    }
+
+    Ok(ConfigDiff {
+        changes,
+        replaces_full_config: false,
+    })
+}
+
+/// Build a client-side preflight diff for a full configuration replacement.
+pub fn config_import_diff(current: &str, replacement: &str) -> Result<ConfigDiff> {
+    let current_values = document_map(current, false)?;
+    let replacement_values = document_map(replacement, false)?;
+    let keys = current_values
+        .keys()
+        .chain(replacement_values.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut changes = Vec::new();
+    for (scope, key) in keys {
+        let before = current_values.get(&(scope.clone(), key.clone())).cloned();
+        let after = replacement_values
+            .get(&(scope.clone(), key.clone()))
+            .cloned();
+        if before != after {
+            changes.push(change(scope, key, before, after));
+        }
+    }
+    Ok(ConfigDiff {
+        changes,
+        replaces_full_config: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_assignments_without_echoing_secret_values() {
+        assert!(validate_config_directive("scanner speed=fast", false).is_ok());
+        let error = validate_config_directive("identity_openid client_secret", false)
+            .expect_err("missing assignment must fail");
+        assert!(!error.to_string().contains("super-secret"));
+    }
+
+    #[test]
+    fn redacts_secret_fields_and_preserves_non_secret_values() {
+        let redacted = redact_config_document(
+            "identity_openid client_id=console client_secret=super-secret\nscanner speed=fast",
+        );
+        assert!(redacted.contains("client_id=\"console\""));
+        assert!(redacted.contains("client_secret=\"*redacted*\""));
+        assert!(redacted.contains("speed=\"fast\""));
+        assert!(!redacted.contains("super-secret"));
+    }
+
+    #[test]
+    fn set_diff_redacts_both_secret_sides() {
+        let diff = config_mutation_diff(
+            "identity_openid client_secret=old client_id=console",
+            "identity_openid client_secret=new",
+            false,
+        )
+        .expect("build set diff");
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].before.as_deref(), Some("*redacted*"));
+        assert_eq!(diff.changes[0].after.as_deref(), Some("*redacted*"));
+    }
+
+    #[test]
+    fn delete_diff_reports_only_present_keys() {
+        let diff =
+            config_mutation_diff("scanner speed=fast cycle=10", "scanner speed missing", true)
+                .expect("build delete diff");
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].key, "speed");
+        assert_eq!(diff.changes[0].after, None);
+    }
+
+    #[test]
+    fn import_diff_reports_additions_changes_and_removals() {
+        let diff = config_import_diff("scanner speed=fast cycle=10", "scanner speed=slow delay=1")
+            .expect("build import diff");
+        assert!(diff.replaces_full_config);
+        assert_eq!(diff.changes.len(), 3);
+    }
+
+    #[test]
+    fn redaction_preserves_quoted_value_semantics() {
+        let redacted = redact_config_document(
+            r#"identity_openid client_id="console app" client_secret="s3cr\"et""#,
+        );
+        assert!(redacted.contains(r#"client_id="console app""#));
+        assert!(redacted.contains(r#"client_secret="*redacted*""#));
+        assert!(validate_config_directive(&redacted, false).is_ok());
+    }
+
+    #[test]
+    fn import_rejects_redacted_secret_placeholders() {
+        let error = validate_config_import(
+            r#"identity_openid client_id="console" client_secret="*redacted*""#,
+        )
+        .expect_err("redacted secrets must not be imported");
+        assert_eq!(error.exit_code(), 2);
+    }
+}

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -3,11 +3,17 @@
 //! This module provides the AdminApi trait and types for managing
 //! IAM users, policies, groups, service accounts, and cluster operations.
 
+mod capabilities;
 mod cluster;
 mod site;
 pub mod tier;
 mod types;
 
+pub use capabilities::{
+    CapabilityAvailability, CapabilityEntry, CapabilityReport, ClusterSnapshotMetadata,
+    ClusterSnapshotSummary, ExtensionMetadata, ExtensionsCatalog, RuntimeCapabilitiesSnapshot,
+    RuntimeCapabilitiesSummary, RuntimeCapabilityState, RuntimeCapabilityStatus,
+};
 pub use cluster::{
     BackendInfo, BackendType, BucketsInfo, ClusterInfo, DecommissionPoolStatus, DecommissionStatus,
     DiskInfo, HealDriveInfo, HealDriveInfos, HealResultItem, HealRuntimeState, HealScanMode,
@@ -254,6 +260,13 @@ pub trait AdminApi: Send + Sync {
 
     /// Remove sites from the site replication cluster
     async fn site_replication_remove(&self, spec: &SiteRemoveSpec) -> Result<serde_json::Value>;
+}
+
+/// Read-only RustFS runtime capability discovery.
+#[async_trait]
+pub trait CapabilityApi: Send + Sync {
+    /// Discover capabilities, bypassing the process cache when `refresh` is true.
+    async fn discover_capabilities(&self, refresh: bool) -> Result<CapabilityReport>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -5,6 +5,7 @@
 
 mod capabilities;
 mod cluster;
+mod configuration;
 mod site;
 pub mod tier;
 mod types;
@@ -21,6 +22,12 @@ pub use cluster::{
     PoolDecommissionInfo, PoolErasureSetInfo, PoolStatus, PoolTarget, RebalanceCleanupWarnings,
     RebalancePoolProgress, RebalancePoolStatus, RebalanceStartResult, RebalanceStatus, ServerInfo,
     UsageInfo,
+};
+pub use configuration::{
+    ConfigApi, ConfigChange, ConfigDiff, ConfigDocument, ConfigHelp, ConfigHelpEntry,
+    ConfigHistoryEntry, ConfigMutationResult, ModuleSwitches, config_document_fields,
+    config_import_diff, config_mutation_diff, redact_config_document, validate_config_directive,
+    validate_config_import,
 };
 pub use site::{PeerSiteSpec, ServiceActionResult, SiteRemoveSpec, SiteStatusOptions};
 pub use tier::{

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -10,12 +10,14 @@ use aws_sigv4::http_request::{
 };
 use aws_sigv4::sign::v4;
 use rc_core::admin::{
-    AccessKeyInfo, AdminApi, BucketQuota, ClusterInfo, CreateServiceAccountRequest,
-    DecommissionPoolStatus, DecommissionStatus, Group, GroupStatus, HealRuntimeState, HealScanMode,
-    HealStartRequest, HealStatus, HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo,
-    PoolStatus, PoolTarget, RebalanceStartResult, RebalanceStatus, ServiceAccount,
-    ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec, SiteStatusOptions,
-    UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
+    AccessKeyInfo, AdminApi, BucketQuota, CapabilityApi, CapabilityAvailability, CapabilityEntry,
+    CapabilityReport, ClusterInfo, ClusterSnapshotMetadata, ClusterSnapshotSummary,
+    CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus, ExtensionsCatalog,
+    Group, GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus,
+    HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
+    RebalanceStartResult, RebalanceStatus, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus,
+    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
+    SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -23,7 +25,53 @@ use reqwest::{Client, Method, StatusCode};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, SystemTime};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CapabilityCacheKey {
+    endpoint: String,
+    region: String,
+    credential_fingerprint: String,
+    transport_security_fingerprint: String,
+}
+
+static CAPABILITY_CACHE: OnceLock<Mutex<HashMap<CapabilityCacheKey, CapabilityReport>>> =
+    OnceLock::new();
+
+fn capability_cache() -> &'static Mutex<HashMap<CapabilityCacheKey, CapabilityReport>> {
+    CAPABILITY_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn transport_security_fingerprint(
+    insecure: bool,
+    ca_bundle: Option<&[u8]>,
+    client_cert: Option<&[u8]>,
+    client_key: Option<&[u8]>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"rc-admin-capability-cache-transport-v1\0");
+    hasher.update(b"native-roots-enabled\0webpki-roots-enabled\0");
+    hasher.update([u8::from(insecure)]);
+
+    for (label, input) in [
+        (b"ca-bundle".as_slice(), ca_bundle),
+        (b"client-certificate".as_slice(), client_cert),
+        (b"client-private-key".as_slice(), client_key),
+    ] {
+        hasher.update(label);
+        hasher.update([0]);
+        match input {
+            Some(bytes) => {
+                hasher.update([1]);
+                hasher.update(Sha256::digest(bytes));
+            }
+            None => hasher.update([0]),
+        }
+    }
+
+    hex::encode(hasher.finalize())
+}
 
 /// Admin API client for RustFS servers
 pub struct AdminClient {
@@ -33,6 +81,7 @@ pub struct AdminClient {
     secret_key: String,
     region: String,
     anonymous: bool,
+    transport_security_fingerprint: String,
 }
 
 impl AdminClient {
@@ -55,7 +104,7 @@ impl AdminClient {
                 .read_timeout(Duration::from_millis(timeout.read_ms));
         }
 
-        if let Some(bundle_path) = alias.ca_bundle.as_deref() {
+        let ca_bundle_pem = if let Some(bundle_path) = alias.ca_bundle.as_deref() {
             let pem = std::fs::read(bundle_path).map_err(|e| {
                 Error::Network(format!("Failed to read CA bundle '{bundle_path}': {e}"))
             })?;
@@ -69,12 +118,15 @@ impl AdminClient {
             for cert in certs {
                 builder = builder.add_root_certificate(cert);
             }
-        }
+            Some(pem)
+        } else {
+            None
+        };
 
-        if let (Some(cert_path), Some(key_path)) =
+        let client_identity_pem = if let (Some(cert_path), Some(key_path)) =
             (alias.client_cert.as_deref(), alias.client_key.as_deref())
         {
-            let mut identity_pem = std::fs::read(cert_path).map_err(|e| {
+            let cert_pem = std::fs::read(cert_path).map_err(|e| {
                 Error::Network(format!(
                     "Failed to read client certificate '{cert_path}': {e}"
                 ))
@@ -82,13 +134,28 @@ impl AdminClient {
             let key_pem = std::fs::read(key_path).map_err(|e| {
                 Error::Network(format!("Failed to read client key '{key_path}': {e}"))
             })?;
+            let mut identity_pem = cert_pem.clone();
             identity_pem.extend_from_slice(b"\n");
             identity_pem.extend_from_slice(&key_pem);
             let identity = reqwest::Identity::from_pem(&identity_pem).map_err(|e| {
                 Error::Network(format!("Invalid client certificate/key identity: {e}"))
             })?;
             builder = builder.use_rustls_tls().identity(identity);
-        }
+            Some((cert_pem, key_pem))
+        } else {
+            None
+        };
+
+        let transport_security_fingerprint = transport_security_fingerprint(
+            alias.insecure,
+            ca_bundle_pem.as_deref(),
+            client_identity_pem
+                .as_ref()
+                .map(|(certificate, _)| certificate.as_slice()),
+            client_identity_pem
+                .as_ref()
+                .map(|(_, private_key)| private_key.as_slice()),
+        );
 
         let http_client = builder
             .build()
@@ -101,12 +168,17 @@ impl AdminClient {
             secret_key: alias.secret_key.clone(),
             region: alias.region.clone(),
             anonymous: alias.anonymous,
+            transport_security_fingerprint,
         })
     }
 
     /// Build the base URL for admin API
     fn admin_url(&self, path: &str) -> String {
         format!("{}/rustfs/admin/v3{}", self.endpoint, path)
+    }
+
+    fn admin_v4_url(&self, path: &str) -> String {
+        format!("{}/rustfs/admin/v4{}", self.endpoint, path)
     }
 
     /// Calculate SHA256 hash of the body
@@ -209,8 +281,26 @@ impl AdminClient {
         query: Option<&[(&str, &str)]>,
         body: Option<&[u8]>,
     ) -> Result<T> {
-        let mut url = self.admin_url(path);
+        self.request_url(method, self.admin_url(path), query, body)
+            .await
+    }
 
+    async fn request_v4<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: Method,
+        path: &str,
+    ) -> Result<T> {
+        self.request_url(method, self.admin_v4_url(path), None, None)
+            .await
+    }
+
+    async fn request_url<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: Method,
+        mut url: String,
+        query: Option<&[(&str, &str)]>,
+        body: Option<&[u8]>,
+    ) -> Result<T> {
         if let Some(q) = query {
             let query_string: String = q
                 .iter()
@@ -335,14 +425,67 @@ impl AdminClient {
 
     /// Map HTTP status codes to appropriate errors
     fn map_error(&self, status: StatusCode, body: &str) -> Error {
+        if matches!(status, StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED) {
+            return Error::Auth(body.to_string());
+        }
+
+        // Route absence is authoritative even when a proxy or compatibility layer returns a
+        // stale structured error body. Capability discovery relies on 404 to identify servers
+        // that predate the Admin API v4 route.
+        if status == StatusCode::NOT_FOUND {
+            return Error::NotFound(body.to_string());
+        }
+
+        let structured_error = parse_admin_error(body);
+        if status == StatusCode::NOT_IMPLEMENTED
+            || structured_error
+                .as_ref()
+                .is_some_and(|error| error.code.as_deref() == Some("NotImplemented"))
+        {
+            return Error::UnsupportedFeature(
+                structured_error
+                    .and_then(|error| error.message)
+                    .unwrap_or_else(|| body.to_string()),
+            );
+        }
+
+        if structured_error
+            .as_ref()
+            .is_some_and(AdminErrorResponse::is_missing_credentials)
+        {
+            return Error::Auth(body.to_string());
+        }
+
         match status {
-            StatusCode::NOT_FOUND => Error::NotFound(body.to_string()),
-            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => Error::Auth(body.to_string()),
             StatusCode::CONFLICT => Error::Conflict(body.to_string()),
             StatusCode::BAD_REQUEST => Error::General(format!("Bad request: {body}")),
             _ => Error::Network(format!("HTTP {}: {}", status.as_u16(), body)),
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct AdminErrorResponse {
+    #[serde(default, alias = "Code")]
+    code: Option<String>,
+    #[serde(default, alias = "Message")]
+    message: Option<String>,
+}
+
+impl AdminErrorResponse {
+    fn is_missing_credentials(&self) -> bool {
+        self.code.as_deref() == Some("InvalidRequest")
+            && matches!(
+                self.message.as_deref().map(str::trim),
+                Some("get cred failed" | "authentication required" | "missing credentials")
+            )
+    }
+}
+
+fn parse_admin_error(body: &str) -> Option<AdminErrorResponse> {
+    serde_json::from_str(body)
+        .ok()
+        .or_else(|| quick_xml::de::from_str(body).ok())
 }
 
 /// Response wrapper for user list
@@ -707,6 +850,296 @@ struct ServerInfoResponse {
 #[derive(Debug, Deserialize)]
 struct PoolStatusResponse {
     pool: PoolStatus,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClusterSnapshotResponse {
+    snapshot: Option<ClusterSnapshotPayload>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClusterSnapshotPayload {
+    summary: ClusterSnapshotSummary,
+    runtime_capabilities_path: String,
+    extensions_catalog_path: String,
+}
+
+impl AdminClient {
+    fn capability_cache_key(&self) -> CapabilityCacheKey {
+        let mut hasher = Sha256::new();
+        if self.anonymous {
+            hasher.update(b"anonymous");
+        } else {
+            hasher.update(b"authenticated\0");
+            hasher.update(self.access_key.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(self.secret_key.as_bytes());
+        }
+
+        CapabilityCacheKey {
+            endpoint: self.endpoint.clone(),
+            region: self.region.clone(),
+            credential_fingerprint: hex::encode(hasher.finalize()),
+            transport_security_fingerprint: self.transport_security_fingerprint.clone(),
+        }
+    }
+
+    fn cached_capabilities(&self) -> Result<Option<CapabilityReport>> {
+        capability_cache()
+            .lock()
+            .map(|cache| cache.get(&self.capability_cache_key()).cloned())
+            .map_err(|_| Error::General("Capability cache lock is poisoned".to_string()))
+    }
+
+    fn store_capabilities(&self, report: &CapabilityReport) -> Result<()> {
+        capability_cache()
+            .lock()
+            .map_err(|_| Error::General("Capability cache lock is poisoned".to_string()))?
+            .insert(self.capability_cache_key(), report.clone());
+        Ok(())
+    }
+
+    async fn discover_capabilities_uncached(&self) -> Result<CapabilityReport> {
+        let cluster_info = self.cluster_info().await?;
+        let server_version = cluster_info.servers.as_ref().and_then(|servers| {
+            servers
+                .iter()
+                .map(|server| server.version.trim())
+                .find(|version| !version.is_empty())
+                .map(str::to_string)
+        });
+
+        let runtime = match self
+            .request_v4::<RuntimeCapabilitiesSnapshot>(Method::GET, "/runtime/capabilities")
+            .await
+        {
+            Ok(runtime) => runtime,
+            Err(Error::NotFound(_)) => {
+                return Ok(version_gated_report(server_version));
+            }
+            Err(Error::UnsupportedFeature(reason)) => {
+                return Ok(stubbed_report(server_version, reason));
+            }
+            Err(error) => return Err(error),
+        };
+
+        let mut capabilities = runtime_summary_entries(&runtime);
+        let extensions = match self
+            .request_v4::<ExtensionsCatalog>(Method::GET, "/extensions/catalog")
+            .await
+        {
+            Ok(catalog) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.extensions-catalog".to_string(),
+                    availability: CapabilityAvailability::Available,
+                    reason: None,
+                });
+                catalog.extensions
+            }
+            Err(Error::NotFound(_)) => {
+                capabilities.push(version_gated_entry(
+                    "admin.extensions-catalog",
+                    "The extensions catalog route is not available on this server version",
+                ));
+                Vec::new()
+            }
+            Err(Error::UnsupportedFeature(reason)) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.extensions-catalog".to_string(),
+                    availability: CapabilityAvailability::Stubbed,
+                    reason: Some(reason),
+                });
+                Vec::new()
+            }
+            Err(error) => return Err(error),
+        };
+
+        let cluster = match self
+            .request_v4::<ClusterSnapshotResponse>(Method::GET, "/cluster/snapshot")
+            .await
+        {
+            Ok(response) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.cluster-snapshot-route".to_string(),
+                    availability: CapabilityAvailability::Available,
+                    reason: response
+                        .snapshot
+                        .as_ref()
+                        .and_then(|snapshot| snapshot.summary.runtime.reason.clone()),
+                });
+                response.snapshot.map_or(
+                    ClusterSnapshotMetadata {
+                        summary: None,
+                        runtime_capabilities_path: None,
+                        extensions_catalog_path: None,
+                    },
+                    |snapshot| ClusterSnapshotMetadata {
+                        summary: Some(snapshot.summary),
+                        runtime_capabilities_path: Some(snapshot.runtime_capabilities_path),
+                        extensions_catalog_path: Some(snapshot.extensions_catalog_path),
+                    },
+                )
+            }
+            Err(Error::NotFound(_)) => {
+                capabilities.push(version_gated_entry(
+                    "admin.cluster-snapshot-route",
+                    "The cluster snapshot route is not available on this server version",
+                ));
+                ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                }
+            }
+            Err(Error::UnsupportedFeature(reason)) => {
+                capabilities.push(CapabilityEntry {
+                    name: "admin.cluster-snapshot-route".to_string(),
+                    availability: CapabilityAvailability::Stubbed,
+                    reason: Some(reason),
+                });
+                ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                }
+            }
+            Err(error) => return Err(error),
+        };
+
+        add_known_server_capabilities(server_version.as_deref(), &mut capabilities);
+        capabilities.sort_by(|left, right| left.name.cmp(&right.name));
+
+        Ok(CapabilityReport {
+            server_version,
+            runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+            extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+            cluster_snapshot_path: runtime.cluster_snapshot_path,
+            capabilities,
+            extensions,
+            cluster,
+        })
+    }
+}
+
+fn runtime_summary_entries(runtime: &RuntimeCapabilitiesSnapshot) -> Vec<CapabilityEntry> {
+    [
+        ("runtime.observability", &runtime.summary.observability),
+        (
+            "runtime.userspace-profiling",
+            &runtime.summary.userspace_profiling,
+        ),
+        ("runtime.memory-sampling", &runtime.summary.memory_sampling),
+        ("runtime.platform", &runtime.summary.platform),
+        ("runtime.topology", &runtime.summary.topology),
+        (
+            "runtime.cluster-snapshot",
+            &runtime.summary.cluster_snapshot,
+        ),
+    ]
+    .into_iter()
+    .map(|(name, status)| capability_entry(name, status))
+    .collect()
+}
+
+fn capability_entry(name: &str, status: &RuntimeCapabilityStatus) -> CapabilityEntry {
+    CapabilityEntry {
+        name: name.to_string(),
+        availability: status.availability(),
+        reason: status.reason.clone(),
+    }
+}
+
+fn version_gated_entry(name: &str, reason: &str) -> CapabilityEntry {
+    CapabilityEntry {
+        name: name.to_string(),
+        availability: CapabilityAvailability::VersionGated,
+        reason: Some(reason.to_string()),
+    }
+}
+
+fn version_gated_report(server_version: Option<String>) -> CapabilityReport {
+    let reason = "RustFS Admin API v4 capability discovery is not available on this server version";
+    CapabilityReport {
+        server_version,
+        runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+        extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+        cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+        capabilities: vec![version_gated_entry("admin.runtime-capabilities", reason)],
+        extensions: Vec::new(),
+        cluster: ClusterSnapshotMetadata {
+            summary: None,
+            runtime_capabilities_path: None,
+            extensions_catalog_path: None,
+        },
+    }
+}
+
+fn stubbed_report(server_version: Option<String>, reason: String) -> CapabilityReport {
+    CapabilityReport {
+        server_version,
+        runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+        extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+        cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+        capabilities: vec![CapabilityEntry {
+            name: "admin.runtime-capabilities".to_string(),
+            availability: CapabilityAvailability::Stubbed,
+            reason: Some(reason),
+        }],
+        extensions: Vec::new(),
+        cluster: ClusterSnapshotMetadata {
+            summary: None,
+            runtime_capabilities_path: None,
+            extensions_catalog_path: None,
+        },
+    }
+}
+
+fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<CapabilityEntry>) {
+    if !version.is_some_and(|version| version.contains("1.0.0-beta.10")) {
+        return;
+    }
+
+    for (name, reason) in [
+        (
+            "admin.batch",
+            "RustFS beta.10 registers batch routes without a scheduler or worker",
+        ),
+        (
+            "admin.ldap-mutation",
+            "RustFS beta.10 returns NotImplemented for LDAP mutations",
+        ),
+        (
+            "admin.logs",
+            "RustFS beta.10 exposes keepalive only and has no live log buffer",
+        ),
+        (
+            "admin.trace",
+            "RustFS beta.10 has no trace subscriber implementation",
+        ),
+        (
+            "admin.update",
+            "RustFS beta.10 accepts update requests without applying an update",
+        ),
+    ] {
+        capabilities.push(CapabilityEntry {
+            name: name.to_string(),
+            availability: CapabilityAvailability::Stubbed,
+            reason: Some(reason.to_string()),
+        });
+    }
+}
+
+#[async_trait]
+impl CapabilityApi for AdminClient {
+    async fn discover_capabilities(&self, refresh: bool) -> Result<CapabilityReport> {
+        if !refresh && let Some(report) = self.cached_capabilities()? {
+            return Ok(report);
+        }
+
+        let report = self.discover_capabilities_uncached().await?;
+        self.store_capabilities(&report)?;
+        Ok(report)
+    }
 }
 
 #[async_trait]
@@ -1387,6 +1820,35 @@ mod tests {
         (endpoint, receiver, handle)
     }
 
+    fn start_admin_sequence_server(
+        responses: Vec<(&'static str, &'static str)>,
+    ) -> (
+        String,
+        mpsc::Receiver<CapturedAdminRequest>,
+        thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+
+        let handle = thread::spawn(move || {
+            for (response_status, response_body) in responses {
+                let (mut stream, _) = listener.accept().expect("accept request");
+                let request = read_admin_request(&mut stream);
+                sender.send(request).expect("send captured request");
+                let response = format!(
+                    "HTTP/1.1 {response_status}\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write HTTP response");
+            }
+        });
+
+        (endpoint, receiver, handle)
+    }
+
     fn admin_client_for_endpoint(endpoint: &str) -> AdminClient {
         let alias = Alias::new("test", endpoint, "access", "secret");
         AdminClient::new(&alias).expect("admin client should build")
@@ -1429,6 +1891,422 @@ mod tests {
             client.admin_url("/list-users"),
             "http://localhost:9000/rustfs/admin/v3/list-users"
         );
+    }
+
+    const CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+    const RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+    const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[{"schema_version":"rustfs.extension-schema.v1","extension_id":"ops.diagnostics","display_name":"Operations Diagnostics","provider":"rustfs","version":"1","kind":"ops_diagnostics","runtime":{"api_version":"v1","boundary":"builtin"},"capabilities":[],"disabled_by_default":false}],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+    const CLUSTER_SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+
+    #[tokio::test]
+    async fn capability_discovery_uses_v4_routes_and_classifies_beta10_stubs() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("capability discovery should succeed");
+        let second_client = admin_client_for_endpoint(&endpoint);
+        let cached = second_client
+            .discover_capabilities(false)
+            .await
+            .expect("process-shared cached discovery should succeed");
+
+        assert_eq!(cached, report);
+        assert_eq!(report.server_version.as_deref(), Some("1.0.0-beta.10"));
+        assert_eq!(report.extensions.len(), 1);
+        assert!(report.cluster.summary.is_some());
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == "runtime.userspace-profiling"
+                && capability.availability == CapabilityAvailability::Disabled
+        }));
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == "runtime.memory-sampling"
+                && capability.availability == CapabilityAvailability::Unsupported
+                && capability.reason.as_deref() == Some("not available on this platform")
+        }));
+        for name in [
+            "admin.batch",
+            "admin.ldap-mutation",
+            "admin.logs",
+            "admin.trace",
+            "admin.update",
+        ] {
+            assert!(report.capabilities.iter().any(|capability| {
+                capability.name == name
+                    && capability.availability == CapabilityAvailability::Stubbed
+            }));
+        }
+
+        let targets = (0..4)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            vec![
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_refreshes_process_shared_cache() {
+        let responses = vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ];
+        let (endpoint, receiver, handle) = start_admin_sequence_server(responses);
+        let first_client = admin_client_for_endpoint(&endpoint);
+        first_client
+            .discover_capabilities(false)
+            .await
+            .expect("initial discovery should succeed");
+
+        let second_client = admin_client_for_endpoint(&endpoint);
+        second_client
+            .discover_capabilities(true)
+            .await
+            .expect("refresh should bypass the process-shared cache");
+
+        let targets = (0..8)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            [
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+            .repeat(2)
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_cache_isolates_tls_contexts_and_refreshes_within_each_context() {
+        let response_set = [
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ];
+        let responses = response_set.repeat(3);
+        let (endpoint, receiver, handle) = start_admin_sequence_server(responses);
+
+        let strict_client = admin_client_for_endpoint(&endpoint);
+        strict_client
+            .discover_capabilities(false)
+            .await
+            .expect("strict TLS context discovery should succeed");
+
+        let mut insecure_alias = Alias::new("test", &endpoint, "access", "secret");
+        insecure_alias.insecure = true;
+        let insecure_client =
+            AdminClient::new(&insecure_alias).expect("insecure admin client should build");
+        assert_ne!(
+            strict_client.capability_cache_key(),
+            insecure_client.capability_cache_key()
+        );
+        insecure_client
+            .discover_capabilities(false)
+            .await
+            .expect("a different TLS context must not reuse the strict cache entry");
+
+        let second_insecure_client =
+            AdminClient::new(&insecure_alias).expect("second insecure client should build");
+        second_insecure_client
+            .discover_capabilities(false)
+            .await
+            .expect("the same TLS context should reuse its cache entry");
+        second_insecure_client
+            .discover_capabilities(true)
+            .await
+            .expect("refresh should bypass the matching TLS context cache entry");
+
+        let targets = (0..12)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            targets,
+            [
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+            ]
+            .repeat(3)
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_404_takes_precedence_over_not_implemented_body() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            (
+                "404 Not Found",
+                r#"{"code":"NotImplemented","message":"route body must not override HTTP 404"}"#,
+            ),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("v4 absence should produce a report");
+
+        assert_eq!(report.capabilities.len(), 1);
+        assert_eq!(
+            report.capabilities[0].availability,
+            CapabilityAvailability::VersionGated
+        );
+        assert_eq!(
+            receiver.recv().expect("info request").target,
+            "/rustfs/admin/v3/info"
+        );
+        assert_eq!(
+            receiver.recv().expect("runtime request").target,
+            "/rustfs/admin/v4/runtime/capabilities"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_reports_http_501_as_stubbed() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            (
+                "501 Not Implemented",
+                r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+            ),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("an explicit stub response should produce a report");
+
+        assert_eq!(report.capabilities.len(), 1);
+        assert_eq!(
+            report.capabilities[0].availability,
+            CapabilityAvailability::Stubbed
+        );
+        assert_eq!(
+            report.capabilities[0].reason.as_deref(),
+            Some("route is not implemented")
+        );
+        assert_eq!(
+            receiver.recv().expect("info request").target,
+            "/rustfs/admin/v3/info"
+        );
+        assert_eq!(
+            receiver.recv().expect("runtime request").target,
+            "/rustfs/admin/v4/runtime/capabilities"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_does_not_misclassify_permission_denial() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("403 Forbidden", r#"{"code":"AccessDenied"}"#),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let error = client
+            .discover_capabilities(false)
+            .await
+            .expect_err("permission denial should fail discovery");
+
+        assert!(matches!(error, Error::Auth(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_maps_rustfs_missing_credentials_to_auth() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            (
+                "400 Bad Request",
+                "<Error><Code>InvalidRequest</Code><Message>get cred failed</Message></Error>",
+            ),
+        ]);
+        let client = anonymous_admin_client_for_endpoint(&endpoint);
+
+        let error = client
+            .discover_capabilities(false)
+            .await
+            .expect_err("RustFS missing credentials should fail discovery");
+
+        assert!(matches!(error, Error::Auth(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn capability_discovery_rejects_malformed_runtime_response() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", r#"{"summary":{}}"#),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let error = client
+            .discover_capabilities(false)
+            .await
+            .expect_err("malformed response should fail discovery");
+
+        assert!(matches!(error, Error::Json(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[test]
+    fn not_implemented_admin_error_maps_to_unsupported_feature() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::NOT_IMPLEMENTED,
+            r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+        );
+
+        assert!(matches!(error, Error::UnsupportedFeature(_)));
+    }
+
+    #[test]
+    fn structured_not_implemented_code_maps_to_unsupported_feature() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::BAD_REQUEST,
+            "<Error><Code>NotImplemented</Code><Message>stub route</Message></Error>",
+        );
+
+        assert!(matches!(error, Error::UnsupportedFeature(message) if message == "stub route"));
+    }
+
+    #[test]
+    fn permission_status_takes_precedence_over_not_implemented_code() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::FORBIDDEN,
+            r#"{"code":"NotImplemented","message":"Access denied"}"#,
+        );
+
+        assert!(matches!(error, Error::Auth(_)));
+    }
+
+    #[test]
+    fn not_found_status_takes_precedence_over_not_implemented_code() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::NOT_FOUND,
+            r#"{"code":"NotImplemented","message":"route is not implemented"}"#,
+        );
+
+        assert!(matches!(error, Error::NotFound(_)));
+    }
+
+    #[test]
+    fn unstructured_not_implemented_text_does_not_change_error_class() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        let error = client.map_error(
+            StatusCode::BAD_REQUEST,
+            "A proxy says NotImplemented but provides no structured error code",
+        );
+
+        assert!(matches!(error, Error::General(_)));
+    }
+
+    #[test]
+    fn rustfs_missing_credentials_invalid_request_maps_to_auth() {
+        let client = admin_client_for_endpoint("http://localhost:9000");
+        for body in [
+            "<Error><Code>InvalidRequest</Code><Message>get cred failed</Message></Error>",
+            r#"{"Code":"InvalidRequest","Message":"authentication required"}"#,
+        ] {
+            let error = client.map_error(StatusCode::BAD_REQUEST, body);
+            assert!(matches!(error, Error::Auth(_)));
+        }
+    }
+
+    #[test]
+    fn capability_cache_key_is_credential_scoped_without_plaintext_secrets() {
+        let first = admin_client_for_endpoint("http://localhost:9000");
+        let mut alias = Alias::new(
+            "test",
+            "http://localhost:9000",
+            "different-access",
+            "different-secret",
+        );
+        alias.region = first.region.clone();
+        let second = AdminClient::new(&alias).expect("admin client should build");
+
+        let first_key = first.capability_cache_key();
+        let second_key = second.capability_cache_key();
+        assert_ne!(first_key, second_key);
+        assert!(!first_key.credential_fingerprint.contains("secret"));
+        assert!(
+            !second_key
+                .credential_fingerprint
+                .contains("different-secret")
+        );
+    }
+
+    #[test]
+    fn transport_security_fingerprint_covers_tls_and_mtls_inputs_without_leaking_them() {
+        let baseline = transport_security_fingerprint(false, None, None, None);
+        let insecure = transport_security_fingerprint(true, None, None, None);
+        let custom_ca = transport_security_fingerprint(false, Some(b"private-ca-root"), None, None);
+        let client_identity = transport_security_fingerprint(
+            false,
+            Some(b"private-ca-root"),
+            Some(b"client-certificate"),
+            Some(b"PRIVATE-KEY-MARKER"),
+        );
+        let different_key = transport_security_fingerprint(
+            false,
+            Some(b"private-ca-root"),
+            Some(b"client-certificate"),
+            Some(b"DIFFERENT-PRIVATE-KEY"),
+        );
+
+        assert_ne!(baseline, insecure);
+        assert_ne!(baseline, custom_ca);
+        assert_ne!(custom_ca, client_identity);
+        assert_ne!(client_identity, different_key);
+        for fingerprint in [
+            baseline,
+            insecure,
+            custom_ca,
+            client_identity,
+            different_key,
+        ] {
+            assert_eq!(fingerprint.len(), 64);
+            assert!(
+                fingerprint
+                    .chars()
+                    .all(|character| character.is_ascii_hexdigit())
+            );
+            assert!(!fingerprint.contains("PRIVATE-KEY-MARKER"));
+            assert!(!fingerprint.contains("private-ca-root"));
+        }
     }
 
     #[test]

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -11,13 +11,15 @@ use aws_sigv4::http_request::{
 use aws_sigv4::sign::v4;
 use rc_core::admin::{
     AccessKeyInfo, AdminApi, BucketQuota, CapabilityApi, CapabilityAvailability, CapabilityEntry,
-    CapabilityReport, ClusterInfo, ClusterSnapshotMetadata, ClusterSnapshotSummary,
+    CapabilityReport, ClusterInfo, ClusterSnapshotMetadata, ClusterSnapshotSummary, ConfigApi,
+    ConfigDocument, ConfigHelp, ConfigHistoryEntry, ConfigMutationResult,
     CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus, ExtensionsCatalog,
     Group, GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus,
-    HealTaskRequest, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
-    RebalanceStartResult, RebalanceStatus, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus,
-    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
-    SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
+    HealTaskRequest, ModuleSwitches, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus,
+    PoolTarget, RebalanceStartResult, RebalanceStatus, RuntimeCapabilitiesSnapshot,
+    RuntimeCapabilityStatus, ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult,
+    SiteRemoveSpec, SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest,
+    User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -415,6 +417,62 @@ impl AdminClient {
         Ok(())
     }
 
+    async fn config_request(
+        &self,
+        method: Method,
+        path: &str,
+        query: Option<&[(&str, &str)]>,
+        body: Option<&[u8]>,
+    ) -> Result<(HeaderMap, Vec<u8>)> {
+        let mut url = self.admin_url(path);
+        if let Some(query) = query {
+            let query_string = query
+                .iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{}={}",
+                        urlencoding::encode(key),
+                        urlencoding::encode(value)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("&");
+            if !query_string.is_empty() {
+                url.push('?');
+                url.push_str(&query_string);
+            }
+        }
+
+        let body = body.unwrap_or_default();
+        let headers = self.request_headers(body)?;
+        let signed_headers = self.sign_request(&method, &url, &headers, body).await?;
+        let mut request = self.http_client.request(method, &url);
+        for (name, value) in &signed_headers {
+            request = request.header(name, value);
+        }
+        if !body.is_empty() {
+            request = request.body(body.to_vec());
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|error| Error::Network(format!("Configuration request failed: {error}")))?;
+        let status = response.status();
+        let headers = response.headers().clone();
+        let response_body = response
+            .bytes()
+            .await
+            .map_err(|error| {
+                Error::Network(format!("Failed to read configuration response: {error}"))
+            })?
+            .to_vec();
+        if !status.is_success() {
+            return Err(safe_config_error(status));
+        }
+        Ok((headers, response_body))
+    }
+
     /// Extract host from endpoint
     fn get_host(&self) -> String {
         self.endpoint
@@ -461,6 +519,30 @@ impl AdminClient {
             StatusCode::BAD_REQUEST => Error::General(format!("Bad request: {body}")),
             _ => Error::Network(format!("HTTP {}: {}", status.as_u16(), body)),
         }
+    }
+}
+
+fn safe_config_error(status: StatusCode) -> Error {
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            Error::Auth("Server denied configuration access".to_string())
+        }
+        StatusCode::NOT_FOUND => Error::NotFound(
+            "Configuration API route or requested resource was not found".to_string(),
+        ),
+        StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED => {
+            Error::Conflict("Server configuration changed before mutation".to_string())
+        }
+        StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+            "Server does not implement this configuration operation".to_string(),
+        ),
+        StatusCode::BAD_REQUEST => Error::Config(
+            "Server rejected the configuration request; review `rc admin config help`".to_string(),
+        ),
+        _ => Error::Network(format!(
+            "Configuration request failed with HTTP {}",
+            status.as_u16()
+        )),
     }
 }
 
@@ -1140,6 +1222,157 @@ impl CapabilityApi for AdminClient {
         self.store_capabilities(&report)?;
         Ok(report)
     }
+}
+
+#[async_trait]
+impl ConfigApi for AdminClient {
+    async fn get_config(&self, selector: &str) -> Result<ConfigDocument> {
+        let (_, body) = self
+            .config_request(
+                Method::GET,
+                "/get-config-kv",
+                Some(&[("key", selector)]),
+                None,
+            )
+            .await?;
+        let content = String::from_utf8(body).map_err(|_| {
+            Error::General("Server returned invalid configuration text".to_string())
+        })?;
+        Ok(ConfigDocument { content })
+    }
+
+    async fn get_full_config(&self) -> Result<ConfigDocument> {
+        let (_, body) = self
+            .config_request(Method::GET, "/config", None, None)
+            .await?;
+        let content = String::from_utf8(body).map_err(|_| {
+            Error::General("Server returned invalid configuration text".to_string())
+        })?;
+        Ok(ConfigDocument { content })
+    }
+
+    async fn set_config(&self, directive: &str) -> Result<ConfigMutationResult> {
+        let (headers, _) = self
+            .config_request(
+                Method::PUT,
+                "/set-config-kv",
+                None,
+                Some(directive.as_bytes()),
+            )
+            .await?;
+        Ok(ConfigMutationResult {
+            applied_dynamically: config_applied(&headers),
+        })
+    }
+
+    async fn delete_config(&self, directive: &str) -> Result<ConfigMutationResult> {
+        let (headers, _) = self
+            .config_request(
+                Method::DELETE,
+                "/del-config-kv",
+                None,
+                Some(directive.as_bytes()),
+            )
+            .await?;
+        Ok(ConfigMutationResult {
+            applied_dynamically: config_applied(&headers),
+        })
+    }
+
+    async fn config_help(
+        &self,
+        subsystem: Option<&str>,
+        key: Option<&str>,
+        env_only: bool,
+    ) -> Result<ConfigHelp> {
+        let mut query = Vec::new();
+        if let Some(subsystem) = subsystem {
+            query.push(("subSys", subsystem));
+        }
+        if let Some(key) = key {
+            query.push(("key", key));
+        }
+        if env_only {
+            query.push(("env", "true"));
+        }
+        let (_, body) = self
+            .config_request(Method::GET, "/help-config-kv", Some(&query), None)
+            .await?;
+        serde_json::from_slice(&body)
+            .map_err(|_| Error::General("Server returned invalid configuration help".to_string()))
+    }
+
+    async fn config_history(&self, count: usize) -> Result<Vec<ConfigHistoryEntry>> {
+        let count = count.to_string();
+        let (_, body) = self
+            .config_request(
+                Method::GET,
+                "/list-config-history-kv",
+                Some(&[("count", count.as_str())]),
+                None,
+            )
+            .await?;
+        serde_json::from_slice(&body).map_err(|_| {
+            Error::General("Server returned invalid configuration history".to_string())
+        })
+    }
+
+    async fn restore_config(&self, restore_id: &str) -> Result<()> {
+        self.config_request(
+            Method::PUT,
+            "/restore-config-history-kv",
+            Some(&[("restoreId", restore_id)]),
+            None,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn import_config(&self, document: &ConfigDocument) -> Result<()> {
+        self.config_request(
+            Method::PUT,
+            "/config",
+            None,
+            Some(document.content.as_bytes()),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn get_module_switches(&self) -> Result<ModuleSwitches> {
+        let (_, body) = self
+            .config_request(Method::GET, "/module-switches", None, None)
+            .await
+            .map_err(|error| match error {
+                Error::NotFound(_) => Error::UnsupportedFeature(
+                    "Server does not advertise module switch operations".to_string(),
+                ),
+                other => other,
+            })?;
+        serde_json::from_slice(&body)
+            .map_err(|_| Error::General("Server returned invalid module switch state".to_string()))
+    }
+
+    async fn set_module_switches(&self, switches: &ModuleSwitches) -> Result<ModuleSwitches> {
+        let body = serde_json::to_vec(&serde_json::json!({
+            "notify_enabled": switches.notify_enabled,
+            "audit_enabled": switches.audit_enabled,
+        }))
+        .map_err(|_| Error::General("Failed to encode module switch request".to_string()))?;
+        let (_, response) = self
+            .config_request(Method::PUT, "/module-switches", None, Some(&body))
+            .await?;
+        serde_json::from_slice(&response)
+            .map_err(|_| Error::General("Server returned invalid module switch state".to_string()))
+    }
+}
+
+fn config_applied(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-rustfs-config-applied")
+        .or_else(|| headers.get("x-minio-config-applied"))
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
 }
 
 #[async_trait]

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -22,6 +22,8 @@ rc admin policy <ls|create|info|rm|attach> ...
 rc admin group <ls|add|info|rm|enable|disable|add-members|rm-members> ...
 rc admin service-account <ls|create|info|rm> ...
 rc admin service <restart|stop|freeze|unfreeze> <ALIAS>
+rc admin config <get|set|delete|help|history|restore|export|import> ...
+rc admin config module-switch <get|set> ...
 rc admin replicate add <ALIAS> <ALIAS> [<ALIAS>...]
 rc admin replicate <info|status> <ALIAS> [OPTIONS]
 rc admin replicate remove <ALIAS> <--all|--site <NAME>>
@@ -42,6 +44,7 @@ rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 | `group` | Manage IAM groups and group membership. |
 | `service-account` | Manage service accounts. |
 | `service` | Control the server process: restart, stop, freeze, unfreeze. |
+| `config` | Inspect, plan, export, and mutate RustFS server configuration. |
 | `replicate` | Manage site replication across clusters. |
 
 ## Examples
@@ -210,6 +213,29 @@ Use `rc admin pool list <ALIAS>` or `rc admin pool status <ALIAS>` to find pool 
 | `rc admin service unfreeze <ALIAS>` | Clear the service freeze flag. |
 
 The server response reports whether the action was `accepted` and whether it is `effective` on the current build. RustFS has no in-process supervisor, so `restart` and `stop` both perform a graceful stop; `restart` relies on the process manager to bring the server back up.
+
+## Server Configuration Workflow
+
+`rc admin config` manages the RustFS server configuration behind an alias. It does not modify the local `rc` alias configuration.
+
+| Command | Description |
+| --- | --- |
+| `rc admin config get <ALIAS> <SUBSYSTEM[:TARGET]>` | Read a subsystem or named target. Secret-bearing fields are redacted again by the client before output. |
+| `rc admin config set <ALIAS> <SUBSYSTEM[:TARGET]> <KEY=VALUE>... [--dry-run]` | Validate keys with server help, read the current state, calculate a redacted diff, and apply the directive unless `--dry-run` is set. |
+| `rc admin config delete <ALIAS> <SUBSYSTEM[:TARGET]> [KEY...] [--dry-run]` | Delete selected keys or the complete target after a redacted preflight diff. |
+| `rc admin config help <ALIAS> [SUBSYSTEM] [KEY] [--env]` | Show server-provided subsystem, key, or environment-variable help. |
+| `rc admin config history <ALIAS> [--count <N>]` | List recent history. History data is classified and redacted locally because server records can contain submitted values. |
+| `rc admin config restore <ALIAS> <RESTORE_ID> [--dry-run] --yes` | Preview or apply a history entry as a complete configuration replacement. |
+| `rc admin config export <ALIAS> --file <PATH>` | Create a new, owner-private, redacted configuration file. Existing files are never overwritten. |
+| `rc admin config import <ALIAS> --file <PATH> [--dry-run] --yes` | Validate and preview a complete configuration replacement from a file. Redacted secret placeholders are rejected. |
+| `rc admin config module-switch get <ALIAS>` | Show effective and persisted notification/audit module switches and their sources. |
+| `rc admin config module-switch set <ALIAS> [--notify on\|off] [--audit on\|off] [--dry-run]` | Update one or both persisted switches. Omitted switches retain their persisted value even when an environment override changes the effective value. |
+
+All set, delete, import, restore, and module-switch dry runs are client-side and do not send a mutation request. RustFS beta.10 does not expose a revision, ETag, or other optimistic concurrency token for these routes, so `rc` does not claim atomic compare-and-set protection.
+
+Full imports and restores require `--yes`. RustFS beta.10 history entries contain the submitted directive rather than a complete pre-change snapshot. The server currently rebuilds its configuration from that directive during restore, which can remove unrelated settings. `rc` shows this as a complete replacement and warns about the unsafe server behavior tracked in [rustfs/backlog#1398](https://github.com/rustfs/backlog/issues/1398); a history restore must not be treated as preservation-safe rollback.
+
+Exports are always redacted because secret values are not a portable client output contract. Replace any required secret values through an approved secret-management workflow before importing; `rc` rejects the `*redacted*` placeholder for secret-bearing fields.
 
 ## Site Replication Workflow
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -69,6 +69,7 @@
         "scope": { "type": "string", "minLength": 1 },
         "support": {
           "type": "string",
+          "description": "Effective support: unsupported is a server-declared runtime state or version gate, while stub is reserved for registered but unimplemented routes.",
           "enum": ["supported", "unsupported", "stub", "disabled", "unknown"]
         },
         "reason": { "$ref": "#/definitions/nullableString" }


### PR DESCRIPTION
## Related issues

Closes rustfs/backlog#1375
Parent roadmap: rustfs/backlog#1361
Server safety follow-ups: rustfs/backlog#1398 and rustfs/backlog#1399

## Background and user impact

RustFS 1.0.0-beta.10 exposes native configuration, history, import/export, and module-switch routes, but rc did not provide a typed workflow. Operators had no client-side dry run, secret-safe output, destructive confirmation, or stable output-v3 result.

The server also returns original history mutation data that can contain secrets, exposes no revision/ETag token, and restores directive-style history as a complete configuration. The client must defend against these limitations without claiming preservation-safe rollback.

## Root cause

rc had no core trait boundary or S3 adapter for the RustFS configuration API. The CLI therefore could not validate server-owned keys, calculate a preflight diff, classify sensitive fields, or preserve typed error and output contracts.

## Solution

- Add config get, set, delete, help, history, restore, export, and import commands.
- Add notification/audit module-switch get and partial set.
- Introduce a core ConfigApi trait and secret-safe value types.
- Validate configuration syntax and server help metadata before mutation.
- Produce client-side dry-run diffs without sending mutation requests.
- Redact selected config, full export, history data, diffs, Debug output, errors, and JSON.
- Reject redacted secret placeholders during import.
- Create owner-private exports without overwriting an existing path.
- Require explicit confirmation for full import and restore.
- Preserve omitted module switches from persisted values rather than environment-overridden effective state.
- Emit schema-v3 admin_operations success and error envelopes.
- Distinguish authorization, conflict, unsupported, validation, and transport errors.

## Server limitations

- beta.10 exposes no revision, ETag, or compare-and-set token, so this PR does not claim optimistic concurrency.
- beta.10 restore rebuilds the complete configuration from the stored directive and can remove unrelated values. rc presents this as a destructive replacement and links rustfs/backlog#1398.
- Server-side default history redaction remains tracked by rustfs/backlog#1399; rc applies defensive local redaction.
- Full export is always redacted; secret export is not advertised.
- HTTP contracts are mock-tested. Live validation against a multi-subsystem beta.10 deployment remains required before merge.

## Validation

Passed locally at exact head e16d366ed43c6f2a1a998a53da8355b395a69d81:

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- core configuration tests: 7 passed
- CLI configuration unit tests: 7 passed
- admin configuration end-to-end tests: 7 passed
- output schema, integration, and documentation tests passed

## BREAKING process

BREAKING marker required because this additive command support updates the protected docs/reference/rc/admin.md behavior contract. It does not change the local rc config schema, exit codes, output_v1, or output_v2. It uses the existing additive output_v3 admin_operations envelope, so no schema migration or version bump is required.

## Review notes

This draft PR is intentionally stacked on rustfs/cli#268 because it requires output schema v3 and runtime capability discovery.