### PR TITLE
feat(rc-admin)!: add bounded client devnull diagnostics

### DIFF
--- a/crates/cli/src/commands/admin/diagnostics.rs
+++ b/crates/cli/src/commands/admin/diagnostics.rs
@@ -1,4 +1,6 @@
-//! Read-only RustFS diagnostic snapshots.
+//! RustFS read-only snapshots and explicitly confirmed bounded active diagnostics.
+
+mod client_devnull;
 
 use std::collections::BTreeMap;
 
@@ -15,6 +17,8 @@ use super::get_admin_client;
 use crate::exit_code::ExitCode;
 use crate::output::Formatter;
 
+pub use client_devnull::ClientDevnullArgs;
+
 #[derive(Subcommand, Debug, Clone)]
 pub enum DiagnosticsCommands {
     /// Display authenticated host, process, and drive health observations
@@ -23,6 +27,9 @@ pub enum DiagnosticsCommands {
     Cluster(DiagnosticsArgs),
     /// Display extension schemas and runtime capability summaries
     Extensions(DiagnosticsArgs),
+    /// Measure bounded client-to-server upload throughput without storing data
+    #[command(name = "client-devnull")]
+    ClientDevnull(ClientDevnullArgs),
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -38,12 +45,14 @@ impl DiagnosticsCommands {
             Self::Health(_) => "health",
             Self::Cluster(_) => "cluster",
             Self::Extensions(_) => "extensions",
+            Self::ClientDevnull(_) => "client-devnull",
         }
     }
 
     pub fn alias(&self) -> &str {
         match self {
             Self::Health(args) | Self::Cluster(args) | Self::Extensions(args) => &args.alias,
+            Self::ClientDevnull(args) => &args.alias,
         }
     }
 
@@ -52,6 +61,7 @@ impl DiagnosticsCommands {
             Self::Health(_) => DiagnosticCapability::HealthSnapshot,
             Self::Cluster(_) => DiagnosticCapability::ClusterSnapshot,
             Self::Extensions(_) => DiagnosticCapability::ExtensionsCatalog,
+            Self::ClientDevnull(_) => DiagnosticCapability::ClientDevnull,
         }
     }
 
@@ -60,6 +70,7 @@ impl DiagnosticsCommands {
             Self::Health(_) => "health_snapshot",
             Self::Cluster(_) => "cluster_snapshot",
             Self::Extensions(_) => "extension_catalog",
+            Self::ClientDevnull(_) => "admin_operations",
         }
     }
 }
@@ -105,11 +116,18 @@ struct ErrorBody<'a> {
 }
 
 pub async fn execute(command: DiagnosticsCommands, formatter: &Formatter) -> ExitCode {
-    let client = match get_admin_client(command.alias(), formatter) {
-        Ok(client) => client,
-        Err(code) => return code,
-    };
-    execute_with_api(command, &client, &client, formatter).await
+    match command {
+        DiagnosticsCommands::ClientDevnull(args) => {
+            client_devnull::execute_client_devnull(args, formatter).await
+        }
+        read_command => {
+            let client = match get_admin_client(read_command.alias(), formatter) {
+                Ok(client) => client,
+                Err(code) => return code,
+            };
+            execute_with_api(read_command, &client, &client, formatter).await
+        }
+    }
 }
 
 async fn execute_with_api(
@@ -170,6 +188,14 @@ async fn execute_with_api(
                 formatter,
             ),
         },
+        DiagnosticsCommands::ClientDevnull(_) => emit_diagnostic_error(
+            &command,
+            "Failed to route active diagnostic",
+            &Error::General(
+                "Client devnull must use the bounded active diagnostic executor".to_string(),
+            ),
+            formatter,
+        ),
     }
 }
 

--- a/crates/cli/src/commands/admin/diagnostics/client_devnull.rs
+++ b/crates/cli/src/commands/admin/diagnostics/client_devnull.rs
@@ -1,0 +1,633 @@
+//! Bounded active client-devnull diagnostic.
+
+use std::future::Future;
+use std::time::Duration;
+
+use clap::Args;
+use rc_core::Error;
+use rc_core::admin::{
+    ClientDevnullRequest, ClientDevnullResult, DEFAULT_CLIENT_DEVNULL_CONCURRENCY, DiagnosticApi,
+};
+use serde::Serialize;
+
+use super::super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+const CLIENT_DEVNULL_CAPABILITY: &str = "admin.diagnostics.client-devnull";
+
+/// Options for the bounded client-to-server devnull probe.
+#[derive(Args, Debug, Clone)]
+pub struct ClientDevnullArgs {
+    /// Alias name of the RustFS server
+    pub alias: String,
+
+    /// Bytes uploaded by each request (for example 8MiB)
+    #[arg(long, default_value = "8MiB")]
+    pub size: String,
+
+    /// Active probe timeout in whole seconds (for example 30s)
+    #[arg(long, default_value = "30s")]
+    pub timeout: String,
+
+    /// Number of concurrent upload requests (1 through 4)
+    #[arg(long, default_value_t = DEFAULT_CLIENT_DEVNULL_CONCURRENCY)]
+    pub concurrency: u8,
+
+    /// Confirm generation of deliberate network load
+    #[arg(long, required = true)]
+    pub yes: bool,
+}
+
+pub(super) async fn execute_client_devnull(
+    args: ClientDevnullArgs,
+    formatter: &Formatter,
+) -> ExitCode {
+    let request = match validate_client_devnull_args(&args) {
+        Ok(request) => request,
+        Err(message) => return emit_code_error(ExitCode::UsageError, message, formatter),
+    };
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    run_client_devnull(
+        &args.alias,
+        request,
+        &client,
+        formatter,
+        tokio::signal::ctrl_c(),
+    )
+    .await
+}
+
+async fn run_client_devnull<F>(
+    alias: &str,
+    request: ClientDevnullRequest,
+    api: &dyn DiagnosticApi,
+    formatter: &Formatter,
+    interrupt: F,
+) -> ExitCode
+where
+    F: Future<Output = std::io::Result<()>>,
+{
+    tokio::pin!(interrupt);
+    let result = tokio::select! {
+        biased;
+        interrupt_result = &mut interrupt => {
+            return match interrupt_result {
+                Ok(()) => emit_code_error(
+                    ExitCode::Interrupted,
+                    "Client devnull probe was interrupted".to_string(),
+                    formatter,
+                ),
+                Err(error) => emit_code_error(
+                    ExitCode::GeneralError,
+                    format!("Failed to register Ctrl-C handler for client devnull probe: {error}"),
+                    formatter,
+                ),
+            };
+        }
+        result = api.client_devnull(request) => result,
+    };
+
+    match result {
+        Ok(result) => {
+            if formatter.is_json() {
+                formatter.json(&success_output(alias, result));
+            } else {
+                for line in human_result_lines(alias, result, formatter) {
+                    formatter.println(&line);
+                }
+            }
+            ExitCode::Success
+        }
+        Err(error) => emit_probe_error(&error, formatter),
+    }
+}
+
+fn validate_client_devnull_args(args: &ClientDevnullArgs) -> Result<ClientDevnullRequest, String> {
+    if !args.yes {
+        return Err("Client devnull requires --yes because it generates network load".to_string());
+    }
+    let bytes = parse_byte_size(&args.size)?;
+    let timeout = parse_timeout(&args.timeout)?;
+    ClientDevnullRequest::new(bytes, args.concurrency, timeout).map_err(|error| error.to_string())
+}
+
+fn parse_byte_size(value: &str) -> Result<u64, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("Client devnull size cannot be empty".to_string());
+    }
+    let split_index = value
+        .find(|character: char| !character.is_ascii_digit())
+        .unwrap_or(value.len());
+    let (number, unit) = value.split_at(split_index);
+    if number.is_empty() {
+        return Err(format!("Invalid client devnull size: '{value}'"));
+    }
+    let number = number
+        .parse::<u64>()
+        .map_err(|_| format!("Invalid client devnull size number: '{number}'"))?;
+    let multiplier = match unit.to_ascii_uppercase().as_str() {
+        "" | "B" => 1,
+        "K" | "KB" | "KIB" => 1024,
+        "M" | "MB" | "MIB" => 1024 * 1024,
+        "G" | "GB" | "GIB" => 1024 * 1024 * 1024,
+        _ => return Err(format!("Invalid client devnull size unit: '{unit}'")),
+    };
+    number
+        .checked_mul(multiplier)
+        .ok_or_else(|| format!("Client devnull size is too large: '{value}'"))
+}
+
+fn parse_timeout(value: &str) -> Result<Duration, String> {
+    let value = value.trim();
+    let seconds = value
+        .strip_suffix('s')
+        .or_else(|| value.strip_suffix('S'))
+        .ok_or_else(|| "Client devnull timeout must use whole seconds such as 30s".to_string())?;
+    if seconds.is_empty() || !seconds.chars().all(|character| character.is_ascii_digit()) {
+        return Err(format!("Invalid client devnull timeout: '{value}'"));
+    }
+    let seconds = seconds
+        .parse::<u64>()
+        .map_err(|_| format!("Client devnull timeout is too large: '{value}'"))?;
+    Ok(Duration::from_secs(seconds))
+}
+
+fn emit_probe_error(error: &Error, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    emit_error(
+        code,
+        format!("Client devnull probe failed: {error}"),
+        matches!(error, Error::UnsupportedFeature(_)),
+        formatter,
+    )
+}
+
+fn emit_code_error(code: ExitCode, message: String, formatter: &Formatter) -> ExitCode {
+    emit_error(code, message, false, formatter)
+}
+
+fn emit_error(
+    code: ExitCode,
+    message: String,
+    unsupported: bool,
+    formatter: &Formatter,
+) -> ExitCode {
+    if formatter.is_json() {
+        formatter.json_error(&error_output(code, message, unsupported));
+    } else {
+        formatter.error_with_code(code, &message);
+    }
+    code
+}
+
+fn human_result_lines(
+    alias: &str,
+    result: ClientDevnullResult,
+    formatter: &Formatter,
+) -> Vec<String> {
+    vec![
+        format!(
+            "Client-to-server devnull throughput ({})",
+            formatter.sanitize_text(alias)
+        ),
+        format!(
+            "Requested: {}",
+            humansize::format_size(result.requested_bytes, humansize::BINARY)
+        ),
+        format!(
+            "Received: {}",
+            humansize::format_size(result.received_bytes, humansize::BINARY)
+        ),
+        format!("Concurrency: {}", result.concurrency),
+        format!("Elapsed: {:.3} s", result.elapsed_seconds),
+        format!(
+            "Aggregate upload throughput: {:.2} MiB/s",
+            result.aggregate_throughput_bytes_per_second / (1024.0 * 1024.0)
+        ),
+    ]
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperationsSuccessOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: AdminOperationsData,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperationsData {
+    operations: Vec<AdminOperationOutput>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperationOutput {
+    operation: &'static str,
+    resource: String,
+    state: &'static str,
+    operation_id: Option<String>,
+    changed: bool,
+    result: ClientDevnullOutput,
+}
+
+#[derive(Debug, Serialize)]
+struct ClientDevnullOutput {
+    direction: &'static str,
+    requested_bytes: u64,
+    received_bytes: u64,
+    concurrency: u8,
+    elapsed_seconds: f64,
+    aggregate_throughput_bytes_per_second: f64,
+}
+
+fn success_output(alias: &str, result: ClientDevnullResult) -> AdminOperationsSuccessOutput {
+    AdminOperationsSuccessOutput {
+        schema_version: 3,
+        output_type: "admin_operations",
+        status: "success",
+        data: AdminOperationsData {
+            operations: vec![AdminOperationOutput {
+                operation: "diagnostics_client_devnull",
+                resource: alias.to_string(),
+                state: "succeeded",
+                operation_id: None,
+                changed: false,
+                result: ClientDevnullOutput {
+                    direction: "client-to-server",
+                    requested_bytes: result.requested_bytes,
+                    received_bytes: result.received_bytes,
+                    concurrency: result.concurrency,
+                    elapsed_seconds: result.elapsed_seconds,
+                    aggregate_throughput_bytes_per_second: result
+                        .aggregate_throughput_bytes_per_second,
+                },
+            }],
+        },
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperationsErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: ProbeErrorOutput,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ProbeErrorOutput {
+    Unsupported(UnsupportedProbeError),
+    Standard(StandardProbeError),
+}
+
+#[derive(Debug, Serialize)]
+struct UnsupportedProbeError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    capability: &'static str,
+    server: Option<String>,
+    suggestion: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct StandardProbeError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    suggestion: Option<&'static str>,
+}
+
+fn error_output(code: ExitCode, message: String, unsupported: bool) -> AdminOperationsErrorOutput {
+    let error = if unsupported {
+        ProbeErrorOutput::Unsupported(UnsupportedProbeError {
+            error_type: "unsupported_feature",
+            message,
+            retryable: false,
+            capability: CLIENT_DEVNULL_CAPABILITY,
+            server: None,
+            suggestion: Some("Use a RustFS release with a measured client-devnull implementation."),
+        })
+    } else {
+        let (error_type, retryable, suggestion) = standard_error_metadata(code);
+        ProbeErrorOutput::Standard(StandardProbeError {
+            error_type,
+            message,
+            retryable,
+            suggestion,
+        })
+    };
+    AdminOperationsErrorOutput {
+        schema_version: 3,
+        output_type: "admin_operations",
+        status: "error",
+        error,
+    }
+}
+
+const fn standard_error_metadata(code: ExitCode) -> (&'static str, bool, Option<&'static str>) {
+    match code {
+        ExitCode::UsageError => (
+            "usage_error",
+            false,
+            Some("Review --size, --timeout, --concurrency, and the required --yes flag."),
+        ),
+        ExitCode::NetworkError => (
+            "network_error",
+            true,
+            Some("Verify connectivity and retry the bounded probe when safe."),
+        ),
+        ExitCode::AuthError => (
+            "auth_error",
+            false,
+            Some("Verify credentials and the HealthInfoAdminAction permission."),
+        ),
+        ExitCode::Interrupted => (
+            "interrupted",
+            true,
+            Some("Retry the bounded probe when network load is safe."),
+        ),
+        ExitCode::NotFound => ("not_found", false, None),
+        ExitCode::Conflict => ("conflict", false, None),
+        ExitCode::Success | ExitCode::GeneralError | ExitCode::UnsupportedFeature => {
+            ("general_error", false, None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::future::{pending, ready};
+    use std::io;
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use jsonschema::Validator;
+    use rc_core::Result;
+    use rc_core::admin::{
+        CapabilityApi, CapabilityReport, DEFAULT_CLIENT_DEVNULL_BYTES,
+        DEFAULT_CLIENT_DEVNULL_TIMEOUT,
+    };
+    use serde_json::Value;
+
+    use super::*;
+    use crate::output::OutputConfig;
+
+    #[derive(Clone, Copy)]
+    enum StubOutcome {
+        Success,
+        Auth,
+        Network,
+        Unsupported,
+        Pending,
+    }
+
+    struct DropMarker(Arc<AtomicBool>);
+
+    impl Drop for DropMarker {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    struct StubDiagnosticApi {
+        outcome: StubOutcome,
+        calls: Arc<AtomicUsize>,
+        dropped: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl CapabilityApi for StubDiagnosticApi {
+        async fn discover_capabilities(&self, _refresh: bool) -> Result<CapabilityReport> {
+            Err(Error::General("not used by the command layer".to_string()))
+        }
+    }
+
+    #[async_trait]
+    impl DiagnosticApi for StubDiagnosticApi {
+        async fn client_devnull(
+            &self,
+            _request: ClientDevnullRequest,
+        ) -> Result<ClientDevnullResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match self.outcome {
+                StubOutcome::Success => Ok(result()),
+                StubOutcome::Auth => Err(Error::Auth("Access denied".to_string())),
+                StubOutcome::Network => Err(Error::Network("Probe timed out".to_string())),
+                StubOutcome::Unsupported => {
+                    Err(Error::UnsupportedFeature("Probe is stubbed".to_string()))
+                }
+                StubOutcome::Pending => {
+                    let _drop_marker = DropMarker(Arc::clone(&self.dropped));
+                    pending::<()>().await;
+                    Err(Error::General("pending probe completed".to_string()))
+                }
+            }
+        }
+    }
+
+    fn api(outcome: StubOutcome) -> StubDiagnosticApi {
+        StubDiagnosticApi {
+            outcome,
+            calls: Arc::new(AtomicUsize::new(0)),
+            dropped: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn args() -> ClientDevnullArgs {
+        ClientDevnullArgs {
+            alias: "local".to_string(),
+            size: "8MiB".to_string(),
+            timeout: "30s".to_string(),
+            concurrency: 1,
+            yes: true,
+        }
+    }
+
+    fn request() -> ClientDevnullRequest {
+        validate_client_devnull_args(&args()).expect("default arguments should be valid")
+    }
+
+    fn result() -> ClientDevnullResult {
+        ClientDevnullResult {
+            requested_bytes: DEFAULT_CLIENT_DEVNULL_BYTES,
+            received_bytes: DEFAULT_CLIENT_DEVNULL_BYTES,
+            concurrency: 1,
+            elapsed_seconds: 0.5,
+            aggregate_throughput_bytes_per_second: 16_777_216.0,
+        }
+    }
+
+    fn formatter() -> Formatter {
+        Formatter::new(OutputConfig {
+            quiet: true,
+            ..OutputConfig::default()
+        })
+    }
+
+    fn output_v3_validator() -> Validator {
+        let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("schemas/output_v3.json");
+        let schema = std::fs::read_to_string(&schema_path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+        let schema: Value = serde_json::from_str(&schema).expect("output v3 schema should parse");
+        jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+    }
+
+    #[test]
+    fn client_devnull_argument_defaults_and_limits_are_validated() {
+        let request = validate_client_devnull_args(&args()).expect("defaults should be valid");
+        assert_eq!(request.bytes_per_request(), DEFAULT_CLIENT_DEVNULL_BYTES);
+        assert_eq!(request.timeout(), DEFAULT_CLIENT_DEVNULL_TIMEOUT);
+        assert_eq!(request.concurrency(), DEFAULT_CLIENT_DEVNULL_CONCURRENCY);
+
+        let mut invalid = args();
+        invalid.yes = false;
+        assert!(validate_client_devnull_args(&invalid).is_err());
+        invalid = args();
+        invalid.size = "32MiB".to_string();
+        invalid.concurrency = 3;
+        assert!(validate_client_devnull_args(&invalid).is_err());
+        invalid = args();
+        invalid.timeout = "61s".to_string();
+        assert!(validate_client_devnull_args(&invalid).is_err());
+    }
+
+    #[test]
+    fn client_devnull_success_output_satisfies_output_v3() {
+        let value = serde_json::to_value(success_output("local", result()))
+            .expect("success output should serialize");
+        assert_eq!(value["type"], "admin_operations");
+        assert_eq!(
+            value["data"]["operations"][0]["result"]["direction"],
+            "client-to-server"
+        );
+        assert_eq!(
+            value["data"]["operations"][0]["result"]["requested_bytes"],
+            DEFAULT_CLIENT_DEVNULL_BYTES
+        );
+        assert!(output_v3_validator().is_valid(&value));
+    }
+
+    #[test]
+    fn client_devnull_human_output_contains_required_measurements() {
+        let lines = human_result_lines("local", result(), &formatter()).join("\n");
+        for expected in [
+            "Client-to-server",
+            "Requested:",
+            "Received:",
+            "Concurrency: 1",
+            "Elapsed: 0.500 s",
+            "Aggregate upload throughput:",
+        ] {
+            assert!(lines.contains(expected), "missing {expected}: {lines}");
+        }
+    }
+
+    #[tokio::test]
+    async fn client_devnull_preserves_auth_timeout_and_unsupported_exit_codes() {
+        for (outcome, expected) in [
+            (StubOutcome::Auth, ExitCode::AuthError),
+            (StubOutcome::Network, ExitCode::NetworkError),
+            (StubOutcome::Unsupported, ExitCode::UnsupportedFeature),
+        ] {
+            let api = api(outcome);
+            let code = run_client_devnull(
+                "local",
+                request(),
+                &api,
+                &formatter(),
+                pending::<io::Result<()>>(),
+            )
+            .await;
+            assert_eq!(code, expected);
+            assert_eq!(api.calls.load(Ordering::SeqCst), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn client_devnull_interrupt_cancels_in_flight_probe() {
+        let api = api(StubOutcome::Pending);
+        let dropped = Arc::clone(&api.dropped);
+
+        let interrupt = async {
+            tokio::task::yield_now().await;
+            Ok(())
+        };
+        let code = run_client_devnull("local", request(), &api, &formatter(), interrupt).await;
+
+        assert_eq!(code, ExitCode::Interrupted);
+        assert!(dropped.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn client_devnull_ready_interrupt_returns_interrupted_without_starting_probe() {
+        let api = api(StubOutcome::Pending);
+
+        let code = run_client_devnull("local", request(), &api, &formatter(), ready(Ok(()))).await;
+
+        assert_eq!(code, ExitCode::Interrupted);
+        assert_eq!(api.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn client_devnull_interrupt_setup_error_returns_general_error() {
+        let api = api(StubOutcome::Pending);
+
+        let code = run_client_devnull(
+            "local",
+            request(),
+            &api,
+            &formatter(),
+            ready(Err(io::Error::other("signal registration failed"))),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::GeneralError);
+        assert_eq!(api.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn client_devnull_pending_interrupt_allows_success() {
+        let api = api(StubOutcome::Success);
+        let code = run_client_devnull(
+            "local",
+            request(),
+            &api,
+            &formatter(),
+            pending::<io::Result<()>>(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+    }
+
+    #[test]
+    fn client_devnull_error_outputs_satisfy_output_v3() {
+        let validator = output_v3_validator();
+        for (code, unsupported) in [
+            (ExitCode::UsageError, false),
+            (ExitCode::NetworkError, false),
+            (ExitCode::AuthError, false),
+            (ExitCode::Interrupted, false),
+            (ExitCode::UnsupportedFeature, true),
+        ] {
+            let value =
+                serde_json::to_value(error_output(code, "probe failed".to_string(), unsupported))
+                    .expect("error output should serialize");
+            assert!(validator.is_valid(&value), "invalid output: {value}");
+        }
+    }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -37,7 +37,7 @@ pub enum AdminCommands {
     /// Discover effective RustFS runtime capabilities
     Capabilities(capabilities::CapabilitiesArgs),
 
-    /// Read bounded RustFS diagnostic snapshots
+    /// Read bounded snapshots or run explicitly confirmed RustFS diagnostic probes
     #[command(subcommand)]
     Diagnostics(diagnostics::DiagnosticsCommands),
 
@@ -264,7 +264,7 @@ mod tests {
     use super::*;
     use clap::Parser;
 
-    #[derive(Parser)]
+    #[derive(Debug, Parser)]
     struct TestCli {
         #[command(subcommand)]
         command: AdminCommands,
@@ -460,6 +460,42 @@ mod tests {
                 _ => panic!("Unexpected command parsing result"),
             }
         }
+    }
+
+    #[test]
+    fn test_parse_admin_diagnostics_client_devnull_options() {
+        let cli = TestCli::parse_from([
+            "rc",
+            "diagnostics",
+            "client-devnull",
+            "local",
+            "--size",
+            "16MiB",
+            "--timeout",
+            "45s",
+            "--concurrency",
+            "2",
+            "--yes",
+        ]);
+
+        match cli.command {
+            AdminCommands::Diagnostics(diagnostics::DiagnosticsCommands::ClientDevnull(args)) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.size, "16MiB");
+                assert_eq!(args.timeout, "45s");
+                assert_eq!(args.concurrency, 2);
+                assert!(args.yes);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_diagnostics_client_devnull_requires_confirmation() {
+        let error = TestCli::try_parse_from(["rc", "diagnostics", "client-devnull", "local"])
+            .expect_err("client devnull must require --yes");
+
+        assert!(error.to_string().contains("--yes"));
     }
 
     #[test]

--- a/crates/cli/tests/admin_diagnostics.rs
+++ b/crates/cli/tests/admin_diagnostics.rs
@@ -1,0 +1,99 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_sequence_test_server};
+use jsonschema::Validator;
+use serde_json::Value;
+
+const INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const RUNTIME_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled"},"memory_sampling":{"state":"unsupported"},"platform":{"state":"supported"},"topology":{"state":"supported"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"supported"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"supported"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+const DEVNULL_RESPONSE: &str = r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":131072.0,"rx_bytes":65536,"duration_secs":0.5}"#;
+
+fn output_v3_validator() -> Validator {
+    let schema_path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("schemas/output_v3.json");
+    let schema = std::fs::read_to_string(&schema_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+    let schema: Value = serde_json::from_str(&schema).expect("output v3 schema should parse");
+    jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+}
+
+#[test]
+fn client_devnull_json_runs_bounded_preflight_and_upload() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", DEVNULL_RESPONSE),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "diagnostics",
+            "client-devnull",
+            "myalias",
+            "--size",
+            "64KiB",
+            "--timeout",
+            "5s",
+            "--concurrency",
+            "1",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    let result = &value["data"]["operations"][0]["result"];
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "admin_operations");
+    assert_eq!(result["direction"], "client-to-server");
+    assert_eq!(result["requested_bytes"], 65_536);
+    assert_eq!(result["received_bytes"], 65_536);
+    assert_eq!(result["concurrency"], 1);
+    assert!(output_v3_validator().is_valid(&value));
+
+    let requests = (0..5)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured admin request")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.target.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "/rustfs/admin/v3/info",
+            "/rustfs/admin/v4/runtime/capabilities",
+            "/rustfs/admin/v4/extensions/catalog",
+            "/rustfs/admin/v4/cluster/snapshot",
+            "/rustfs/admin/v3/speedtest/client/devnull",
+        ]
+    );
+    assert_eq!(requests[4].method, "POST");
+    assert_eq!(requests[4].body.len(), 65_536);
+    assert!(requests[4].headers.contains("content-length: 65536"));
+    handle.join().expect("admin test server finished");
+}

--- a/crates/cli/tests/admin_support/mod.rs
+++ b/crates/cli/tests/admin_support/mod.rs
@@ -5,12 +5,14 @@ use std::sync::mpsc::{self, Receiver};
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, Instant};
 
-#[derive(Debug)]
 #[allow(dead_code)]
+#[derive(Debug)]
 pub struct CapturedAdminRequest {
     #[allow(dead_code)]
     pub method: String,
     pub target: String,
+    #[allow(dead_code)]
+    pub headers: String,
     #[allow(dead_code)]
     pub body: Vec<u8>,
 }
@@ -77,12 +79,12 @@ fn read_admin_request(stream: &mut TcpStream) -> CapturedAdminRequest {
     let mut parts = request_line.split_whitespace();
     let method = parts.next().expect("request method").to_string();
     let target = parts.next().expect("request target").to_string();
-
     let body = request[header_end..header_end + content_length].to_vec();
 
     CapturedAdminRequest {
         method,
         target,
+        headers,
         body,
     }
 }

--- a/crates/core/src/admin/diagnostics.rs
+++ b/crates/core/src/admin/diagnostics.rs
@@ -1,12 +1,13 @@
 //! Bounded read-only diagnostic snapshot contracts.
 
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 
-use crate::Result;
+use crate::{Error, Result};
 
 use super::RuntimeCapabilityStatus;
 
@@ -233,10 +234,143 @@ pub struct ClusterUsageSnapshot {
     pub extra: BTreeMap<String, Value>,
 }
 
+/// Default bytes uploaded by each client-devnull request.
+pub const DEFAULT_CLIENT_DEVNULL_BYTES: u64 = 8 * 1024 * 1024;
+/// Maximum bytes uploaded across all concurrent client-devnull requests.
+pub const MAX_CLIENT_DEVNULL_AGGREGATE_BYTES: u64 = 64 * 1024 * 1024;
+/// Default number of concurrent client-devnull requests.
+pub const DEFAULT_CLIENT_DEVNULL_CONCURRENCY: u8 = 1;
+/// Maximum number of concurrent client-devnull requests.
+pub const MAX_CLIENT_DEVNULL_CONCURRENCY: u8 = 4;
+/// Default active probe timeout.
+pub const DEFAULT_CLIENT_DEVNULL_TIMEOUT: Duration = Duration::from_secs(30);
+/// Maximum active probe timeout.
+pub const MAX_CLIENT_DEVNULL_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Validated limits for one bounded client-to-server devnull probe.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClientDevnullRequest {
+    bytes_per_request: u64,
+    total_bytes: u64,
+    concurrency: u8,
+    timeout: Duration,
+}
+
+impl ClientDevnullRequest {
+    /// Validate probe limits before any server request is made.
+    pub fn new(bytes_per_request: u64, concurrency: u8, timeout: Duration) -> Result<Self> {
+        if bytes_per_request == 0 {
+            return Err(Error::Config(
+                "Client devnull size must be greater than zero".to_string(),
+            ));
+        }
+        if !(1..=MAX_CLIENT_DEVNULL_CONCURRENCY).contains(&concurrency) {
+            return Err(Error::Config(format!(
+                "Client devnull concurrency must be between 1 and {MAX_CLIENT_DEVNULL_CONCURRENCY}"
+            )));
+        }
+        let total_bytes = bytes_per_request
+            .checked_mul(u64::from(concurrency))
+            .ok_or_else(|| {
+                Error::Config("Client devnull aggregate size is too large".to_string())
+            })?;
+        if total_bytes > MAX_CLIENT_DEVNULL_AGGREGATE_BYTES {
+            return Err(Error::Config(format!(
+                "Client devnull aggregate size must not exceed {MAX_CLIENT_DEVNULL_AGGREGATE_BYTES} bytes"
+            )));
+        }
+        if timeout < Duration::from_secs(1) || timeout > MAX_CLIENT_DEVNULL_TIMEOUT {
+            return Err(Error::Config(format!(
+                "Client devnull timeout must be between 1 and {} seconds",
+                MAX_CLIENT_DEVNULL_TIMEOUT.as_secs()
+            )));
+        }
+
+        Ok(Self {
+            bytes_per_request,
+            total_bytes,
+            concurrency,
+            timeout,
+        })
+    }
+
+    /// Bytes sent by each concurrent request.
+    pub const fn bytes_per_request(self) -> u64 {
+        self.bytes_per_request
+    }
+
+    /// Aggregate bytes sent by all requests.
+    pub const fn total_bytes(self) -> u64 {
+        self.total_bytes
+    }
+
+    /// Number of concurrent requests.
+    pub const fn concurrency(self) -> u8 {
+        self.concurrency
+    }
+
+    /// Maximum duration of the active probe.
+    pub const fn timeout(self) -> Duration {
+        self.timeout
+    }
+}
+
+/// Validated aggregate result from a client-to-server devnull probe.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ClientDevnullResult {
+    pub requested_bytes: u64,
+    pub received_bytes: u64,
+    pub concurrency: u8,
+    pub elapsed_seconds: f64,
+    pub aggregate_throughput_bytes_per_second: f64,
+}
+
 /// Read-only diagnostic adapter boundary.
 #[async_trait]
 pub trait DiagnosticReadApi: Send + Sync {
     async fn health_snapshot(&self) -> Result<DetailedHealthSnapshot>;
     async fn cluster_snapshot(&self) -> Result<ClusterSnapshotDocument>;
     async fn extensions_catalog(&self) -> Result<super::ExtensionsCatalog>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_devnull_defaults_match_the_bounded_probe_contract() {
+        assert_eq!(DEFAULT_CLIENT_DEVNULL_BYTES, 8 * 1024 * 1024);
+        assert_eq!(MAX_CLIENT_DEVNULL_AGGREGATE_BYTES, 64 * 1024 * 1024);
+        assert_eq!(DEFAULT_CLIENT_DEVNULL_TIMEOUT, Duration::from_secs(30));
+        assert_eq!(DEFAULT_CLIENT_DEVNULL_CONCURRENCY, 1);
+    }
+
+    #[test]
+    fn client_devnull_request_accepts_the_maximum_aggregate_payload() {
+        let request = ClientDevnullRequest::new(16 * 1024 * 1024, 4, Duration::from_secs(60))
+            .expect("maximum aggregate payload should be valid");
+
+        assert_eq!(request.bytes_per_request(), 16 * 1024 * 1024);
+        assert_eq!(request.total_bytes(), 64 * 1024 * 1024);
+        assert_eq!(request.concurrency(), 4);
+        assert_eq!(request.timeout(), Duration::from_secs(60));
+    }
+
+    #[test]
+    fn client_devnull_request_rejects_invalid_limits() {
+        for (bytes, concurrency, timeout) in [
+            (0, 1, Duration::from_secs(30)),
+            (8 * 1024 * 1024, 0, Duration::from_secs(30)),
+            (8 * 1024 * 1024, 5, Duration::from_secs(30)),
+            (32 * 1024 * 1024, 3, Duration::from_secs(30)),
+            (8 * 1024 * 1024, 1, Duration::ZERO),
+            (8 * 1024 * 1024, 1, Duration::from_millis(999)),
+            (8 * 1024 * 1024, 1, Duration::from_secs(61)),
+        ] {
+            assert!(
+                ClientDevnullRequest::new(bytes, concurrency, timeout).is_err(),
+                "bytes={bytes}, concurrency={concurrency}, timeout={timeout:?}"
+            );
+        }
+    }
 }

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -29,10 +29,13 @@ pub use cluster::{
     UsageInfo,
 };
 pub use diagnostics::{
-    ClusterComponentSnapshot, ClusterComponentSnapshots, ClusterListingSnapshot,
-    ClusterSnapshotDocument, ClusterUsageSnapshot, DetailedHealthSnapshot,
-    DiagnosticClusterSnapshot, DiagnosticClusterSummary, DiagnosticReadApi, HealthCpuSnapshot,
-    HealthDriveSnapshot, HealthMemorySnapshot, HealthOsSnapshot, HealthProcessSnapshot,
+    ClientDevnullRequest, ClientDevnullResult, ClusterComponentSnapshot, ClusterComponentSnapshots,
+    ClusterListingSnapshot, ClusterSnapshotDocument, ClusterUsageSnapshot,
+    DEFAULT_CLIENT_DEVNULL_BYTES, DEFAULT_CLIENT_DEVNULL_CONCURRENCY,
+    DEFAULT_CLIENT_DEVNULL_TIMEOUT, DetailedHealthSnapshot, DiagnosticClusterSnapshot,
+    DiagnosticClusterSummary, DiagnosticReadApi, HealthCpuSnapshot, HealthDriveSnapshot,
+    HealthMemorySnapshot, HealthOsSnapshot, HealthProcessSnapshot,
+    MAX_CLIENT_DEVNULL_AGGREGATE_BYTES, MAX_CLIENT_DEVNULL_CONCURRENCY, MAX_CLIENT_DEVNULL_TIMEOUT,
     MAX_DIAGNOSTIC_RESPONSE_BYTES,
 };
 pub use kms::{
@@ -320,6 +323,13 @@ pub trait AdminApi: Send + Sync {
 pub trait CapabilityApi: Send + Sync {
     /// Discover capabilities, bypassing the process cache when `refresh` is true.
     async fn discover_capabilities(&self, refresh: bool) -> Result<CapabilityReport>;
+}
+
+/// Bounded active RustFS diagnostic probes.
+#[async_trait]
+pub trait DiagnosticApi: CapabilityApi {
+    /// Measure client-to-server upload throughput without persisting an object.
+    async fn client_devnull(&self, request: ClientDevnullRequest) -> Result<ClientDevnullResult>;
 }
 
 #[cfg(test)]

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -4308,7 +4308,7 @@ mod tests {
         let task = tokio::spawn(async move { client.client_devnull(request).await });
         tokio::task::spawn_blocking(move || {
             accepted_receiver
-                .recv_timeout(Duration::from_secs(5))
+                .recv_timeout(Duration::from_secs(15))
                 .expect("active request accepted")
         })
         .await
@@ -4320,7 +4320,7 @@ mod tests {
         release_sender.send(()).expect("release test server");
 
         let (content_length, received) = result_receiver
-            .recv_timeout(Duration::from_secs(5))
+            .recv_timeout(Duration::from_secs(15))
             .expect("cancellation result");
         assert_eq!(content_length, 64 * 1024 * 1024);
         assert!(

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -3,6 +3,8 @@
 //! This module provides the AdminClient that implements the AdminApi trait
 //! using HTTP requests with AWS SigV4 signing.
 
+mod diagnostics;
+
 use async_trait::async_trait;
 use aws_credential_types::Credentials;
 use aws_sigv4::http_request::{
@@ -49,6 +51,11 @@ impl AsRef<[u8]> for SensitiveRequestBody {
         self.0.as_slice()
     }
 }
+
+#[cfg(test)]
+use diagnostics::{
+    CLIENT_DEVNULL_CHUNK_BYTES, client_devnull_payload_hash, next_client_devnull_chunk,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CapabilityCacheKey {
@@ -245,6 +252,17 @@ impl AdminClient {
         headers: &HeaderMap,
         body: &[u8],
     ) -> Result<HeaderMap> {
+        self.sign_request_with_body(method, url, headers, SignableBody::Bytes(body))
+            .await
+    }
+
+    async fn sign_request_with_body(
+        &self,
+        method: &Method,
+        url: &str,
+        headers: &HeaderMap,
+        signable_body: SignableBody<'_>,
+    ) -> Result<HeaderMap> {
         if self.anonymous {
             return Ok(headers.clone());
         }
@@ -275,8 +293,6 @@ impl AdminClient {
             .iter()
             .filter_map(|(k, v)| v.to_str().ok().map(|v| (k.as_str(), v)))
             .collect();
-
-        let signable_body = SignableBody::Bytes(body);
 
         let signable_request = SignableRequest::new(
             method.as_str(),
@@ -3398,6 +3414,7 @@ impl ReplicationDiffApi for AdminClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rc_core::admin::{ClientDevnullRequest, DiagnosticApi};
     use std::io::{Read, Write};
     use std::net::{TcpListener, TcpStream};
     use std::sync::mpsc;
@@ -3454,6 +3471,29 @@ mod tests {
             headers,
             body,
         }
+    }
+
+    fn read_admin_request_head(stream: &mut TcpStream) -> (String, usize, usize) {
+        let mut buffer = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        let header_end = loop {
+            let read = stream.read(&mut chunk).expect("read HTTP request headers");
+            assert!(read > 0, "client closed connection before headers");
+            buffer.extend_from_slice(&chunk[..read]);
+            if let Some(position) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+                break position + 4;
+            }
+        };
+        let headers = String::from_utf8_lossy(&buffer[..header_end]).into_owned();
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().expect("valid content length"))
+            })
+            .unwrap_or(0);
+        (headers, content_length, buffer.len() - header_end)
     }
 
     fn start_admin_test_server(
@@ -3674,6 +3714,36 @@ mod tests {
         (endpoint, receiver, handle)
     }
 
+    fn start_client_devnull_raw_response_server(
+        raw_response: Vec<u8>,
+    ) -> (String, thread::JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let handle = thread::spawn(move || {
+            for response_body in [
+                CAPABILITY_INFO_RESPONSE,
+                RUNTIME_CAPABILITIES_RESPONSE,
+                EXTENSIONS_RESPONSE,
+                CLUSTER_SNAPSHOT_RESPONSE,
+            ] {
+                let (mut stream, _) = listener.accept().expect("accept discovery request");
+                let _request = read_admin_request(&mut stream);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write discovery response");
+            }
+
+            let (mut stream, _) = listener.accept().expect("accept active request");
+            let _request = read_admin_request(&mut stream);
+            let _write_result = stream.write_all(&raw_response);
+        });
+        (endpoint, handle)
+    }
+
     fn admin_client_for_endpoint(endpoint: &str) -> AdminClient {
         let alias = Alias::new("test", endpoint, "access", "secret");
         AdminClient::new(&alias).expect("admin client should build")
@@ -3723,6 +3793,7 @@ mod tests {
     const RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
     const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[{"schema_version":"rustfs.extension-schema.v1","extension_id":"ops.diagnostics","display_name":"Operations Diagnostics","provider":"rustfs","version":"1","kind":"ops_diagnostics","runtime":{"api_version":"v1","boundary":"builtin"},"capabilities":[],"disabled_by_default":false}],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
     const CLUSTER_SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+    const CLIENT_DEVNULL_RESPONSE: &str = r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":65536,"duration_secs":0.5}"#;
 
     #[tokio::test]
     async fn capability_discovery_uses_v4_routes_and_classifies_beta10_stubs() {
@@ -3882,6 +3953,399 @@ mod tests {
         assert!(is_rustfs_beta_10("rustfs/v1.0.0-beta.10+build.7"));
         assert!(!is_rustfs_beta_10("1.0.0-beta.100"));
         assert!(!is_rustfs_beta_10("1.0.0-beta.9"));
+    }
+
+    #[tokio::test]
+    async fn client_devnull_streams_exact_signed_payloads_and_aggregates_measurements() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+            ("200 OK", CLIENT_DEVNULL_RESPONSE),
+            ("200 OK", CLIENT_DEVNULL_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = ClientDevnullRequest::new(65_536, 2, Duration::from_secs(5))
+            .expect("probe request should be valid");
+
+        let result = client
+            .client_devnull(request)
+            .await
+            .expect("client devnull should succeed");
+
+        assert_eq!(result.requested_bytes, 131_072);
+        assert_eq!(result.received_bytes, 131_072);
+        assert_eq!(result.concurrency, 2);
+        assert!(result.elapsed_seconds > 0.0);
+        assert!(result.elapsed_seconds < 5.0);
+        assert_eq!(
+            result.aggregate_throughput_bytes_per_second,
+            result.received_bytes as f64 / result.elapsed_seconds
+        );
+
+        let captured = (0..6)
+            .map(|_| receiver.recv().expect("captured request"))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            captured
+                .iter()
+                .map(|request| request.target.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "/rustfs/admin/v3/info",
+                "/rustfs/admin/v4/runtime/capabilities",
+                "/rustfs/admin/v4/extensions/catalog",
+                "/rustfs/admin/v4/cluster/snapshot",
+                "/rustfs/admin/v3/speedtest/client/devnull",
+                "/rustfs/admin/v3/speedtest/client/devnull",
+            ]
+        );
+        for request in &captured[4..] {
+            assert_eq!(request.method, "POST");
+            assert_eq!(request.body.len(), 65_536);
+            assert!(request.body.iter().all(|byte| *byte == 0));
+            assert!(request.headers.contains("content-length: 65536"));
+            assert!(request.headers.contains(&format!(
+                "x-amz-content-sha256: {}",
+                AdminClient::sha256_hash(&request.body)
+            )));
+        }
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn client_devnull_rejects_placeholder_and_mismatched_responses() {
+        for response in [
+            r#"{"kind":"client-devnull","measured":false,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":65536,"duration_secs":0.5}"#,
+            r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":1,"duration_secs":0.5}"#,
+            r#"{"kind":"object","measured":true,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":65536,"duration_secs":0.5}"#,
+            r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":0.0,"rx_bytes":65536,"duration_secs":0.5}"#,
+            r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":65536,"duration_secs":0.0}"#,
+            r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":65536}"#,
+            r#"{"kind":"client-devnull","measured":true,"rx_bytes":65536,"duration_secs":0.5}"#,
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+                ("200 OK", CAPABILITY_INFO_RESPONSE),
+                ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+                ("200 OK", EXTENSIONS_RESPONSE),
+                ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+                ("200 OK", response),
+            ]);
+            let client = admin_client_for_endpoint(&endpoint);
+            let request = ClientDevnullRequest::new(65_536, 1, Duration::from_secs(5))
+                .expect("probe request should be valid");
+
+            let error = client
+                .client_devnull(request)
+                .await
+                .expect_err("placeholder responses must not succeed");
+
+            assert!(matches!(error, Error::UnsupportedFeature(_)));
+            handle.join().expect("server thread should finish");
+        }
+    }
+
+    #[tokio::test]
+    async fn client_devnull_fails_closed_before_active_request_on_unknown_version() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", UNKNOWN_CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = ClientDevnullRequest::new(65_536, 1, Duration::from_secs(5))
+            .expect("probe request should be valid");
+
+        let error = client
+            .client_devnull(request)
+            .await
+            .expect_err("unknown capability must fail closed");
+
+        assert!(matches!(error, Error::UnsupportedFeature(_)));
+        let targets = (0..4)
+            .map(|_| receiver.recv().expect("captured request").target)
+            .collect::<Vec<_>>();
+        assert!(!targets.iter().any(|target| target.contains("devnull")));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn client_devnull_preserves_permission_denial() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+            ("403 Forbidden", r#"{"code":"AccessDenied"}"#),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = ClientDevnullRequest::new(65_536, 1, Duration::from_secs(5))
+            .expect("probe request should be valid");
+
+        let error = client
+            .client_devnull(request)
+            .await
+            .expect_err("permission denial must not be reclassified");
+
+        assert!(matches!(error, Error::Auth(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn client_devnull_timeout_stops_incremental_body_generation() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            for response_body in [
+                CAPABILITY_INFO_RESPONSE,
+                RUNTIME_CAPABILITIES_RESPONSE,
+                EXTENSIONS_RESPONSE,
+                CLUSTER_SNAPSHOT_RESPONSE,
+            ] {
+                let (mut stream, _) = listener.accept().expect("accept discovery request");
+                let _request = read_admin_request(&mut stream);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write discovery response");
+            }
+
+            let (mut stream, _) = listener.accept().expect("accept active request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+            let (_headers, content_length, mut received) = read_admin_request_head(&mut stream);
+            thread::sleep(Duration::from_millis(1_200));
+            let mut chunk = [0_u8; 8192];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(read) => received += read,
+                }
+            }
+            sender
+                .send((content_length, received))
+                .expect("send upload byte counts");
+        });
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = ClientDevnullRequest::new(64 * 1024 * 1024, 1, Duration::from_secs(1))
+            .expect("probe request should be valid");
+
+        let error = client
+            .client_devnull(request)
+            .await
+            .expect_err("stalled upload must time out");
+
+        assert!(matches!(error, Error::Network(message) if message.contains("timed out")));
+        let (content_length, received) = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("upload byte counts");
+        assert_eq!(content_length, 64 * 1024 * 1024);
+        assert!(
+            received < content_length,
+            "received {received} of {content_length}"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn client_devnull_does_not_retry_server_failures() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            for response_body in [
+                CAPABILITY_INFO_RESPONSE,
+                RUNTIME_CAPABILITIES_RESPONSE,
+                EXTENSIONS_RESPONSE,
+                CLUSTER_SNAPSHOT_RESPONSE,
+            ] {
+                let (mut stream, _) = listener.accept().expect("accept discovery request");
+                let _request = read_admin_request(&mut stream);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write discovery response");
+            }
+
+            let (mut stream, _) = listener.accept().expect("accept active request");
+            let request = read_admin_request(&mut stream);
+            assert_eq!(request.target, "/rustfs/admin/v3/speedtest/client/devnull");
+            stream
+                .write_all(
+                    b"HTTP/1.1 503 Service Unavailable\r\ncontent-length: 4\r\nconnection: close\r\n\r\nbusy",
+                )
+                .expect("write active response");
+
+            listener
+                .set_nonblocking(true)
+                .expect("set listener nonblocking");
+            let deadline = std::time::Instant::now() + Duration::from_millis(300);
+            let mut active_requests = 1;
+            while std::time::Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((_stream, _)) => active_requests += 1,
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("accept retry request: {error}"),
+                }
+            }
+            sender
+                .send(active_requests)
+                .expect("send active request count");
+        });
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = ClientDevnullRequest::new(65_536, 1, Duration::from_secs(5))
+            .expect("probe request should be valid");
+
+        let error = client
+            .client_devnull(request)
+            .await
+            .expect_err("server failure must be returned");
+
+        assert!(matches!(error, Error::Network(_)));
+        assert_eq!(
+            receiver
+                .recv_timeout(Duration::from_secs(2))
+                .expect("active request count"),
+            1
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn client_devnull_rejects_declared_and_chunked_response_overflow() {
+        let declared = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            64 * 1024 + 1
+        )
+        .into_bytes();
+        let first_chunk = vec![b'a'; 32 * 1024];
+        let second_chunk = vec![b'b'; 32 * 1024 + 1];
+        let mut chunked =
+            b"HTTP/1.1 200 OK\r\ntransfer-encoding: chunked\r\nconnection: close\r\n\r\n".to_vec();
+        chunked.extend_from_slice(format!("{:x}\r\n", first_chunk.len()).as_bytes());
+        chunked.extend_from_slice(&first_chunk);
+        chunked.extend_from_slice(b"\r\n");
+        chunked.extend_from_slice(format!("{:x}\r\n", second_chunk.len()).as_bytes());
+        chunked.extend_from_slice(&second_chunk);
+        chunked.extend_from_slice(b"\r\n0\r\n\r\n");
+
+        for raw_response in [declared, chunked] {
+            let (endpoint, handle) = start_client_devnull_raw_response_server(raw_response);
+            let client = admin_client_for_endpoint(&endpoint);
+            let request = ClientDevnullRequest::new(65_536, 1, Duration::from_secs(5))
+                .expect("probe request should be valid");
+
+            let error = client
+                .client_devnull(request)
+                .await
+                .expect_err("oversized responses must be rejected");
+
+            assert!(
+                matches!(error, Error::UnsupportedFeature(message) if message.contains("exceeded"))
+            );
+            handle.join().expect("server thread should finish");
+        }
+    }
+
+    #[tokio::test]
+    async fn aborting_client_devnull_closes_an_incomplete_upload() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (accepted_sender, accepted_receiver) = mpsc::channel();
+        let (release_sender, release_receiver) = mpsc::channel();
+        let (result_sender, result_receiver) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            for response_body in [
+                CAPABILITY_INFO_RESPONSE,
+                RUNTIME_CAPABILITIES_RESPONSE,
+                EXTENSIONS_RESPONSE,
+                CLUSTER_SNAPSHOT_RESPONSE,
+            ] {
+                let (mut stream, _) = listener.accept().expect("accept discovery request");
+                let _request = read_admin_request(&mut stream);
+                let response = format!(
+                    "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{response_body}",
+                    response_body.len()
+                );
+                stream
+                    .write_all(response.as_bytes())
+                    .expect("write discovery response");
+            }
+
+            let (mut stream, _) = listener.accept().expect("accept active request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+            let (_headers, content_length, mut received) = read_admin_request_head(&mut stream);
+            accepted_sender.send(()).expect("signal active request");
+            release_receiver.recv().expect("wait for cancellation");
+            let mut chunk = [0_u8; 8192];
+            loop {
+                match stream.read(&mut chunk) {
+                    Ok(0) | Err(_) => break,
+                    Ok(read) => received += read,
+                }
+            }
+            result_sender
+                .send((content_length, received))
+                .expect("send cancellation result");
+        });
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = ClientDevnullRequest::new(64 * 1024 * 1024, 1, Duration::from_secs(60))
+            .expect("probe request should be valid");
+        let task = tokio::spawn(async move { client.client_devnull(request).await });
+        tokio::task::spawn_blocking(move || {
+            accepted_receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("active request accepted")
+        })
+        .await
+        .expect("accept wait task");
+
+        task.abort();
+        let join_error = task.await.expect_err("aborted task must not complete");
+        assert!(join_error.is_cancelled());
+        release_sender.send(()).expect("release test server");
+
+        let (content_length, received) = result_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("cancellation result");
+        assert_eq!(content_length, 64 * 1024 * 1024);
+        assert!(
+            received < content_length,
+            "received {received} of {content_length}"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[test]
+    fn client_devnull_chunks_and_hash_are_bounded_and_exact() {
+        let mut remaining = 2 * CLIENT_DEVNULL_CHUNK_BYTES as u64 + 17;
+        let mut generated = 0_u64;
+        while let Some((chunk, next_remaining)) = next_client_devnull_chunk(remaining) {
+            assert!(chunk.len() <= CLIENT_DEVNULL_CHUNK_BYTES);
+            assert!(chunk.iter().all(|byte| *byte == 0));
+            generated += chunk.len() as u64;
+            remaining = next_remaining;
+        }
+
+        assert_eq!(generated, 2 * CLIENT_DEVNULL_CHUNK_BYTES as u64 + 17);
+        assert_eq!(
+            client_devnull_payload_hash(3),
+            AdminClient::sha256_hash(&[0, 0, 0])
+        );
     }
 
     #[tokio::test]

--- a/crates/s3/src/admin/diagnostics.rs
+++ b/crates/s3/src/admin/diagnostics.rs
@@ -1,0 +1,248 @@
+use std::io;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::try_join_all;
+use futures::{StreamExt, stream};
+use rc_core::admin::{
+    CapabilityApi, ClientDevnullRequest, ClientDevnullResult, DiagnosticApi, DiagnosticCapability,
+};
+use rc_core::{Error, Result};
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, HOST, HeaderMap, HeaderValue};
+use reqwest::{Body, Method, Response, StatusCode};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use super::AdminClient;
+use aws_sigv4::http_request::SignableBody;
+
+pub(super) const CLIENT_DEVNULL_CHUNK_BYTES: usize = 64 * 1024;
+const MAX_CLIENT_DEVNULL_RESPONSE_BYTES: usize = 64 * 1024;
+static CLIENT_DEVNULL_ZERO_CHUNK: [u8; CLIENT_DEVNULL_CHUNK_BYTES] =
+    [0; CLIENT_DEVNULL_CHUNK_BYTES];
+
+#[derive(Debug, Deserialize)]
+struct ClientDevnullResponse {
+    kind: String,
+    measured: bool,
+    capability_note: Option<String>,
+    rx_bytes: Option<u64>,
+    duration_secs: Option<f64>,
+    aggregate_write_throughput_bytes_per_sec: Option<f64>,
+}
+
+pub(super) fn next_client_devnull_chunk(remaining: u64) -> Option<(Bytes, u64)> {
+    if remaining == 0 {
+        return None;
+    }
+
+    let chunk_len = remaining.min(CLIENT_DEVNULL_CHUNK_BYTES as u64) as usize;
+    Some((
+        Bytes::from_static(&CLIENT_DEVNULL_ZERO_CHUNK[..chunk_len]),
+        remaining - chunk_len as u64,
+    ))
+}
+
+pub(super) fn client_devnull_payload_hash(bytes: u64) -> String {
+    let mut hasher = Sha256::new();
+    let mut remaining = bytes;
+    while let Some((chunk, next_remaining)) = next_client_devnull_chunk(remaining) {
+        hasher.update(&chunk);
+        remaining = next_remaining;
+    }
+    hex::encode(hasher.finalize())
+}
+
+fn client_devnull_body(bytes: u64) -> Body {
+    let chunks = stream::unfold(bytes, |remaining| async move {
+        next_client_devnull_chunk(remaining)
+            .map(|(chunk, next_remaining)| (Ok::<Bytes, io::Error>(chunk), next_remaining))
+    });
+    Body::wrap_stream(chunks)
+}
+
+impl AdminClient {
+    fn client_devnull_headers(&self, bytes: u64, payload_hash: &str) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            CONTENT_LENGTH,
+            HeaderValue::from_str(&bytes.to_string())
+                .map_err(|error| Error::Auth(format!("Invalid content length header: {error}")))?,
+        );
+        headers.insert(
+            "x-amz-content-sha256",
+            HeaderValue::from_str(payload_hash)
+                .map_err(|error| Error::Auth(format!("Invalid content hash header: {error}")))?,
+        );
+        headers.insert(
+            HOST,
+            HeaderValue::from_str(&self.get_host())
+                .map_err(|error| Error::Auth(format!("Invalid host header: {error}")))?,
+        );
+        headers.insert(
+            CONTENT_TYPE,
+            HeaderValue::from_static("application/octet-stream"),
+        );
+        Ok(headers)
+    }
+
+    async fn client_devnull_once(&self, bytes: u64, payload_hash: &str) -> Result<u64> {
+        let method = Method::POST;
+        let url = self.admin_url("/speedtest/client/devnull");
+        let headers = self.client_devnull_headers(bytes, payload_hash)?;
+        let signed_headers = self
+            .sign_request_with_body(
+                &method,
+                &url,
+                &headers,
+                SignableBody::Precomputed(payload_hash.to_string()),
+            )
+            .await?;
+
+        let response = self
+            .http_client
+            .request(method, url)
+            .headers(signed_headers)
+            .body(client_devnull_body(bytes))
+            .send()
+            .await
+            .map_err(|error| Error::Network(format!("Client devnull request failed: {error}")))?;
+        let (status, response_body) = self.read_client_devnull_response(response).await?;
+        if !status.is_success() {
+            return Err(self.map_error(status, &String::from_utf8_lossy(&response_body)));
+        }
+
+        let response: ClientDevnullResponse =
+            serde_json::from_slice(&response_body).map_err(|error| {
+                Error::UnsupportedFeature(format!(
+                    "Client devnull response is not a valid measurement: {error}"
+                ))
+            })?;
+        validate_client_devnull_response(response, bytes)
+    }
+
+    async fn read_client_devnull_response(
+        &self,
+        response: Response,
+    ) -> Result<(StatusCode, Vec<u8>)> {
+        let status = response.status();
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_CLIENT_DEVNULL_RESPONSE_BYTES as u64)
+        {
+            return Err(self.client_devnull_response_overflow(status));
+        }
+
+        let mut body = Vec::new();
+        let mut chunks = response.bytes_stream();
+        while let Some(chunk) = chunks.next().await {
+            let chunk = chunk.map_err(|error| {
+                Error::Network(format!("Failed to read client devnull response: {error}"))
+            })?;
+            if body.len().saturating_add(chunk.len()) > MAX_CLIENT_DEVNULL_RESPONSE_BYTES {
+                return Err(self.client_devnull_response_overflow(status));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok((status, body))
+    }
+
+    fn client_devnull_response_overflow(&self, status: StatusCode) -> Error {
+        let message =
+            format!("Client devnull response exceeded {MAX_CLIENT_DEVNULL_RESPONSE_BYTES} bytes");
+        if status.is_success() {
+            Error::UnsupportedFeature(message)
+        } else {
+            self.map_error(status, &message)
+        }
+    }
+
+    async fn run_client_devnull(
+        &self,
+        request: ClientDevnullRequest,
+    ) -> Result<ClientDevnullResult> {
+        let payload_hash = client_devnull_payload_hash(request.bytes_per_request());
+        let started = Instant::now();
+        let requests = (0..request.concurrency())
+            .map(|_| self.client_devnull_once(request.bytes_per_request(), payload_hash.as_str()));
+        let received = tokio::time::timeout(request.timeout(), try_join_all(requests))
+            .await
+            .map_err(|_| {
+                Error::Network(format!(
+                    "Client devnull probe timed out after {} seconds",
+                    request.timeout().as_secs()
+                ))
+            })??;
+        let elapsed_seconds = started.elapsed().as_secs_f64().max(f64::MIN_POSITIVE);
+        let received_bytes = received.into_iter().sum();
+
+        Ok(ClientDevnullResult {
+            requested_bytes: request.total_bytes(),
+            received_bytes,
+            concurrency: request.concurrency(),
+            elapsed_seconds,
+            aggregate_throughput_bytes_per_second: received_bytes as f64 / elapsed_seconds,
+        })
+    }
+}
+
+fn validate_client_devnull_response(
+    response: ClientDevnullResponse,
+    expected_bytes: u64,
+) -> Result<u64> {
+    let unsupported = |reason: String| {
+        let note = response
+            .capability_note
+            .as_deref()
+            .map(|note| format!(" ({note})"))
+            .unwrap_or_default();
+        Error::UnsupportedFeature(format!(
+            "Client devnull measurement is unavailable: {reason}{note}"
+        ))
+    };
+
+    if response.kind != "client-devnull" {
+        return Err(unsupported(format!(
+            "unexpected response kind '{}'",
+            response.kind
+        )));
+    }
+    if !response.measured {
+        return Err(unsupported("server returned measured=false".to_string()));
+    }
+    let received_bytes = response
+        .rx_bytes
+        .ok_or_else(|| unsupported("rx_bytes is missing".to_string()))?;
+    if received_bytes != expected_bytes {
+        return Err(unsupported(format!(
+            "server received {received_bytes} bytes, expected {expected_bytes}"
+        )));
+    }
+    let duration = response
+        .duration_secs
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .ok_or_else(|| unsupported("duration_secs must be finite and positive".to_string()))?;
+    let throughput = response
+        .aggregate_write_throughput_bytes_per_sec
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .ok_or_else(|| {
+            unsupported(
+                "aggregate_write_throughput_bytes_per_sec must be finite and positive".to_string(),
+            )
+        })?;
+    let _validated_measurement = (duration, throughput);
+
+    Ok(received_bytes)
+}
+
+#[async_trait]
+impl DiagnosticApi for AdminClient {
+    async fn client_devnull(&self, request: ClientDevnullRequest) -> Result<ClientDevnullResult> {
+        let capabilities = self.discover_capabilities(false).await?;
+        capabilities
+            .require_diagnostic_capability(DiagnosticCapability::ClientDevnull)
+            .map_err(|error| Error::UnsupportedFeature(error.to_string()))?;
+        self.run_client_devnull(request).await
+    }
+}

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -38,6 +38,7 @@ rc admin policy <ls|create|info|rm|attach> ...
 rc admin group <ls|add|info|rm|enable|disable|add-members|rm-members> ...
 rc admin service-account <ls|create|info|rm> ...
 rc admin service <restart|stop|freeze|unfreeze> <ALIAS>
+rc admin diagnostics client-devnull <ALIAS> [--size <SIZE>] [--timeout <DURATION>] [--concurrency <N>] --yes
 rc admin replicate add <ALIAS> <ALIAS> [<ALIAS>...]
 rc admin replicate <info|status> <ALIAS> [OPTIONS]
 rc admin replicate edit <ALIAS> --site <DEPLOYMENT_ID|NAME> [EDIT OPTIONS] --yes
@@ -50,7 +51,7 @@ rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 
 | Command | Description |
 | --- | --- |
-| `diagnostics` | Read bounded authenticated health, cluster, and extension snapshots. |
+| `diagnostics` | Read bounded authenticated snapshots or run explicitly confirmed bounded probes. |
 | `info` | Display cluster, server, or disk information. |
 | `scanner` | Inspect scanner health, freshness, and cycle state. |
 | `metrics` | Query bounded realtime metrics as normalized JSON Lines or raw server records. |
@@ -205,11 +206,17 @@ rc admin service stop local
 rc admin service restart local
 ```
 
+Measure bounded client-to-server upload throughput without storing an object:
+
+```bash
+rc admin diagnostics client-devnull local --size 8MiB --timeout 30s --concurrency 1 --yes
+```
+
 ## Behavior
 
 Admin operations use the configured alias to create a RustFS admin client. The credentials behind the alias must have permissions for the requested administrative API. The command accepts aliases with or without a trailing slash.
 
-`rc admin diagnostics` performs bounded read-only requests. Each JSON response is limited to 8 MiB. The health command reads the authenticated RustFS health snapshot and is separate from public liveness or readiness probes. Its drive throughput and latency fields are live observations, not active benchmarks, and the command preserves the server's `unsupported_probes` list instead of claiming `mc support diag` parity. Cluster output represents `snapshot: null` as `initializing_or_unavailable`. Extension diagnostics read schemas and runtime capability summaries only; they never request extension instance configuration.
+`rc admin diagnostics health`, `rc admin diagnostics cluster`, and `rc admin diagnostics extensions` perform bounded read-only requests. Each JSON response for these three snapshot commands is limited to 8 MiB. The health command reads the authenticated RustFS health snapshot and is separate from public liveness or readiness probes. Its drive throughput and latency fields are live observations, not active benchmarks, and the command preserves the server's `unsupported_probes` list instead of claiming `mc support diag` parity. Cluster output represents `snapshot: null` as `initializing_or_unavailable`. Extension diagnostics read schemas and runtime capability summaries only; they never request extension instance configuration.
 
 The diagnostic commands require capability discovery to classify the corresponding route as available. Authentication failures, unsupported routes, malformed JSON, and transport failures retain distinct exit codes.
 
@@ -276,6 +283,33 @@ The v3 lifecycle success operations are `configure`, `reconfigure`, `start`, `re
 `kms key status` describes native RustFS key lifecycle metadata. It does not claim compatibility with the `mc admin kms key status` encryption/decryption probe. The round-trip diagnostic uses only the S3 object API and does not call an Admin API key-generation route. RustFS beta.10 has no direct decrypt-test Admin API or KMS-specific metrics route/selector contract, so `rc` does not offer KMS-specific metrics and intentionally does not expose the legacy `generate-data-key` response because that response contains plaintext data-key material.
 
 `rc admin heal status <ALIAS>` reports aggregate background heal status. Manual heals started with `rc admin heal start` are token-scoped tasks; the start output includes a client token. Root recursive tasks are inspected or stopped with `--client-token`, while bucket or prefix tasks additionally pass `--bucket` and optional `--prefix`.
+
+## Diagnostics Workflow
+
+`rc admin diagnostics client-devnull` measures bounded client-to-server ingress throughput by sending zero-filled request bodies to the RustFS devnull endpoint. The server consumes the bytes without creating an object. The command requires credentials with `HealthInfoAdminAction` permission.
+
+```bash
+rc admin diagnostics client-devnull <ALIAS> \
+  [--size <SIZE>] \
+  [--timeout <DURATION>] \
+  [--concurrency <N>] \
+  --yes
+```
+
+| Option | Default | Limits and behavior |
+| --- | --- | --- |
+| `--size <SIZE>` | `8MiB` | Bytes sent by each request. The value must be greater than zero; binary byte units such as `MiB` are accepted. `size × concurrency` must not exceed `64MiB`. |
+| `--timeout <DURATION>` | `30s` | Overall active-probe timeout. Use whole seconds from `1s` through `60s`. |
+| `--concurrency <N>` | `1` | Number of simultaneous requests, from `1` through `4`. |
+| `--yes` | none | Required confirmation because the command deliberately generates network load. |
+
+The client checks RustFS diagnostic capabilities before starting the upload and fails closed unless discovery explicitly reports the non-stub `admin.diagnostics.client-devnull` capability. Unknown server versions, missing capability data, and advertised placeholder implementations are rejected without sending an active probe.
+
+Every successful request must return a measured response with the exact kind `client-devnull`, `measured: true`, an `rx_bytes` value equal to the bytes sent by that request, and present, finite, positive duration and aggregate-write-throughput measurements. Each active-probe response body is limited to 64 KiB. Placeholder responses, oversized or incomplete measurements, non-finite or non-positive measurements, and byte-count mismatches are reported as unsupported rather than as successful results.
+
+A successful result reports `requested_bytes`, `received_bytes`, `concurrency`, `elapsed_seconds`, and `aggregate_throughput_bytes_per_second`; human output presents the same values with readable units. Requested and received byte counts are aggregate values across all concurrent requests, and aggregate throughput is calculated from received bytes over client-observed elapsed time.
+
+The active upload is attempted once per concurrent lane and is never retried. Reaching the timeout or pressing Ctrl-C cancels the in-flight requests and stops further body generation; Ctrl-C returns the interrupted exit status. The command does not run object read/write, server-to-client, network mesh, site, drive, or netperf probes, and it does not persist diagnostic payloads.
 
 ## Heal Workflow
 


### PR DESCRIPTION
## Related issue

Closes rustfs/backlog#1404

Depends on the bounded diagnostic snapshots merged in #285.

## Background and user impact

RustFS beta.10 implements one real active diagnostic performance route: client-to-server upload-to-devnull. Other object, network, and site speedtest families are incomplete or placeholder implementations. `rc` needs to expose only the measured route with strict load limits, fail-closed capability checks, cancellation, and no automatic retries.

## Solution

- Add `rc admin diagnostics client-devnull ALIAS --size 8MiB --timeout 30s --concurrency 1 --yes`.
- Validate all input before capability discovery or active traffic.
- Limit aggregate traffic to 64 MiB, concurrency to 1-4, and timeout to 1-60 seconds.
- Generate a static zero body incrementally in 64 KiB chunks without allocating the full payload.
- Set exact Content-Length and precompute the matching SHA-256 for SigV4 signing.
- Fail closed on unknown or stubbed capability states before the active POST.
- Never retry an active probe automatically.
- Cancel peer requests and body production on timeout, Ctrl-C, or future abort.
- Bound each active response or error body to 64 KiB.
- Require `kind=client-devnull`, `measured=true`, exact `rx_bytes`, and finite positive duration and throughput.
- Report requested and received bytes, concurrency, wall-clock elapsed time, and aggregate throughput through the existing output-v3 `admin_operations` family.

## BREAKING contract note

**BREAKING:** This PR updates the protected `docs/reference/rc/admin.md` behavior contract for a new additive active diagnostics command. It does not change output v1/v2/v3 schemas, config schema, exit-code definitions, or existing command behavior. No schema migration is required.

## Validation

Exact head: `73cc41fca3d34edd7bb743e7c871d531a153c673`

- `cargo fmt --all --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --workspace -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test --workspace`
- Core client-devnull limits: 3 passed
- S3 client-devnull: 9 passed
- S3 read-only diagnostics regression: 3 passed
- Combined CLI diagnostics: 13 passed in both lib and main targets
- CLI request-capture integration: 1 passed
- Cancellation regression: 20 consecutive targeted runs passed
- Review audit: 0 reviews and 0 review threads

## Limitations

- Client-to-server devnull only.
- Object speedtest, inter-node network speedtest, site speedtest, site-replication netperf, active drive benchmark, and continuous traffic generation are excluded.
- The RustFS handler itself does not enforce a request-body size limit; this CLI guarantees that it sends no more than 64 MiB, but other callers must enforce their own limits.
- Live configured-environment behavior remains covered by the repository compatibility workflow and GitHub checks; local validation uses source-backed contract and mock integration coverage.
