### PR TITLE
feat(rc-site-replication)!: expose persisted resync snapshots

### DIFF
--- a/crates/cli/src/commands/admin/replicate.rs
+++ b/crates/cli/src/commands/admin/replicate.rs
@@ -5,6 +5,7 @@
 //! configured alias names; their endpoints and credentials are resolved
 //! from the local alias store.
 
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -17,7 +18,8 @@ use crate::exit_code::ExitCode;
 use crate::output::Formatter;
 use rc_core::admin::{
     AdminApi, PeerSiteSpec, ReplicateEditStatus, SiteRemoveSpec, SiteReplicationInfo,
-    SiteReplicationPeer, SiteStatusOptions, validate_site_replication_ca_bundle,
+    SiteReplicationPeer, SiteReplicationResyncOperation, SiteReplicationResyncStatus,
+    SiteStatusOptions, validate_site_replication_ca_bundle,
 };
 use rc_core::{AliasManager, Error};
 use rc_s3::AdminClient;
@@ -33,6 +35,9 @@ pub enum ReplicateCommands {
 
     /// Safely edit one exact site replication peer
     Edit(EditArgs),
+
+    /// Manage persisted site resync operation snapshots
+    Resync(ResyncArgs),
 
     /// Show site replication status
     Status(StatusArgs),
@@ -94,6 +99,48 @@ pub struct EditArgs {
 }
 
 #[derive(clap::Args, Debug)]
+pub struct ResyncArgs {
+    #[command(subcommand)]
+    pub command: ResyncCommands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ResyncCommands {
+    /// Start resync for one exact peer and retain the mutation snapshot
+    Start(ResyncMutationArgs),
+
+    /// Read the persisted snapshot from the last start or cancel request
+    Status(ResyncStatusArgs),
+
+    /// Cancel resync for one exact peer and retain the mutation snapshot
+    Cancel(ResyncMutationArgs),
+}
+
+#[derive(clap::Args, Debug)]
+pub struct ResyncMutationArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Exact deployment ID or unique exact site name
+    #[arg(long)]
+    pub site: String,
+
+    /// Confirm the resync mutation
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(clap::Args, Debug)]
+pub struct ResyncStatusArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Exact deployment ID or unique exact site name
+    #[arg(long)]
+    pub site: String,
+}
+
+#[derive(clap::Args, Debug)]
 pub struct StatusArgs {
     /// Alias name of the server
     pub alias: String,
@@ -139,6 +186,7 @@ pub async fn execute(cmd: ReplicateCommands, formatter: &Formatter) -> ExitCode 
         ReplicateCommands::Add(args) => execute_add(args, formatter).await,
         ReplicateCommands::Info(args) => execute_info(args, formatter).await,
         ReplicateCommands::Edit(args) => execute_edit(args, formatter).await,
+        ReplicateCommands::Resync(args) => execute_resync(args, formatter).await,
         ReplicateCommands::Status(args) => execute_status(args, formatter).await,
         ReplicateCommands::Remove(args) => execute_remove(args, formatter).await,
     }
@@ -398,7 +446,228 @@ async fn execute_edit(args: EditArgs, formatter: &Formatter) -> ExitCode {
             }
             ExitCode::Success
         }
-        Err(error) => emit_admin_error(formatter, &error, "site_replication_edit", true),
+        Err(error) => emit_admin_error(
+            formatter,
+            &error,
+            "site_replication_edit",
+            mutation_was_attempted(true, &error),
+        ),
+    }
+}
+
+async fn execute_resync(args: ResyncArgs, formatter: &Formatter) -> ExitCode {
+    match args.command {
+        ResyncCommands::Start(args) => {
+            execute_resync_mutation(args, SiteReplicationResyncOperation::Start, formatter).await
+        }
+        ResyncCommands::Status(args) => execute_resync_status(args, formatter).await,
+        ResyncCommands::Cancel(args) => {
+            execute_resync_mutation(args, SiteReplicationResyncOperation::Cancel, formatter).await
+        }
+    }
+}
+
+async fn execute_resync_mutation(
+    args: ResyncMutationArgs,
+    operation: SiteReplicationResyncOperation,
+    formatter: &Formatter,
+) -> ExitCode {
+    let operation_name = resync_operation_name(operation);
+    if !args.yes {
+        return emit_admin_message_error(
+            formatter,
+            ExitCode::UsageError,
+            operation_name,
+            true,
+            format!(
+                "Site replication resync {} requires --yes confirmation",
+                operation.as_str()
+            ),
+        );
+    }
+    execute_resync_request(&args.alias, &args.site, operation, formatter).await
+}
+
+async fn execute_resync_status(args: ResyncStatusArgs, formatter: &Formatter) -> ExitCode {
+    execute_resync_request(
+        &args.alias,
+        &args.site,
+        SiteReplicationResyncOperation::Status,
+        formatter,
+    )
+    .await
+}
+
+async fn execute_resync_request(
+    alias_name: &str,
+    selector: &str,
+    operation: SiteReplicationResyncOperation,
+    formatter: &Formatter,
+) -> ExitCode {
+    let operation_name = resync_operation_name(operation);
+    let mutation = operation.is_mutation();
+    if selector.trim().is_empty() {
+        return emit_admin_message_error(
+            formatter,
+            ExitCode::UsageError,
+            operation_name,
+            false,
+            "Site selector must not be empty".to_string(),
+        );
+    }
+    let (client, local_endpoint) = match load_admin_client_with_endpoint(alias_name) {
+        Ok(context) => context,
+        Err(error) => {
+            return emit_admin_error(formatter, &error, operation_name, false);
+        }
+    };
+    let info = match client.site_replication_info().await {
+        Ok(info) => info,
+        Err(error) => {
+            return emit_admin_error(formatter, &error, operation_name, false);
+        }
+    };
+    let selected = match info.resolve_peer(selector) {
+        Ok(peer) => peer,
+        Err(error) => {
+            return emit_admin_error(formatter, &error, operation_name, false);
+        }
+    };
+    let endpoint = match selected
+        .endpoint()
+        .filter(|endpoint| !endpoint.trim().is_empty())
+        .map(validate_site_endpoint)
+        .transpose()
+    {
+        Ok(Some(endpoint)) => endpoint,
+        Ok(None) | Err(_) => {
+            return emit_admin_message_error(
+                formatter,
+                ExitCode::Conflict,
+                operation_name,
+                false,
+                "Selected site has no valid endpoint".to_string(),
+            );
+        }
+    };
+    if mutation && validate_site_endpoint(&local_endpoint).is_ok_and(|local| local == endpoint) {
+        return emit_admin_message_error(
+            formatter,
+            ExitCode::Conflict,
+            operation_name,
+            false,
+            "Cannot resync a site replication peer to itself".to_string(),
+        );
+    }
+
+    // RustFS expects the complete PeerInfo object. In legacy snapshots the
+    // endpoint may be stored as `endpoints`; inserting the singular field lets
+    // current servers consume it while all opaque fields remain intact.
+    let mut peer = selected.clone();
+    peer.set_endpoint(endpoint);
+    let resource = selected
+        .deployment_id()
+        .filter(|deployment_id| !deployment_id.trim().is_empty())
+        .unwrap_or_else(|| peer.endpoint().unwrap_or(selector))
+        .to_string();
+    match client.site_replication_resync(operation, &peer).await {
+        Ok(status) => emit_resync_status(formatter, operation, operation_name, resource, status),
+        Err(error) => {
+            let mutation_attempted = mutation_was_attempted(mutation, &error);
+            emit_admin_error(formatter, &error, operation_name, mutation_attempted)
+        }
+    }
+}
+
+fn mutation_was_attempted(mutation: bool, error: &Error) -> bool {
+    mutation && !matches!(error, Error::RequestRejected(_))
+}
+
+const fn resync_operation_name(operation: SiteReplicationResyncOperation) -> &'static str {
+    match operation {
+        SiteReplicationResyncOperation::Start => "site_replication_resync_start",
+        SiteReplicationResyncOperation::Status => "site_replication_resync_status",
+        SiteReplicationResyncOperation::Cancel => "site_replication_resync_cancel",
+    }
+}
+
+fn emit_resync_status(
+    formatter: &Formatter,
+    requested: SiteReplicationResyncOperation,
+    operation_name: &'static str,
+    resource: String,
+    status: SiteReplicationResyncStatus,
+) -> ExitCode {
+    if requested == SiteReplicationResyncOperation::Status && status.is_not_found() {
+        return emit_admin_message_error(
+            formatter,
+            ExitCode::Conflict,
+            operation_name,
+            false,
+            "No persisted resync operation snapshot exists for the selected site".to_string(),
+        );
+    }
+
+    let failed = status.has_failure();
+    let state = if requested == SiteReplicationResyncOperation::Status {
+        "unknown"
+    } else if failed {
+        "failed"
+    } else {
+        "succeeded"
+    };
+    let operation_id = (!status.resync_id.is_empty()).then(|| status.resync_id.clone());
+    let result = SafeSiteReplicationResyncResult::new(requested, &status);
+    if formatter.is_json() {
+        formatter.json(&admin_operation_output(
+            operation_name,
+            resource,
+            state,
+            operation_id,
+            requested.is_mutation(),
+            result,
+        ));
+    } else {
+        let snapshot = if requested == SiteReplicationResyncOperation::Status {
+            "persisted last-operation snapshot"
+        } else {
+            "mutation response snapshot"
+        };
+        formatter.println(&format!(
+            "Site resync {snapshot} for {}: operation={}, status={}, lifecycle=unknown",
+            formatter.sanitize_text(&resource),
+            formatter.sanitize_text(&status.operation),
+            formatter.sanitize_text(&status.status)
+        ));
+        if !status.resync_id.is_empty() {
+            formatter.println(&format!(
+                "  Operation ID: {}",
+                formatter.sanitize_text(&status.resync_id)
+            ));
+        }
+        if !status.error_detail.is_empty() {
+            formatter.println(&format!(
+                "  Error detail: {}",
+                formatter.sanitize_text(&status.error_detail)
+            ));
+        }
+        for bucket in &status.buckets {
+            formatter.println(&format!(
+                "  {}  {}{}",
+                formatter.sanitize_text(&bucket.bucket),
+                formatter.sanitize_text(&bucket.status),
+                if bucket.error_detail.is_empty() {
+                    String::new()
+                } else {
+                    format!("  {}", formatter.sanitize_text(&bucket.error_detail))
+                }
+            ));
+        }
+    }
+    if failed {
+        ExitCode::GeneralError
+    } else {
+        ExitCode::Success
     }
 }
 
@@ -406,6 +675,13 @@ fn load_admin_client(alias_name: &str) -> Result<AdminClient, Error> {
     let alias_manager = AliasManager::new()?;
     let alias = alias_manager.get(normalize_admin_alias(alias_name))?;
     AdminClient::new(&alias)
+}
+
+fn load_admin_client_with_endpoint(alias_name: &str) -> Result<(AdminClient, String), Error> {
+    let alias_manager = AliasManager::new()?;
+    let alias = alias_manager.get(normalize_admin_alias(alias_name))?;
+    let endpoint = alias.endpoint.clone();
+    Ok((AdminClient::new(&alias)?, endpoint))
 }
 
 fn validate_site_endpoint(endpoint: &str) -> Result<String, Error> {
@@ -537,6 +813,17 @@ fn admin_success_output<T: Serialize>(
     changed: bool,
     result: T,
 ) -> AdminOperationsSuccess<T> {
+    admin_operation_output(operation, resource, "succeeded", None, changed, result)
+}
+
+fn admin_operation_output<T: Serialize>(
+    operation: &'static str,
+    resource: String,
+    state: &'static str,
+    operation_id: Option<String>,
+    changed: bool,
+    result: T,
+) -> AdminOperationsSuccess<T> {
     AdminOperationsSuccess {
         schema_version: 3,
         output_type: "admin_operations",
@@ -545,8 +832,8 @@ fn admin_success_output<T: Serialize>(
             operations: vec![AdminOperation {
                 operation,
                 resource,
-                state: "succeeded",
-                operation_id: None,
+                state,
+                operation_id,
                 changed,
                 result,
             }],
@@ -672,6 +959,111 @@ impl SafeSiteReplicationEditResult {
     }
 }
 
+#[derive(Serialize)]
+struct SafeSiteReplicationResyncResult {
+    snapshot_kind: &'static str,
+    lifecycle_state: &'static str,
+    server_operation: String,
+    server_status: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    error_detail: String,
+    buckets: Vec<SafeSiteReplicationResyncBucket>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    future: BTreeMap<String, Value>,
+}
+
+impl SafeSiteReplicationResyncResult {
+    fn new(
+        requested: SiteReplicationResyncOperation,
+        status: &SiteReplicationResyncStatus,
+    ) -> Self {
+        Self {
+            snapshot_kind: if requested == SiteReplicationResyncOperation::Status {
+                "persisted_last_operation"
+            } else {
+                "mutation_response"
+            },
+            lifecycle_state: "unknown",
+            server_operation: status.operation.clone(),
+            server_status: status.status.clone(),
+            error_detail: status.error_detail.clone(),
+            buckets: status
+                .buckets
+                .iter()
+                .map(SafeSiteReplicationResyncBucket::from)
+                .collect(),
+            future: safe_resync_future_fields(&status.extensions),
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct SafeSiteReplicationResyncBucket {
+    bucket: String,
+    status: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    error_detail: String,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    future: BTreeMap<String, Value>,
+}
+
+impl From<&rc_core::admin::SiteReplicationResyncBucketStatus> for SafeSiteReplicationResyncBucket {
+    fn from(bucket: &rc_core::admin::SiteReplicationResyncBucketStatus) -> Self {
+        Self {
+            bucket: bucket.bucket.clone(),
+            status: bucket.status.clone(),
+            error_detail: bucket.error_detail.clone(),
+            future: safe_resync_future_fields(&bucket.extensions),
+        }
+    }
+}
+
+fn safe_resync_future_fields(fields: &BTreeMap<String, Value>) -> BTreeMap<String, Value> {
+    fields
+        .iter()
+        .filter(|(name, _)| safe_resync_future_field_name(name))
+        .filter_map(|(name, value)| {
+            safe_resync_future_value(value).map(|value| (name.clone(), value))
+        })
+        .collect()
+}
+
+fn safe_resync_future_value(value: &Value) -> Option<Value> {
+    match value {
+        Value::Null | Value::Bool(_) | Value::Number(_) | Value::String(_) => Some(value.clone()),
+        Value::Array(values) => Some(Value::Array(
+            values.iter().filter_map(safe_resync_future_value).collect(),
+        )),
+        Value::Object(fields) => Some(Value::Object(
+            fields
+                .iter()
+                .filter(|(name, _)| safe_resync_future_field_name(name))
+                .filter_map(|(name, value)| {
+                    safe_resync_future_value(value).map(|value| (name.clone(), value))
+                })
+                .collect(),
+        )),
+    }
+}
+
+fn safe_resync_future_field_name(name: &str) -> bool {
+    matches!(
+        name,
+        "createdAt"
+            | "startedAt"
+            | "updatedAt"
+            | "completedAt"
+            | "generation"
+            | "progress"
+            | "total"
+            | "completed"
+            | "failed"
+            | "pending"
+            | "state"
+            | "phase"
+    )
+}
+
 fn info_resource(info: &SiteReplicationInfo, alias: &str) -> String {
     if info.name.is_empty() {
         alias.to_string()
@@ -758,7 +1150,7 @@ fn admin_error_output(
             suggestion: Some("Upgrade RustFS or verify server support for this operation."),
         })
     } else {
-        let (error_type, retryable, suggestion) = admin_error_metadata(code, mutation);
+        let (error_type, retryable, suggestion) = admin_error_metadata(code, operation, mutation);
         AdminErrorOutput::Standard(StandardAdminError {
             error_type,
             message,
@@ -774,15 +1166,29 @@ fn admin_error_output(
     }
 }
 
-const fn admin_error_metadata(
+fn admin_error_metadata(
     code: ExitCode,
+    operation: &str,
     mutation: bool,
 ) -> (&'static str, bool, Option<&'static str>) {
+    let resync = operation.starts_with("site_replication_resync_");
     match code {
+        ExitCode::UsageError if resync => (
+            "usage_error",
+            false,
+            Some("Run the command with --help and verify its site selector and confirmation."),
+        ),
         ExitCode::UsageError => (
             "usage_error",
             false,
             Some("Run the command with --help and verify its edit options."),
+        ),
+        ExitCode::NetworkError if mutation && resync => (
+            "network_error",
+            false,
+            Some(
+                "The resync mutation outcome may be unknown; inspect the persisted snapshot and storage state before retrying.",
+            ),
         ),
         ExitCode::NetworkError if mutation => (
             "network_error",
@@ -813,6 +1219,13 @@ const fn admin_error_metadata(
             "interrupted",
             false,
             Some("Inspect site replication state before retrying."),
+        ),
+        ExitCode::GeneralError if mutation && resync => (
+            "general_error",
+            false,
+            Some(
+                "The mutation response was rejected; inspect the persisted snapshot and storage state before retrying.",
+            ),
         ),
         ExitCode::Success | ExitCode::GeneralError | ExitCode::UnsupportedFeature => {
             ("general_error", false, None)
@@ -945,6 +1358,12 @@ mod tests {
         include_str!("../../../tests/fixtures/output_v3/admin/site_replication_edit_error.json");
     const INFO_ERROR_GOLDEN: &str =
         include_str!("../../../tests/fixtures/output_v3/admin/site_replication_info_error.json");
+    const RESYNC_START_SUCCESS_GOLDEN: &str = include_str!(
+        "../../../tests/fixtures/output_v3/admin/site_replication_resync_start_success.json"
+    );
+    const RESYNC_STATUS_PARTIAL_GOLDEN: &str = include_str!(
+        "../../../tests/fixtures/output_v3/admin/site_replication_resync_status_partial.json"
+    );
 
     #[test]
     fn edit_endpoint_must_be_a_safe_http_origin() {
@@ -1111,6 +1530,76 @@ mod tests {
             assert_eq!(actual, expected);
             assert_valid_v3(&actual);
         }
+    }
+
+    #[test]
+    fn resync_outputs_match_v3_schema_and_drop_unsafe_future_fields() {
+        let started: SiteReplicationResyncStatus = serde_json::from_value(serde_json::json!({
+            "op": "start",
+            "id": "resync-123",
+            "status": "success",
+            "buckets": [{"bucket": "photos", "status": "started"}],
+            "generation": 7,
+            "sessionToken": "MUST-NOT-PRINT"
+        }))
+        .expect("valid start snapshot");
+        let start_output = serde_json::to_value(admin_operation_output(
+            "site_replication_resync_start",
+            "deployment-2".into(),
+            "succeeded",
+            Some(started.resync_id.clone()),
+            true,
+            SafeSiteReplicationResyncResult::new(SiteReplicationResyncOperation::Start, &started),
+        ))
+        .expect("start output serializes");
+
+        let partial: SiteReplicationResyncStatus = serde_json::from_value(serde_json::json!({
+            "op": "start",
+            "id": "resync-partial",
+            "status": "success",
+            "buckets": [
+                {"bucket": "photos", "status": "started", "updatedAt": "2026-07-22T00:00:00Z"},
+                {"bucket": "archive", "status": "failed", "errorDetail": "target unavailable", "accessToken": "MUST-NOT-PRINT"}
+            ],
+            "errorDetail": "partial failure in starting site resync",
+            "updatedAt": "2026-07-22T00:00:01Z",
+            "secretKey": "MUST-NOT-PRINT"
+        }))
+        .expect("valid partial snapshot");
+        let partial_output = serde_json::to_value(admin_operation_output(
+            "site_replication_resync_status",
+            "deployment-2".into(),
+            "unknown",
+            Some(partial.resync_id.clone()),
+            false,
+            SafeSiteReplicationResyncResult::new(SiteReplicationResyncOperation::Status, &partial),
+        ))
+        .expect("status output serializes");
+
+        for (actual, expected) in [
+            (start_output, golden(RESYNC_START_SUCCESS_GOLDEN)),
+            (partial_output, golden(RESYNC_STATUS_PARTIAL_GOLDEN)),
+        ] {
+            assert_eq!(actual, expected);
+            assert_valid_v3(&actual);
+            assert!(!actual.to_string().contains("MUST-NOT-PRINT"));
+        }
+    }
+
+    #[test]
+    fn resync_local_request_rejection_is_not_reported_as_an_attempted_mutation() {
+        assert!(!mutation_was_attempted(
+            true,
+            &Error::RequestRejected("request too large".to_string())
+        ));
+        assert!(mutation_was_attempted(
+            true,
+            &Error::Network("connection lost".to_string())
+        ));
+        assert!(!mutation_was_attempted(
+            false,
+            &Error::Network("connection lost".to_string())
+        ));
     }
 
     fn output_v3_validator() -> Validator {

--- a/crates/cli/tests/admin_replicate.rs
+++ b/crates/cli/tests/admin_replicate.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use admin_support::{
     rc_binary, rc_host_alias, start_admin_sequence_test_server, start_admin_test_server,
+    start_admin_test_server_with_endpoint_response,
 };
 
 const EDIT_INFO_RESPONSE: &str = r#"{
@@ -31,6 +32,70 @@ const EDIT_INFO_RESPONSE: &str = r#"{
 
 const EDIT_SUCCESS_RESPONSE: &str =
     r#"{"success":true,"status":"updated","errorDetail":"","apiVersion":"v1"}"#;
+
+const RESYNC_INFO_RESPONSE: &str = r#"{
+    "enabled":true,
+    "name":"primary",
+    "sites":[{
+        "endpoints":"https://secondary.example.test",
+        "name":"secondary",
+        "deploymentID":"deployment-2",
+        "sync":"enable",
+        "futurePeer":{"mode":"preserved"}
+    }]
+}"#;
+
+const RESYNC_START_RESPONSE: &str = r#"{
+    "op":"start",
+    "id":"resync-123",
+    "status":"success",
+    "buckets":[{"bucket":"photos","status":"started"}],
+    "generation":7,
+    "sessionToken":"MUST-NOT-PRINT"
+}"#;
+
+fn run_resync_command(
+    operation: &str,
+    info: &'static str,
+    response_status: &'static str,
+    response: &'static str,
+    confirm: bool,
+) -> (
+    std::process::Output,
+    Vec<admin_support::CapturedAdminRequest>,
+) {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", info), (response_status, response)]);
+    let mut command = Command::new(rc_binary());
+    command.args([
+        "--json",
+        "admin",
+        "replicate",
+        "resync",
+        operation,
+        "myalias",
+        "--site",
+        "secondary",
+    ]);
+    if confirm {
+        command.arg("--yes");
+    }
+    let output = command
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+    let requests = (0..2)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured resync request")
+        })
+        .collect();
+    handle.join().expect("admin test server finished");
+    (output, requests)
+}
 
 fn run_edit_and_capture_body(info: &'static str, options: &[String]) -> serde_json::Value {
     let config_dir = tempfile::tempdir().expect("create config dir");
@@ -901,6 +966,62 @@ fn replicate_edit_rejects_malformed_selected_peer_before_put() {
 }
 
 #[test]
+fn replicate_edit_oversized_local_request_is_not_reported_as_attempted() {
+    let oversized_ca = "x".repeat(rc_core::admin::MAX_SITE_REPLICATION_REQUEST_BYTES + 1);
+    let info = serde_json::json!({
+        "enabled": true,
+        "sites": [{
+            "endpoint": "https://secondary.example.test",
+            "name": "secondary",
+            "deploymentID": "deployment-2",
+            "caCertPem": oversized_ca
+        }]
+    })
+    .to_string();
+    let info: &'static str = Box::leak(info.into_boxed_str());
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(info);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "replicate",
+            "edit",
+            "myalias",
+            "--site",
+            "deployment-2",
+            "--name",
+            "secondary-renamed",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    let payload: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error");
+    assert_eq!(payload["error"]["type"], "general_error");
+    assert_eq!(payload["error"]["retryable"], false);
+    assert!(payload["error"]["suggestion"].is_null());
+    assert!(
+        payload["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("exceeds"))
+    );
+    assert!(
+        !stderr.contains("outcome may be unknown"),
+        "stderr: {stderr}"
+    );
+    receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured info request");
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
 fn replicate_edit_rejects_http_final_state_with_active_tls_values() {
     let config_dir = tempfile::tempdir().expect("create config dir");
     let (endpoint, receiver, handle) = start_admin_test_server(EDIT_INFO_RESPONSE);
@@ -927,5 +1048,466 @@ fn replicate_edit_rejects_http_final_state_with_active_tls_values() {
     receiver
         .recv_timeout(Duration::from_secs(5))
         .expect("captured info request");
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn replicate_resync_start_requires_confirmation_before_alias_setup() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "replicate",
+            "resync",
+            "start",
+            "missing-alias",
+            "--site",
+            "secondary",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("--yes"), "stderr: {stderr}");
+    assert!(!stderr.contains("missing-alias"), "stderr: {stderr}");
+}
+
+#[test]
+fn replicate_resync_cancel_requires_confirmation_before_alias_setup() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "replicate",
+            "resync",
+            "cancel",
+            "missing-alias",
+            "--site",
+            "secondary",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("--yes"), "stderr: {stderr}");
+    assert!(!stderr.contains("missing-alias"), "stderr: {stderr}");
+}
+
+#[test]
+fn replicate_resync_start_sends_complete_peer_with_legacy_endpoint_fallback() {
+    let (output, requests) = run_resync_command(
+        "start",
+        RESYNC_INFO_RESPONSE,
+        "200 OK",
+        RESYNC_START_RESPONSE,
+        true,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[0].target, "/rustfs/admin/v3/site-replication/info");
+    assert_eq!(requests[1].method, "PUT");
+    assert_eq!(
+        requests[1].target,
+        "/rustfs/admin/v3/site-replication/resync/op?operation=start"
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[1].body).expect("resync request JSON");
+    assert_eq!(body["endpoint"], "https://secondary.example.test");
+    assert_eq!(body["endpoints"], "https://secondary.example.test");
+    assert_eq!(body["deploymentID"], "deployment-2");
+    assert_eq!(body["futurePeer"]["mode"], "preserved");
+
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("resync output JSON");
+    let operation = &payload["data"]["operations"][0];
+    assert_eq!(operation["operation"], "site_replication_resync_start");
+    assert_eq!(operation["state"], "succeeded");
+    assert_eq!(operation["operation_id"], "resync-123");
+    assert_eq!(operation["changed"], true);
+    assert_eq!(operation["result"]["snapshot_kind"], "mutation_response");
+    assert_eq!(operation["result"]["future"]["generation"], 7);
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(!stdout.contains("MUST-NOT-PRINT"), "stdout: {stdout}");
+}
+
+#[test]
+fn replicate_resync_start_accepts_legacy_peer_without_deployment_id() {
+    const LEGACY_INFO: &str = r#"{
+        "enabled":true,
+        "sites":[{
+            "endpoints":"https://legacy.example.test",
+            "name":"secondary",
+            "sync":"enable",
+            "futurePeer":{"mode":"preserved"}
+        }]
+    }"#;
+    let (output, requests) =
+        run_resync_command("start", LEGACY_INFO, "200 OK", RESYNC_START_RESPONSE, true);
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[1].body).expect("resync request JSON");
+    assert_eq!(body["endpoint"], "https://legacy.example.test");
+    assert!(body.get("deploymentID").is_none());
+    assert_eq!(body["futurePeer"]["mode"], "preserved");
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("resync output JSON");
+    assert_eq!(
+        payload["data"]["operations"][0]["resource"],
+        "https://legacy.example.test"
+    );
+}
+
+#[test]
+fn replicate_resync_status_is_a_persisted_snapshot_and_retains_bucket_failures() {
+    const PARTIAL_STATUS: &str = r#"{
+        "op":"start",
+        "id":"resync-partial",
+        "status":"success",
+        "buckets":[
+            {"bucket":"photos","status":"started","updatedAt":"2026-07-22T00:00:00Z"},
+            {"bucket":"archive","status":"failed","errorDetail":"target unavailable","accessToken":"MUST-NOT-PRINT"}
+        ],
+        "errorDetail":"partial failure in starting site resync",
+        "updatedAt":"2026-07-22T00:00:01Z",
+        "secretKey":"MUST-NOT-PRINT"
+    }"#;
+    let (output, requests) = run_resync_command(
+        "status",
+        RESYNC_INFO_RESPONSE,
+        "200 OK",
+        PARTIAL_STATUS,
+        false,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(
+        requests[1].target,
+        "/rustfs/admin/v3/site-replication/resync/op?operation=status"
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("resync output JSON");
+    let operation = &payload["data"]["operations"][0];
+    assert_eq!(operation["state"], "unknown");
+    assert_eq!(operation["changed"], false);
+    assert_eq!(operation["operation_id"], "resync-partial");
+    assert_eq!(
+        operation["result"]["snapshot_kind"],
+        "persisted_last_operation"
+    );
+    assert_eq!(operation["result"]["lifecycle_state"], "unknown");
+    assert_eq!(operation["result"]["server_operation"], "start");
+    assert_eq!(operation["result"]["server_status"], "success");
+    assert_eq!(operation["result"]["buckets"][1]["bucket"], "archive");
+    assert_eq!(
+        operation["result"]["buckets"][1]["error_detail"],
+        "target unavailable"
+    );
+    assert_eq!(
+        operation["result"]["future"]["updatedAt"],
+        "2026-07-22T00:00:01Z"
+    );
+    assert_eq!(
+        operation["result"]["buckets"][0]["future"]["updatedAt"],
+        "2026-07-22T00:00:00Z"
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(!stdout.contains("MUST-NOT-PRINT"), "stdout: {stdout}");
+}
+
+#[test]
+fn replicate_resync_status_without_a_snapshot_returns_conflict() {
+    let (output, requests) = run_resync_command(
+        "status",
+        RESYNC_INFO_RESPONSE,
+        "200 OK",
+        r#"{"op":"status","status":"not-found"}"#,
+        false,
+    );
+
+    assert_eq!(output.status.code(), Some(6));
+    assert_eq!(requests.len(), 2);
+}
+
+#[test]
+fn replicate_resync_cancel_returns_success_and_reuses_server_operation_id() {
+    let (output, requests) = run_resync_command(
+        "cancel",
+        RESYNC_INFO_RESPONSE,
+        "200 OK",
+        r#"{"op":"cancel","id":"resync-123","status":"success","buckets":[{"bucket":"photos","status":"canceled"}]}"#,
+        true,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        requests[1].target,
+        "/rustfs/admin/v3/site-replication/resync/op?operation=cancel"
+    );
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("resync output JSON");
+    let operation = &payload["data"]["operations"][0];
+    assert_eq!(operation["operation"], "site_replication_resync_cancel");
+    assert_eq!(operation["state"], "succeeded");
+    assert_eq!(operation["operation_id"], "resync-123");
+    assert_eq!(operation["changed"], true);
+}
+
+#[test]
+fn replicate_resync_cancel_partial_failure_keeps_every_bucket_and_exits_general() {
+    let (output, _) = run_resync_command(
+        "cancel",
+        RESYNC_INFO_RESPONSE,
+        "200 OK",
+        r#"{
+            "op":"cancel",
+            "id":"resync-123",
+            "status":"success",
+            "buckets":[
+                {"bucket":"photos","status":"canceled"},
+                {"bucket":"archive","status":"failed","errorDetail":"target unavailable"}
+            ],
+            "errorDetail":"partial failure in canceling site resync"
+        }"#,
+        true,
+    );
+
+    assert_eq!(output.status.code(), Some(1));
+    let payload: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("resync output JSON");
+    let operation = &payload["data"]["operations"][0];
+    assert_eq!(operation["state"], "failed");
+    assert_eq!(operation["changed"], true);
+    assert_eq!(
+        operation["result"]["buckets"].as_array().map(Vec::len),
+        Some(2)
+    );
+    assert_eq!(operation["result"]["buckets"][1]["bucket"], "archive");
+    assert_eq!(
+        operation["result"]["buckets"][1]["error_detail"],
+        "target unavailable"
+    );
+}
+
+#[test]
+fn replicate_resync_human_output_includes_operation_id_and_top_error_detail() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", RESYNC_INFO_RESPONSE),
+        (
+            "200 OK",
+            r#"{
+                "op":"cancel",
+                "id":"resync-human-123",
+                "status":"failed",
+                "errorDetail":"snapshot save failed"
+            }"#,
+        ),
+    ]);
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "replicate",
+            "resync",
+            "cancel",
+            "myalias",
+            "--site",
+            "secondary",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(
+        stdout.contains("Operation ID: resync-human-123"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Error detail: snapshot save failed"),
+        "stdout: {stdout}"
+    );
+    for _ in 0..2 {
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured resync request");
+    }
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn replicate_resync_human_mutation_server_error_warns_against_blind_retry() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", RESYNC_INFO_RESPONSE),
+        (
+            "500 Internal Server Error",
+            r#"{"message":"snapshot save failed"}"#,
+        ),
+    ]);
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "replicate",
+            "resync",
+            "start",
+            "myalias",
+            "--site",
+            "secondary",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(3));
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be UTF-8");
+    assert!(stderr.contains("outcome is unknown"), "stderr: {stderr}");
+    assert!(stderr.contains("do not retry blindly"), "stderr: {stderr}");
+    assert!(!stderr.contains("snapshot save failed"), "stderr: {stderr}");
+    for _ in 0..2 {
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured resync request");
+    }
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn replicate_resync_cancel_without_server_state_returns_conflict() {
+    let (output, requests) = run_resync_command(
+        "cancel",
+        RESYNC_INFO_RESPONSE,
+        "400 Bad Request",
+        r#"{"Code":"InvalidRequest","Message":"no resync in progress"}"#,
+        true,
+    );
+
+    assert_eq!(output.status.code(), Some(6));
+    assert_eq!(requests.len(), 2);
+}
+
+#[test]
+fn replicate_resync_start_rejects_self_before_mutation() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let listener_response = r#"{
+        "enabled":true,
+        "sites":[{
+            "endpoint":"SELF_ENDPOINT",
+            "name":"self",
+            "deploymentID":"local-deployment"
+        }]
+    }"#;
+    let (endpoint, receiver, handle) =
+        start_admin_test_server_with_endpoint_response(listener_response);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "replicate",
+            "resync",
+            "start",
+            "myalias",
+            "--site",
+            "self",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(6));
+    receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured info request");
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn replicate_resync_start_returns_not_found_without_a_put() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(RESYNC_INFO_RESPONSE);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "replicate",
+            "resync",
+            "start",
+            "myalias",
+            "--site",
+            "missing",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(5));
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured info request");
+    assert_eq!(request.method, "GET");
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn replicate_resync_cancel_rejects_an_ambiguous_exact_name_without_a_put() {
+    const AMBIGUOUS_INFO: &str = r#"{
+        "enabled":true,
+        "sites":[
+            {"endpoint":"https://one.example.test","name":"secondary","deploymentID":"deployment-1"},
+            {"endpoint":"https://two.example.test","name":"secondary","deploymentID":"deployment-2"}
+        ]
+    }"#;
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(AMBIGUOUS_INFO);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "replicate",
+            "resync",
+            "cancel",
+            "myalias",
+            "--site",
+            "secondary",
+            "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(6));
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured info request");
+    assert_eq!(request.method, "GET");
     handle.join().expect("admin test server finished");
 }

--- a/crates/cli/tests/admin_support/mod.rs
+++ b/crates/cli/tests/admin_support/mod.rs
@@ -129,6 +129,48 @@ pub fn start_admin_test_server(
 }
 
 #[allow(dead_code)]
+pub fn start_admin_test_server_with_endpoint_response(
+    response_template: &'static str,
+) -> (String, Receiver<CapturedAdminRequest>, JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind admin test server");
+    listener
+        .set_nonblocking(true)
+        .expect("set admin test server nonblocking");
+    let endpoint = format!("http://{}", listener.local_addr().expect("server address"));
+    let response_body = response_template.replace("SELF_ENDPOINT", &endpoint);
+    let (sender, receiver) = mpsc::channel();
+
+    let handle = thread::spawn(move || {
+        let deadline = Instant::now() + Duration::from_secs(120);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(accepted) => break accepted,
+                Err(e) if e.kind() == ErrorKind::WouldBlock && Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(e) => panic!("accept admin request: {e}"),
+            }
+        };
+        stream
+            .set_nonblocking(false)
+            .expect("set admin request stream blocking");
+        let request = read_admin_request(&mut stream);
+        sender.send(request).expect("send captured request");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .expect("write admin response");
+    });
+
+    (endpoint, receiver, handle)
+}
+
+#[allow(dead_code)]
 pub fn start_admin_sequence_test_server(
     responses: Vec<(&'static str, &'static str)>,
 ) -> (String, Receiver<CapturedAdminRequest>, JoinHandle<()>) {

--- a/crates/cli/tests/fixtures/output_v3/admin/site_replication_resync_start_success.json
+++ b/crates/cli/tests/fixtures/output_v3/admin/site_replication_resync_start_success.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 3,
+  "type": "admin_operations",
+  "status": "success",
+  "data": {
+    "operations": [
+      {
+        "operation": "site_replication_resync_start",
+        "resource": "deployment-2",
+        "state": "succeeded",
+        "operation_id": "resync-123",
+        "changed": true,
+        "result": {
+          "snapshot_kind": "mutation_response",
+          "lifecycle_state": "unknown",
+          "server_operation": "start",
+          "server_status": "success",
+          "buckets": [
+            {
+              "bucket": "photos",
+              "status": "started"
+            }
+          ],
+          "future": {
+            "generation": 7
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/admin/site_replication_resync_status_partial.json
+++ b/crates/cli/tests/fixtures/output_v3/admin/site_replication_resync_status_partial.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": 3,
+  "type": "admin_operations",
+  "status": "success",
+  "data": {
+    "operations": [
+      {
+        "operation": "site_replication_resync_status",
+        "resource": "deployment-2",
+        "state": "unknown",
+        "operation_id": "resync-partial",
+        "changed": false,
+        "result": {
+          "snapshot_kind": "persisted_last_operation",
+          "lifecycle_state": "unknown",
+          "server_operation": "start",
+          "server_status": "success",
+          "error_detail": "partial failure in starting site resync",
+          "buckets": [
+            {
+              "bucket": "photos",
+              "status": "started",
+              "future": {
+                "updatedAt": "2026-07-22T00:00:00Z"
+              }
+            },
+            {
+              "bucket": "archive",
+              "status": "failed",
+              "error_detail": "target unavailable"
+            }
+          ],
+          "future": {
+            "updatedAt": "2026-07-22T00:00:01Z"
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -488,6 +488,26 @@ fn nested_subcommand_help_contract() {
             ],
         },
         HelpCase {
+            args: &["admin", "replicate", "resync"],
+            usage: "Usage: rc admin replicate resync [OPTIONS] <COMMAND>",
+            expected_tokens: &["start", "status", "cancel"],
+        },
+        HelpCase {
+            args: &["admin", "replicate", "resync", "start"],
+            usage: "Usage: rc admin replicate resync start [OPTIONS] --site <SITE> <ALIAS>",
+            expected_tokens: &["--site", "--yes"],
+        },
+        HelpCase {
+            args: &["admin", "replicate", "resync", "status"],
+            usage: "Usage: rc admin replicate resync status [OPTIONS] --site <SITE> <ALIAS>",
+            expected_tokens: &["--site"],
+        },
+        HelpCase {
+            args: &["admin", "replicate", "resync", "cancel"],
+            usage: "Usage: rc admin replicate resync cancel [OPTIONS] --site <SITE> <ALIAS>",
+            expected_tokens: &["--site", "--yes"],
+        },
+        HelpCase {
             args: &["admin", "heal", "status"],
             usage: "Usage: rc admin heal status [OPTIONS] <ALIAS>",
             expected_tokens: &["--bucket", "--prefix", "--client-token"],

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -26,7 +26,8 @@ pub use site::{
     MAX_SITE_REPLICATION_CA_CERT_BYTES, MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_REQUEST_BYTES, MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, PeerSiteSpec,
     ReplicateEditStatus, ServiceActionResult, SiteRemoveSpec, SiteReplicationInfo,
-    SiteReplicationPeer, SiteStatusOptions, validate_site_replication_ca_bundle,
+    SiteReplicationPeer, SiteReplicationResyncBucketStatus, SiteReplicationResyncOperation,
+    SiteReplicationResyncStatus, SiteStatusOptions, validate_site_replication_ca_bundle,
 };
 pub use tier::{
     TierAliyun, TierAzure, TierConfig, TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2,
@@ -259,6 +260,13 @@ pub trait AdminApi: Send + Sync {
         &self,
         peer: &SiteReplicationPeer,
     ) -> Result<ReplicateEditStatus>;
+
+    /// Start, inspect, or cancel a resync toward one complete peer snapshot
+    async fn site_replication_resync(
+        &self,
+        operation: SiteReplicationResyncOperation,
+        peer: &SiteReplicationPeer,
+    ) -> Result<SiteReplicationResyncStatus>;
 
     /// Add peer sites to the site replication cluster
     async fn site_replication_add(&self, sites: &[PeerSiteSpec]) -> Result<serde_json::Value>;

--- a/crates/core/src/admin/site.rs
+++ b/crates/core/src/admin/site.rs
@@ -168,6 +168,11 @@ impl Serialize for SiteReplicationPeer {
 impl SiteReplicationPeer {
     pub fn endpoint(&self) -> Option<&str> {
         self.string_field("endpoint")
+            .filter(|endpoint| !endpoint.is_empty())
+            .or_else(|| {
+                self.string_field("endpoints")
+                    .filter(|endpoint| !endpoint.is_empty())
+            })
     }
 
     pub fn name(&self) -> Option<&str> {
@@ -333,6 +338,148 @@ impl SiteReplicationInfo {
         }
         Ok(peer)
     }
+}
+
+/// Operation accepted by `site-replication/resync/op`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SiteReplicationResyncOperation {
+    Start,
+    Status,
+    Cancel,
+}
+
+impl SiteReplicationResyncOperation {
+    /// Exact query value expected by the RustFS admin route.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Start => "start",
+            Self::Status => "status",
+            Self::Cancel => "cancel",
+        }
+    }
+
+    /// Whether this operation changes server-side resync state.
+    pub const fn is_mutation(self) -> bool {
+        matches!(self, Self::Start | Self::Cancel)
+    }
+}
+
+/// Per-bucket result returned by a site replication resync operation.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct SiteReplicationResyncBucketStatus {
+    #[serde(default)]
+    pub bucket: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(rename = "errorDetail", default)]
+    pub error_detail: String,
+    #[serde(flatten)]
+    pub extensions: BTreeMap<String, Value>,
+}
+
+impl SiteReplicationResyncBucketStatus {
+    /// Detect a failed bucket even when the server's status summary is stale.
+    pub fn has_failure(&self) -> bool {
+        status_is_failed(&self.status) || !self.error_detail.trim().is_empty()
+    }
+}
+
+impl fmt::Debug for SiteReplicationResyncBucketStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SiteReplicationResyncBucketStatus")
+            .field("has_bucket", &!self.bucket.is_empty())
+            .field("has_status", &!self.status.is_empty())
+            .field("has_error_detail", &!self.error_detail.is_empty())
+            .field("extension_count", &self.extensions.len())
+            .finish()
+    }
+}
+
+/// Typed response from `site-replication/resync/op`.
+#[derive(Clone, Serialize, Deserialize, Default)]
+pub struct SiteReplicationResyncStatus {
+    #[serde(rename = "op", default)]
+    pub operation: String,
+    #[serde(rename = "id", default)]
+    pub resync_id: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub buckets: Vec<SiteReplicationResyncBucketStatus>,
+    #[serde(rename = "errorDetail", default)]
+    pub error_detail: String,
+    #[serde(flatten)]
+    pub extensions: BTreeMap<String, Value>,
+    #[serde(skip)]
+    semantic_failure: Option<bool>,
+    #[serde(skip)]
+    semantic_not_found: bool,
+}
+
+impl SiteReplicationResyncStatus {
+    /// Freeze protocol semantics before credentials are redacted for output.
+    ///
+    /// Once captured, the semantic result intentionally remains stable even if
+    /// the public wire fields are replaced by their safe output projections.
+    pub fn capture_semantics(&mut self) {
+        self.semantic_failure = Some(self.compute_failure());
+        self.semantic_not_found = self.status.trim().eq_ignore_ascii_case("not-found");
+    }
+
+    /// Detect overall and partial failures without trusting a success summary.
+    pub fn has_failure(&self) -> bool {
+        self.semantic_failure
+            .unwrap_or_else(|| self.compute_failure())
+    }
+
+    /// Detect the wire-level no-snapshot marker after output sanitization.
+    pub fn is_not_found(&self) -> bool {
+        self.semantic_not_found || self.status.trim().eq_ignore_ascii_case("not-found")
+    }
+
+    fn compute_failure(&self) -> bool {
+        !status_is_success(&self.status)
+            || !self.error_detail.trim().is_empty()
+            || self
+                .buckets
+                .iter()
+                .any(SiteReplicationResyncBucketStatus::has_failure)
+    }
+}
+
+impl PartialEq for SiteReplicationResyncStatus {
+    fn eq(&self, other: &Self) -> bool {
+        self.operation == other.operation
+            && self.resync_id == other.resync_id
+            && self.status == other.status
+            && self.buckets == other.buckets
+            && self.error_detail == other.error_detail
+            && self.extensions == other.extensions
+    }
+}
+
+impl fmt::Debug for SiteReplicationResyncStatus {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SiteReplicationResyncStatus")
+            .field("has_operation", &!self.operation.is_empty())
+            .field("has_resync_id", &!self.resync_id.is_empty())
+            .field("has_status", &!self.status.is_empty())
+            .field("bucket_count", &self.buckets.len())
+            .field("has_error_detail", &!self.error_detail.is_empty())
+            .field("extension_count", &self.extensions.len())
+            .finish()
+    }
+}
+
+fn status_is_failed(status: &str) -> bool {
+    status.trim().eq_ignore_ascii_case("failed")
+}
+
+fn status_is_success(status: &str) -> bool {
+    status.trim().eq_ignore_ascii_case("success")
 }
 
 /// Typed response from `site-replication/edit`.
@@ -516,6 +663,36 @@ mod tests {
     }
 
     #[test]
+    fn peer_endpoint_falls_back_to_legacy_string_without_overriding_singular_endpoint() {
+        let legacy: SiteReplicationPeer = serde_json::from_value(serde_json::json!({
+            "endpoints": "https://legacy.example.test"
+        }))
+        .expect("legacy peer fixture");
+        let both: SiteReplicationPeer = serde_json::from_value(serde_json::json!({
+            "endpoint": "https://current.example.test",
+            "endpoints": "https://legacy.example.test"
+        }))
+        .expect("current peer fixture");
+        let empty_current: SiteReplicationPeer = serde_json::from_value(serde_json::json!({
+            "endpoint": "",
+            "endpoints": "https://legacy.example.test"
+        }))
+        .expect("empty current endpoint fixture");
+        let malformed_legacy: SiteReplicationPeer = serde_json::from_value(serde_json::json!({
+            "endpoints": ["https://legacy.example.test"]
+        }))
+        .expect("opaque legacy peer fixture");
+
+        assert_eq!(legacy.endpoint(), Some("https://legacy.example.test"));
+        assert_eq!(both.endpoint(), Some("https://current.example.test"));
+        assert_eq!(
+            empty_current.endpoint(),
+            Some("https://legacy.example.test")
+        );
+        assert_eq!(malformed_legacy.endpoint(), None);
+    }
+
+    #[test]
     fn peer_debug_reports_ca_presence_without_exposing_certificate() {
         let info: SiteReplicationInfo =
             serde_json::from_str(SITE_INFO).expect("valid site information fixture");
@@ -610,6 +787,175 @@ mod tests {
         let debug = format!("{status:?}");
         assert!(!debug.contains("updated"));
         assert!(!debug.contains("preserved"));
+    }
+
+    #[test]
+    fn resync_operations_use_exact_wire_values_and_classify_mutations() {
+        for (operation, wire, mutation) in [
+            (SiteReplicationResyncOperation::Start, "start", true),
+            (SiteReplicationResyncOperation::Status, "status", false),
+            (SiteReplicationResyncOperation::Cancel, "cancel", true),
+        ] {
+            assert_eq!(operation.as_str(), wire);
+            assert_eq!(operation.is_mutation(), mutation);
+            assert_eq!(
+                serde_json::to_value(operation).expect("operation is serializable"),
+                wire
+            );
+            assert_eq!(
+                serde_json::from_value::<SiteReplicationResyncOperation>(Value::String(
+                    wire.to_string()
+                ))
+                .expect("operation is deserializable"),
+                operation
+            );
+        }
+    }
+
+    #[test]
+    fn resync_status_preserves_exact_fields_and_unknown_extensions() {
+        let status: SiteReplicationResyncStatus = serde_json::from_value(serde_json::json!({
+            "op": "start",
+            "id": "resync-id",
+            "status": "success",
+            "buckets": [{
+                "bucket": "photos",
+                "status": "started",
+                "errorDetail": "",
+                "futureBucket": {"attempt": 2}
+            }],
+            "errorDetail": "",
+            "futureResponse": {"revision": 7}
+        }))
+        .expect("valid site resync status");
+
+        assert_eq!(status.operation, "start");
+        assert_eq!(status.resync_id, "resync-id");
+        assert_eq!(status.status, "success");
+        assert_eq!(status.buckets[0].bucket, "photos");
+        assert_eq!(status.buckets[0].status, "started");
+        assert_eq!(status.buckets[0].extensions["futureBucket"]["attempt"], 2);
+        assert_eq!(status.extensions["futureResponse"]["revision"], 7);
+
+        let wire = serde_json::to_value(status).expect("status is serializable");
+        assert_eq!(wire["op"], "start");
+        assert_eq!(wire["id"], "resync-id");
+        assert_eq!(wire["buckets"][0]["errorDetail"], "");
+        assert_eq!(wire["futureResponse"]["revision"], 7);
+    }
+
+    #[test]
+    fn resync_status_wire_equality_ignores_frozen_output_semantics() {
+        let mut status: SiteReplicationResyncStatus = serde_json::from_value(serde_json::json!({
+            "op": "status",
+            "status": "not-found"
+        }))
+        .expect("valid site resync status");
+        status.capture_semantics();
+        status.status = "[REDACTED]".to_string();
+
+        assert!(status.is_not_found());
+        assert!(status.has_failure());
+        let wire = serde_json::to_vec(&status).expect("status is serializable");
+        let round_trip: SiteReplicationResyncStatus =
+            serde_json::from_slice(&wire).expect("status is deserializable");
+        assert_eq!(status, round_trip);
+    }
+
+    #[test]
+    fn resync_status_debug_never_prints_arbitrary_server_strings() {
+        let status: SiteReplicationResyncStatus = serde_json::from_value(serde_json::json!({
+            "op": "SECRET-OPERATION",
+            "id": "SECRET-RESYNC-ID",
+            "status": "SECRET-STATUS",
+            "buckets": [{
+                "bucket": "SECRET-BUCKET",
+                "status": "SECRET-BUCKET-STATUS",
+                "errorDetail": "SECRET-BUCKET-ERROR",
+                "SECRET-BUCKET-EXTENSION": "SECRET-BUCKET-VALUE"
+            }],
+            "errorDetail": "SECRET-ERROR",
+            "SECRET-EXTENSION": "SECRET-VALUE"
+        }))
+        .expect("valid sensitive status fixture");
+
+        let status_debug = format!("{status:?}");
+        let bucket_debug = format!("{:?}", status.buckets[0]);
+        for secret in [
+            "SECRET-OPERATION",
+            "SECRET-RESYNC-ID",
+            "SECRET-STATUS",
+            "SECRET-BUCKET",
+            "SECRET-BUCKET-STATUS",
+            "SECRET-BUCKET-ERROR",
+            "SECRET-BUCKET-EXTENSION",
+            "SECRET-BUCKET-VALUE",
+            "SECRET-ERROR",
+            "SECRET-EXTENSION",
+            "SECRET-VALUE",
+        ] {
+            assert!(!status_debug.contains(secret));
+            assert!(!bucket_debug.contains(secret));
+        }
+        assert!(status_debug.contains("bucket_count: 1"));
+        assert!(bucket_debug.contains("has_error_detail: true"));
+    }
+
+    #[test]
+    fn resync_status_detects_overall_and_partial_bucket_failures() {
+        let success_bucket = SiteReplicationResyncBucketStatus {
+            bucket: "photos".into(),
+            status: "started".into(),
+            ..Default::default()
+        };
+        let success = SiteReplicationResyncStatus {
+            status: "success".into(),
+            buckets: vec![success_bucket.clone()],
+            ..Default::default()
+        };
+        assert!(!success.has_failure());
+
+        let overall_failed = SiteReplicationResyncStatus {
+            status: "FAILED".into(),
+            ..Default::default()
+        };
+        assert!(overall_failed.has_failure());
+
+        let partial_overall = SiteReplicationResyncStatus {
+            status: "partial".into(),
+            ..Default::default()
+        };
+        assert!(partial_overall.has_failure());
+
+        let overall_error = SiteReplicationResyncStatus {
+            status: "success".into(),
+            error_detail: "partial failure".into(),
+            ..Default::default()
+        };
+        assert!(overall_error.has_failure());
+
+        let failed_bucket = SiteReplicationResyncStatus {
+            status: "success".into(),
+            buckets: vec![SiteReplicationResyncBucketStatus {
+                status: "failed".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(failed_bucket.has_failure());
+
+        let bucket_error = SiteReplicationResyncStatus {
+            status: "success".into(),
+            buckets: vec![SiteReplicationResyncBucketStatus {
+                status: "started".into(),
+                error_detail: "target rejected bucket".into(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        assert!(bucket_error.has_failure());
+        assert!(bucket_error.buckets[0].has_failure());
+        assert!(!success_bucket.has_failure());
     }
 
     #[test]

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -69,6 +69,10 @@ pub enum Error {
     /// General error
     #[error("{0}")]
     General(String),
+
+    /// Request rejected locally before any network operation was attempted
+    #[error("{0}")]
+    RequestRejected(String),
 }
 
 impl Error {
@@ -82,6 +86,7 @@ impl Error {
             Error::NotFound(_) | Error::AliasNotFound(_) => 5, // NotFound
             Error::Conflict(_) | Error::AliasExists(_) => 6,   // Conflict
             Error::UnsupportedFeature(_) => 7,                 // UnsupportedFeature
+            Error::RequestRejected(_) => 1,                    // GeneralError
             _ => 1,                                            // GeneralError
         }
     }
@@ -102,6 +107,7 @@ mod tests {
         assert_eq!(Error::Conflict("test".into()).exit_code(), 6);
         assert_eq!(Error::AliasExists("test".into()).exit_code(), 6);
         assert_eq!(Error::UnsupportedFeature("test".into()).exit_code(), 7);
+        assert_eq!(Error::RequestRejected("test".into()).exit_code(), 1);
         assert_eq!(Error::General("test".into()).exit_code(), 1);
     }
 

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -20,8 +20,8 @@ use rc_core::admin::{
     PoolStatus, PoolTarget, RebalanceStartResult, RebalanceStatus, ReplicateEditStatus,
     RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ServiceAccount,
     ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec, SiteReplicationInfo,
-    SiteReplicationPeer, SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest,
-    User, UserStatus,
+    SiteReplicationPeer, SiteReplicationResyncOperation, SiteReplicationResyncStatus,
+    SiteStatusOptions, UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -368,17 +368,18 @@ impl AdminClient {
         path: &str,
         body: Option<&[u8]>,
         operation_label: &'static str,
+        mutation_outcome_label: Option<&'static str>,
+        uncertain_response_label: Option<&'static str>,
     ) -> Result<T> {
         let body_bytes = body.unwrap_or(&[]);
         if body_bytes.len() > MAX_SITE_REPLICATION_REQUEST_BYTES {
-            return Err(Error::General(format!(
+            return Err(Error::RequestRejected(format!(
                 "Site replication request size {} exceeds the {} byte limit",
                 body_bytes.len(),
                 MAX_SITE_REPLICATION_REQUEST_BYTES
             )));
         }
 
-        let is_edit = method == Method::PUT;
         let url = self.admin_url(path);
         let headers = self.request_headers(body_bytes)?;
         let signed_headers = self
@@ -393,9 +394,9 @@ impl AdminClient {
         }
 
         let response = request_builder.send().await.map_err(|error| {
-            if is_edit {
+            if let Some(mutation_outcome_label) = mutation_outcome_label {
                 Error::Network(format!(
-                    "Site replication edit outcome is unknown; the request was not retried: {error}"
+                    "{mutation_outcome_label} outcome is unknown; the request was not retried: {error}"
                 ))
             } else {
                 Error::Network(format!("Request failed: {error}"))
@@ -411,36 +412,57 @@ impl AdminClient {
             .content_length()
             .is_some_and(|content_length| content_length > limit as u64)
         {
-            return Err(Error::General(format!(
-                "Site replication response exceeds the {limit} byte limit"
-            )));
+            return Err(site_replication_response_rejected(
+                uncertain_response_label,
+                format!("response exceeds the {limit} byte limit"),
+            ));
         }
 
         let mut bytes = Vec::new();
         let mut stream = response.bytes_stream();
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(|error| {
-                if is_edit {
+                if let Some(mutation_outcome_label) = mutation_outcome_label {
                     Error::Network(format!(
-                        "Site replication edit outcome is unknown; the response could not be read and the request was not retried: {error}"
+                        "{mutation_outcome_label} outcome is unknown; the response could not be read and the request was not retried: {error}"
                     ))
                 } else {
                     Error::Network(format!("Failed to read site replication response: {error}"))
                 }
             })?;
             if bytes.len().saturating_add(chunk.len()) > limit {
-                return Err(Error::General(format!(
-                    "Site replication response exceeds the {limit} byte limit"
-                )));
+                return Err(site_replication_response_rejected(
+                    uncertain_response_label,
+                    format!("response exceeds the {limit} byte limit"),
+                ));
             }
             bytes.extend_from_slice(&chunk);
         }
 
         if !status.is_success() {
             let error_body = String::from_utf8_lossy(&bytes);
-            return Err(self.map_site_replication_error(status, &error_body, operation_label));
+            let error = self.map_site_replication_error(status, &error_body, operation_label);
+            if !status.is_redirection()
+                && matches!(error, Error::Network(_))
+                && let Some(label) = uncertain_response_label
+            {
+                return Err(site_replication_response_unknown_network(
+                    label,
+                    status.as_u16(),
+                ));
+            }
+            return Err(error);
         }
-        serde_json::from_slice(&bytes).map_err(Error::Json)
+        serde_json::from_slice(&bytes).map_err(|error| {
+            if uncertain_response_label.is_some() {
+                site_replication_response_rejected(
+                    uncertain_response_label,
+                    "server returned malformed JSON".to_string(),
+                )
+            } else {
+                Error::Json(error)
+            }
+        })
     }
 
     /// Make a signed request that returns no body
@@ -562,8 +584,14 @@ impl AdminClient {
                 "{operation_label} is not supported by this server"
             ));
         }
-        if status == StatusCode::BAD_REQUEST && site_replication_operation_conflicts(body) {
-            return Error::Conflict("A site replication operation is already pending".to_string());
+        if status == StatusCode::BAD_REQUEST
+            && (site_replication_operation_conflicts(body)
+                || (operation_label.starts_with("Site replication resync")
+                    && site_replication_resync_conflicts(body)))
+        {
+            return Error::Conflict(
+                "Site replication request conflicts with current server state".to_string(),
+            );
         }
         if matches!(status, StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED) {
             return Error::Auth("Authentication failed for site replication request".to_string());
@@ -581,13 +609,74 @@ impl AdminClient {
     }
 
     fn sanitize_site_replication_status(&self, status: &mut ReplicateEditStatus) {
-        for credential in [&self.access_key, &self.secret_key] {
-            if !credential.is_empty() {
-                status.status = status.status.replace(credential, "[REDACTED]");
-                status.error_detail = status.error_detail.replace(credential, "[REDACTED]");
+        self.redact_admin_credentials(&mut status.status);
+        self.redact_admin_credentials(&mut status.error_detail);
+    }
+
+    fn sanitize_site_replication_resync_status(&self, status: &mut SiteReplicationResyncStatus) {
+        self.redact_admin_credentials(&mut status.operation);
+        self.redact_admin_credentials(&mut status.resync_id);
+        self.redact_admin_credentials(&mut status.status);
+        self.redact_admin_credentials(&mut status.error_detail);
+        for value in status.extensions.values_mut() {
+            self.redact_admin_credentials_in_value(value);
+        }
+        for bucket in &mut status.buckets {
+            self.redact_admin_credentials(&mut bucket.bucket);
+            self.redact_admin_credentials(&mut bucket.status);
+            self.redact_admin_credentials(&mut bucket.error_detail);
+            for value in bucket.extensions.values_mut() {
+                self.redact_admin_credentials_in_value(value);
             }
         }
     }
+
+    fn redact_admin_credentials_in_value(&self, value: &mut serde_json::Value) {
+        match value {
+            serde_json::Value::String(value) => self.redact_admin_credentials(value),
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    self.redact_admin_credentials_in_value(value);
+                }
+            }
+            serde_json::Value::Object(values) => {
+                for value in values.values_mut() {
+                    self.redact_admin_credentials_in_value(value);
+                }
+            }
+            serde_json::Value::Null | serde_json::Value::Bool(_) | serde_json::Value::Number(_) => {
+            }
+        }
+    }
+
+    fn redact_admin_credentials(&self, value: &mut String) {
+        let mut credentials = [&self.access_key, &self.secret_key];
+        credentials.sort_by_key(|credential| std::cmp::Reverse(credential.len()));
+        for credential in credentials {
+            if !credential.is_empty() {
+                *value = value.replace(credential, "[REDACTED]");
+            }
+        }
+    }
+}
+
+fn site_replication_response_rejected(
+    mutation_outcome_label: Option<&str>,
+    reason: String,
+) -> Error {
+    if let Some(label) = mutation_outcome_label {
+        Error::General(format!(
+            "{label} outcome is unknown because the {reason}; do not retry blindly; inspect the persisted resync snapshot and storage state"
+        ))
+    } else {
+        Error::General(format!("Site replication {reason}"))
+    }
+}
+
+fn site_replication_response_unknown_network(label: &str, status: u16) -> Error {
+    Error::Network(format!(
+        "{label} outcome is unknown after the server returned HTTP {status}; do not retry blindly; inspect the persisted resync snapshot and storage state"
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -616,6 +705,80 @@ fn site_replication_operation_conflicts(body: &str) -> bool {
         error.code.as_deref(),
         error.message.as_deref().unwrap_or_default(),
     )
+}
+
+fn site_replication_resync_conflicts(body: &str) -> bool {
+    let Some(error) = parse_admin_error(body) else {
+        return false;
+    };
+    if error.code.as_deref() != Some("InvalidRequest") {
+        return false;
+    }
+
+    matches!(
+        error
+            .message
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase()
+            .as_str(),
+        "no resync in progress"
+            | "invalid peer specified - cannot resync to self"
+            | "site replication peer not found"
+    )
+}
+
+fn validate_site_replication_resync_status(
+    requested_operation: &SiteReplicationResyncOperation,
+    status: &SiteReplicationResyncStatus,
+) -> Result<()> {
+    if status.operation.trim().is_empty() {
+        return Err(Error::General(
+            "Site replication resync response is missing the operation".to_string(),
+        ));
+    }
+    if status.status.trim().is_empty() {
+        return Err(Error::General(
+            "Site replication resync response is missing the status".to_string(),
+        ));
+    }
+    if requested_operation.is_mutation()
+        && !status
+            .operation
+            .trim()
+            .eq_ignore_ascii_case(requested_operation.as_str())
+    {
+        return Err(Error::General(
+            "Site replication resync response operation does not match the requested mutation"
+                .to_string(),
+        ));
+    }
+    let response_is_mutation = matches!(
+        status.operation.trim().to_ascii_lowercase().as_str(),
+        "start" | "cancel"
+    );
+    let is_no_snapshot = *requested_operation == SiteReplicationResyncOperation::Status
+        && status.operation.trim().eq_ignore_ascii_case("status")
+        && status.status.trim().eq_ignore_ascii_case("not-found");
+    if (requested_operation.is_mutation() || response_is_mutation)
+        && !is_no_snapshot
+        && status.resync_id.trim().is_empty()
+    {
+        return Err(Error::General(
+            "Site replication resync response is missing the operation ID".to_string(),
+        ));
+    }
+    if status
+        .buckets
+        .iter()
+        .any(|bucket| bucket.bucket.trim().is_empty() || bucket.status.trim().is_empty())
+    {
+        return Err(Error::General(
+            "Site replication resync response contains an incomplete bucket record".to_string(),
+        ));
+    }
+    Ok(())
 }
 
 fn site_replication_server_invalid_state(code: Option<&str>, message: &str) -> bool {
@@ -1860,6 +2023,8 @@ impl AdminApi for AdminClient {
             "/site-replication/info",
             None,
             "Site replication info",
+            None,
+            None,
         )
         .await
     }
@@ -1875,6 +2040,8 @@ impl AdminApi for AdminClient {
                 "/site-replication/edit",
                 Some(&body),
                 "Site replication edit",
+                Some("Site replication edit"),
+                None,
             )
             .await?;
         self.sanitize_site_replication_status(&mut status);
@@ -1896,6 +2063,51 @@ impl AdminApi for AdminClient {
                 "Site replication edit was rejected by the server".to_string(),
             ))
         }
+    }
+
+    async fn site_replication_resync(
+        &self,
+        operation: SiteReplicationResyncOperation,
+        peer: &SiteReplicationPeer,
+    ) -> Result<SiteReplicationResyncStatus> {
+        let (operation_label, mutation_outcome_label) = match &operation {
+            SiteReplicationResyncOperation::Start => (
+                "Site replication resync start",
+                Some("Site replication resync start"),
+            ),
+            SiteReplicationResyncOperation::Status => ("Site replication resync status", None),
+            SiteReplicationResyncOperation::Cancel => (
+                "Site replication resync cancel",
+                Some("Site replication resync cancel"),
+            ),
+        };
+        let path = format!(
+            "/site-replication/resync/op?operation={}",
+            operation.as_str()
+        );
+        let body = serde_json::to_vec(peer).map_err(Error::Json)?;
+        let mut status = self
+            .request_site_replication(
+                Method::PUT,
+                &path,
+                Some(&body),
+                operation_label,
+                mutation_outcome_label,
+                mutation_outcome_label,
+            )
+            .await?;
+        if let Err(error) = validate_site_replication_resync_status(&operation, &status) {
+            if operation.is_mutation() {
+                return Err(site_replication_response_rejected(
+                    mutation_outcome_label,
+                    "server returned an invalid resync response".to_string(),
+                ));
+            }
+            return Err(error);
+        }
+        status.capture_semantics();
+        self.sanitize_site_replication_resync_status(&mut status);
+        Ok(status)
     }
 
     async fn site_replication_add(&self, sites: &[PeerSiteSpec]) -> Result<serde_json::Value> {
@@ -2063,6 +2275,24 @@ mod tests {
         });
 
         (endpoint, handle)
+    }
+
+    fn start_admin_disconnect_server() -> (
+        String,
+        mpsc::Receiver<CapturedAdminRequest>,
+        thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            sender
+                .send(read_admin_request(&mut stream))
+                .expect("send captured request");
+        });
+
+        (endpoint, receiver, handle)
     }
 
     fn admin_client_for_endpoint(endpoint: &str) -> AdminClient {
@@ -3697,7 +3927,7 @@ mod tests {
             .await
             .expect_err("oversized request must fail before connecting");
 
-        assert!(matches!(error, Error::General(_)));
+        assert!(matches!(error, Error::RequestRejected(_)));
         assert!(error.to_string().contains("exceeds"));
     }
 
@@ -3979,6 +4209,575 @@ mod tests {
         assert!(!status.error_detail.contains("access"));
         assert!(!status.error_detail.contains("secret"));
         assert!(status.status.contains("[REDACTED]"));
+        handle.join().expect("server thread should finish");
+    }
+
+    fn site_replication_resync_peer() -> SiteReplicationPeer {
+        serde_json::from_str(
+            r#"{
+                "endpoint":"https://secondary.example.test",
+                "name":"secondary",
+                "deploymentID":"deployment-2",
+                "sync":"enable",
+                "futurePeer":{"mode":"preserved"}
+            }"#,
+        )
+        .expect("valid resync peer")
+    }
+
+    const SITE_REPLICATION_RESYNC_RESPONSE: &str = r#"{
+        "op":"start",
+        "id":"resync-123",
+        "status":"success",
+        "buckets":[{"bucket":"photos","status":"started","errorDetail":""}],
+        "errorDetail":"",
+        "generation":7
+    }"#;
+
+    #[tokio::test]
+    async fn site_replication_resync_sends_exact_start_query_and_complete_peer() {
+        let (endpoint, receiver, handle) =
+            start_admin_test_server("200 OK", SITE_REPLICATION_RESYNC_RESPONSE);
+        let client = admin_client_for_endpoint(&endpoint);
+        let peer = site_replication_resync_peer();
+
+        let status = client
+            .site_replication_resync(SiteReplicationResyncOperation::Start, &peer)
+            .await
+            .expect("resync start request");
+
+        let returned = serde_json::to_value(status).expect("resync status serializes");
+        assert_eq!(returned["op"], "start");
+        assert_eq!(returned["id"], "resync-123");
+        assert_eq!(returned["buckets"][0]["bucket"], "photos");
+        assert_eq!(returned["generation"], 7);
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "PUT");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/site-replication/resync/op?operation=start"
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&request.body).expect("resync body should be JSON");
+        assert_eq!(body["endpoint"], "https://secondary.example.test");
+        assert_eq!(body["deploymentID"], "deployment-2");
+        assert_eq!(body["sync"], "enable");
+        assert_eq!(body["futurePeer"]["mode"], "preserved");
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_status_works_with_a_fresh_client() {
+        let (endpoint, receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", SITE_REPLICATION_RESYNC_RESPONSE),
+            ("200 OK", SITE_REPLICATION_RESYNC_RESPONSE),
+        ]);
+        let peer = site_replication_resync_peer();
+        let first_client = admin_client_for_endpoint(&endpoint);
+        first_client
+            .site_replication_resync(SiteReplicationResyncOperation::Start, &peer)
+            .await
+            .expect("resync start request");
+        drop(first_client);
+
+        let fresh_client = admin_client_for_endpoint(&endpoint);
+        let status = fresh_client
+            .site_replication_resync(SiteReplicationResyncOperation::Status, &peer)
+            .await
+            .expect("fresh-client resync status request");
+
+        assert_eq!(
+            serde_json::to_value(status).expect("status serializes")["id"],
+            "resync-123"
+        );
+        let start = receiver.recv().expect("captured start request");
+        let status = receiver.recv().expect("captured status request");
+        assert_eq!(
+            start.target,
+            "/rustfs/admin/v3/site-replication/resync/op?operation=start"
+        );
+        assert_eq!(
+            status.target,
+            "/rustfs/admin/v3/site-replication/resync/op?operation=status"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_redacts_known_and_nested_extension_values() {
+        let response = r#"{
+            "op":"start-access",
+            "id":"secret-id",
+            "status":"access secret",
+            "buckets":[{
+                "bucket":"access-bucket",
+                "status":"secret-status",
+                "errorDetail":"access secret",
+                "futureBucket":"access secret"
+            }],
+            "errorDetail":"access secret",
+            "futureTop":{
+                "updatedAt":"access secret",
+                "progress":["access",{"message":"secret"}]
+            }
+        }"#;
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", response);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let status = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Status,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect("resync status request");
+        let value = serde_json::to_value(status).expect("resync status serializes");
+
+        for field in [
+            &value["op"],
+            &value["id"],
+            &value["status"],
+            &value["errorDetail"],
+            &value["buckets"][0]["bucket"],
+            &value["buckets"][0]["status"],
+            &value["buckets"][0]["errorDetail"],
+        ] {
+            let field = field.as_str().expect("known string field");
+            assert!(!field.contains("access"));
+            assert!(!field.contains("secret"));
+            assert!(field.contains("[REDACTED]"));
+        }
+        assert_eq!(value["futureTop"]["updatedAt"], "[REDACTED] [REDACTED]");
+        assert_eq!(value["futureTop"]["progress"][0], "[REDACTED]");
+        assert_eq!(value["futureTop"]["progress"][1]["message"], "[REDACTED]");
+        assert_eq!(value["buckets"][0]["futureBucket"], "[REDACTED] [REDACTED]");
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_preserves_semantics_when_credentials_match_status_values() {
+        let response = r#"{
+            "op":"start",
+            "id":"resync-1",
+            "status":"success",
+            "buckets":[{"bucket":"photos","status":"started"}]
+        }"#;
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", response);
+        let alias = Alias::new("test", &endpoint, "success", "success-extra");
+        let client = AdminClient::new(&alias).expect("admin client should build");
+
+        let status = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Start,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect("resync start request");
+
+        assert!(!status.has_failure());
+        assert_eq!(status.status, "[REDACTED]");
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_redacts_overlapping_credentials_longest_first() {
+        let response = r#"{
+            "op":"start",
+            "id":"resync-1",
+            "status":"success",
+            "updatedAt":"ABCDEF ABC"
+        }"#;
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", response);
+        let alias = Alias::new("test", &endpoint, "ABC", "ABCDEF");
+        let client = AdminClient::new(&alias).expect("admin client should build");
+
+        let status = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Start,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect("resync start request");
+        let value = serde_json::to_value(status).expect("resync status serializes");
+
+        assert_eq!(value["updatedAt"], "[REDACTED] [REDACTED]");
+        assert!(!value.to_string().contains("DEF"));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_rejects_incomplete_success_payloads_without_echoing_them() {
+        for malformed in [
+            r#"{"status":"success","id":"resync-1","marker":"DO-NOT-ECHO"}"#,
+            r#"{"op":"start","id":"resync-1","marker":"DO-NOT-ECHO"}"#,
+            r#"{"op":"start","status":"success","marker":"DO-NOT-ECHO"}"#,
+            r#"{"op":"cancel","status":"success","marker":"DO-NOT-ECHO"}"#,
+            r#"{"op":"start","status":"not-found","marker":"DO-NOT-ECHO"}"#,
+            r#"{"op":"start","id":"resync-1","status":"success","buckets":[{"status":"started"}],"marker":"DO-NOT-ECHO"}"#,
+            r#"{"op":"start","id":"resync-1","status":"success","buckets":[{"bucket":"photos"}],"marker":"DO-NOT-ECHO"}"#,
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", malformed);
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(
+                    SiteReplicationResyncOperation::Status,
+                    &site_replication_resync_peer(),
+                )
+                .await
+                .expect_err("incomplete resync response must fail");
+
+            assert!(matches!(error, Error::General(_)));
+            assert_eq!(error.exit_code(), 1);
+            assert!(!error.to_string().contains("DO-NOT-ECHO"));
+            handle.join().expect("server thread should finish");
+        }
+
+        let (endpoint, _receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"op":"status","status":"success","marker":"DO-NOT-ECHO"}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Start,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect_err("requested mutation must require an operation ID");
+        assert!(matches!(error, Error::General(_)));
+        assert_eq!(error.exit_code(), 1);
+        assert!(!error.to_string().contains("DO-NOT-ECHO"));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_accepts_not_found_without_id_and_future_wire_values() {
+        for response in [
+            r#"{"op":"status","status":"not-found"}"#,
+            r#"{"op":"future-operation","status":"future-status","future":true}"#,
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", response);
+            let client = admin_client_for_endpoint(&endpoint);
+            let status = client
+                .site_replication_resync(
+                    SiteReplicationResyncOperation::Status,
+                    &site_replication_resync_peer(),
+                )
+                .await
+                .expect("valid future-compatible resync response");
+
+            let value = serde_json::to_value(status).expect("resync status serializes");
+            let expected: serde_json::Value =
+                serde_json::from_str(response).expect("valid expected JSON");
+            assert_eq!(value["op"], expected["op"]);
+            assert_eq!(value["status"], expected["status"]);
+            if expected.get("future").is_some() {
+                assert_eq!(value["future"], true);
+            }
+            handle.join().expect("server thread should finish");
+        }
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_requires_mutations_to_echo_the_requested_operation() {
+        for (operation, response_operation) in [
+            (SiteReplicationResyncOperation::Start, "cancel"),
+            (SiteReplicationResyncOperation::Cancel, "start"),
+        ] {
+            let response =
+                format!(r#"{{"op":"{response_operation}","id":"resync-1","status":"success"}}"#);
+            let leaked: &'static str = Box::leak(response.into_boxed_str());
+            let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", leaked);
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(operation, &site_replication_resync_peer())
+                .await
+                .expect_err("mismatched mutation operation must fail");
+
+            assert!(matches!(error, Error::General(_)));
+            assert!(error.to_string().contains("outcome is unknown"));
+            assert!(error.to_string().contains("do not retry blindly"));
+            handle.join().expect("server thread should finish");
+        }
+
+        let (endpoint, _receiver, handle) = start_admin_test_server(
+            "200 OK",
+            r#"{"op":"start","id":"resync-1","status":"success"}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+        client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Status,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect("status may return the persisted start snapshot");
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_rejects_oversized_request_before_network() {
+        let client = admin_client_for_endpoint("http://127.0.0.1:1");
+        let mut peer = site_replication_resync_peer();
+        peer.set_ca_cert_pem("x".repeat(MAX_SITE_REPLICATION_REQUEST_BYTES + 1));
+
+        let error = client
+            .site_replication_resync(SiteReplicationResyncOperation::Start, &peer)
+            .await
+            .expect_err("oversized resync request must fail before connecting");
+
+        assert!(matches!(error, Error::RequestRejected(_)));
+        assert!(error.to_string().contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_enforces_success_and_error_response_bounds() {
+        let success_response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n",
+            MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES + 1
+        )
+        .into_bytes();
+        let (endpoint, handle) = start_admin_raw_response_server(success_response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let peer = site_replication_resync_peer();
+        let error = client
+            .site_replication_resync(SiteReplicationResyncOperation::Status, &peer)
+            .await
+            .expect_err("declared oversized success must fail");
+        assert!(matches!(error, Error::General(_)));
+        assert!(error.to_string().contains("exceeds"));
+        assert!(!error.to_string().contains("outcome is unknown"));
+        handle.join().expect("server thread should finish");
+
+        let mut error_response = b"HTTP/1.1 500 Internal Server Error\r\ntransfer-encoding: chunked\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n".to_vec();
+        let body = vec![b'x'; MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES + 1];
+        error_response.extend_from_slice(format!("{:x}\r\n", body.len()).as_bytes());
+        error_response.extend_from_slice(&body);
+        error_response.extend_from_slice(b"\r\n0\r\n\r\n");
+        let (endpoint, handle) = start_admin_raw_response_server(error_response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(SiteReplicationResyncOperation::Start, &peer)
+            .await
+            .expect_err("chunked oversized error must fail");
+        assert!(matches!(error, Error::General(_)));
+        assert!(error.to_string().contains("exceeds"));
+        assert!(error.to_string().contains("outcome is unknown"));
+        assert!(error.to_string().contains("do not retry blindly"));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_mutation_rejects_malformed_success_as_unknown() {
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", "{not-json");
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Start,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect_err("malformed mutation response must fail");
+
+        assert!(matches!(error, Error::General(_)));
+        assert!(error.to_string().contains("outcome is unknown"));
+        assert!(error.to_string().contains("do not retry blindly"));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_mutation_server_error_is_an_unknown_outcome() {
+        for operation in [
+            SiteReplicationResyncOperation::Start,
+            SiteReplicationResyncOperation::Cancel,
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server(
+                "500 Internal Server Error",
+                r#"{"message":"snapshot save failed"}"#,
+            );
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(operation, &site_replication_resync_peer())
+                .await
+                .expect_err("mutation server error must report an unknown outcome");
+
+            assert!(matches!(error, Error::Network(_)));
+            assert!(error.to_string().contains("outcome is unknown"));
+            assert!(error.to_string().contains("do not retry blindly"));
+            assert!(!error.to_string().contains("snapshot save failed"));
+            handle.join().expect("server thread should finish");
+        }
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_does_not_follow_redirects() {
+        for operation in [
+            SiteReplicationResyncOperation::Start,
+            SiteReplicationResyncOperation::Status,
+            SiteReplicationResyncOperation::Cancel,
+        ] {
+            let response = b"HTTP/1.1 307 Temporary Redirect\r\nlocation: http://127.0.0.1:1/replayed\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec();
+            let (endpoint, handle) = start_admin_raw_response_server(response);
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(operation, &site_replication_resync_peer())
+                .await
+                .expect_err("resync redirect must not be followed");
+
+            assert!(matches!(error, Error::Network(_)));
+            assert!(error.to_string().contains("HTTP 307"));
+            handle.join().expect("server thread should finish");
+        }
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_start_and_cancel_disconnects_have_specific_unknown_outcomes() {
+        for (operation, label) in [
+            (SiteReplicationResyncOperation::Start, "resync start"),
+            (SiteReplicationResyncOperation::Cancel, "resync cancel"),
+        ] {
+            let expected_target = format!(
+                "/rustfs/admin/v3/site-replication/resync/op?operation={}",
+                operation.as_str()
+            );
+            let (endpoint, receiver, handle) = start_admin_disconnect_server();
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(operation, &site_replication_resync_peer())
+                .await
+                .expect_err("mutation disconnect must report unknown outcome");
+
+            assert!(matches!(error, Error::Network(_)));
+            assert_eq!(error.exit_code(), 3);
+            assert!(error.to_string().contains(label));
+            assert!(error.to_string().contains("outcome is unknown"));
+            assert!(error.to_string().contains("not retried"));
+            let request = receiver.recv().expect("single captured request");
+            assert_eq!(request.method, "PUT");
+            assert_eq!(request.target, expected_target);
+            handle.join().expect("server thread should finish");
+        }
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_cancel_read_disconnect_has_specific_unknown_outcome() {
+        let response = b"HTTP/1.1 200 OK\r\ncontent-length: 128\r\ncontent-type: application/json\r\nconnection: close\r\n\r\n{\"op\":\"cancel\"".to_vec();
+        let (endpoint, handle) = start_admin_raw_response_server(response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Cancel,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect_err("truncated cancel response must fail");
+
+        assert!(matches!(error, Error::Network(_)));
+        assert!(error.to_string().contains("resync cancel"));
+        assert!(error.to_string().contains("outcome is unknown"));
+        assert!(error.to_string().contains("response could not be read"));
+        assert!(error.to_string().contains("not retried"));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_status_disconnect_is_retryable_network_semantics() {
+        let (endpoint, receiver, handle) = start_admin_disconnect_server();
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Status,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect_err("status disconnect must fail");
+
+        assert!(matches!(error, Error::Network(_)));
+        assert_eq!(error.exit_code(), 3);
+        assert!(!error.to_string().contains("outcome is unknown"));
+        assert!(!error.to_string().contains("not retried"));
+        let request = receiver.recv().expect("single captured request");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/site-replication/resync/op?operation=status"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn site_replication_resync_maps_route_and_state_errors() {
+        for (status, expected_exit) in [
+            ("401 Unauthorized", 4),
+            ("403 Forbidden", 4),
+            ("404 Not Found", 7),
+            ("405 Method Not Allowed", 7),
+            ("501 Not Implemented", 7),
+            ("409 Conflict", 6),
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server(status, "{}");
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(
+                    SiteReplicationResyncOperation::Status,
+                    &site_replication_resync_peer(),
+                )
+                .await
+                .expect_err("mapped resync response must fail");
+
+            assert_eq!(error.exit_code(), expected_exit, "HTTP status {status}");
+            handle.join().expect("server thread should finish");
+        }
+
+        let (endpoint, _receiver, handle) = start_admin_test_server(
+            "400 Bad Request",
+            r#"{"code":"SiteReplicationOperationPending","message":"site replication operation pending"}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Start,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect_err("pending resync must conflict");
+        assert_eq!(error.exit_code(), 6);
+        handle.join().expect("server thread should finish");
+
+        for message in [
+            "no resync in progress",
+            "invalid peer specified - cannot resync to self",
+            "site replication peer not found",
+        ] {
+            let body = format!(r#"{{"code":"InvalidRequest","message":"{message}"}}"#);
+            let leaked: &'static str = Box::leak(body.into_boxed_str());
+            let (endpoint, _receiver, handle) = start_admin_test_server("400 Bad Request", leaked);
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .site_replication_resync(
+                    SiteReplicationResyncOperation::Status,
+                    &site_replication_resync_peer(),
+                )
+                .await
+                .expect_err("known resync invalid state must conflict");
+
+            assert_eq!(error.exit_code(), 6, "message {message}");
+            handle.join().expect("server thread should finish");
+        }
+
+        let (endpoint, _receiver, handle) = start_admin_test_server(
+            "400 Bad Request",
+            r#"{"code":"InvalidRequest","message":"resync option is malformed"}"#,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+        let error = client
+            .site_replication_resync(
+                SiteReplicationResyncOperation::Status,
+                &site_replication_resync_peer(),
+            )
+            .await
+            .expect_err("arbitrary bad request must remain general");
+        assert_eq!(error.exit_code(), 1);
         handle.join().expect("server thread should finish");
     }
 

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -25,6 +25,8 @@ rc admin service <restart|stop|freeze|unfreeze> <ALIAS>
 rc admin replicate add <ALIAS> <ALIAS> [<ALIAS>...]
 rc admin replicate <info|status> <ALIAS> [OPTIONS]
 rc admin replicate edit <ALIAS> --site <DEPLOYMENT_ID|NAME> [EDIT OPTIONS] --yes
+rc admin replicate resync <start|cancel> <ALIAS> --site <DEPLOYMENT_ID|NAME> --yes
+rc admin replicate resync status <ALIAS> --site <DEPLOYMENT_ID|NAME>
 rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 ```
 
@@ -132,6 +134,8 @@ Link two sites for site replication and check the result:
 rc admin replicate add site1 site2
 rc admin replicate info site1
 rc admin replicate edit site1 --site <DEPLOYMENT_ID> --name edge-eu --yes
+rc admin replicate resync start site1 --site edge-eu --yes
+rc admin replicate resync status site1 --site edge-eu
 rc admin replicate status site1
 ```
 
@@ -222,6 +226,9 @@ The server response reports whether the action was `accepted` and whether it is 
 | `rc admin replicate add <ALIAS> <ALIAS> [<ALIAS>...]` | Link two or more sites into a site replication cluster. The first alias receives the request. |
 | `rc admin replicate info <ALIAS>` | Show the current site replication configuration. |
 | `rc admin replicate edit <ALIAS> --site <DEPLOYMENT_ID\|NAME> [EDIT OPTIONS] --yes` | Read the complete peer document, select one exact peer, apply a bounded edit, and write the peer document back. |
+| `rc admin replicate resync start <ALIAS> --site <DEPLOYMENT_ID\|NAME> --yes` | Request a site resync and return the mutation response snapshot. |
+| `rc admin replicate resync status <ALIAS> --site <DEPLOYMENT_ID\|NAME>` | Return the last persisted start or cancel snapshot. This is not live worker status. |
+| `rc admin replicate resync cancel <ALIAS> --site <DEPLOYMENT_ID\|NAME> --yes` | Request cancellation and return the mutation response snapshot. |
 | `rc admin replicate status <ALIAS> [OPTIONS]` | Show replication status. Without flags the buckets, users, groups, and policies summaries are requested. |
 | `rc admin replicate remove <ALIAS> --all` | Dissolve the entire site replication cluster. |
 | `rc admin replicate remove <ALIAS> --site <NAME>` | Remove one or more named sites. Repeat `--site` per name. |
@@ -252,6 +259,14 @@ The server response reports whether the action was `accepted` and whether it is 
 At least one edit option must produce an effective semantic change. Endpoint origins are canonicalized for comparison, while an omitted `skipTlsVerify` is treated as `false` and an omitted `caCertPem` is treated as empty. The command rejects a final HTTP peer state when `skipTlsVerify=true` or a non-empty custom CA remains. This permits an atomic HTTPS-to-HTTP conversion only when the same command clears the active TLS values.
 
 The complete selected peer object is retained privately and sent back with opaque future fields unchanged during the read-modify-write operation, but those fields are never printed. `info` and `edit` output use explicit safe projections: service-account access keys, CA contents, opaque future fields, and arbitrary server status strings are never printed. Successful JSON output uses output schema v3 with the `admin_operations` family. Mutating network failures are reported as non-retryable in JSON because the server outcome may be unknown; inspect `info` before deciding whether to retry.
+
+`resync start` and `resync cancel` require `--yes` before alias lookup or network access. All three resync commands select a deployment ID first, otherwise a unique exact site name. Their output retains the operation ID, ordered bucket snapshots, and error details. A failed bucket or non-empty error detail produces General exit `1` while still emitting the complete result. A missing persisted snapshot produces Conflict exit `6`.
+
+The current RustFS `resync status` endpoint returns the persisted result of the last successful start or cancel handler invocation; it does not inspect live workers. Every output therefore reports an unknown lifecycle state. Start operations can overlap, cancel is not idempotent, and bucket side effects are not atomic with snapshot persistence. A mutation timeout, malformed success response, or oversized success response has an unknown outcome and must not be retried blindly. See [Site Replication Resync Snapshots](../../site-replication-resync.md) for response bounds and the complete server limitations.
+
+### BREAKING resync contract migration
+
+The resync subcommands are additive and do not change existing command invocations. They use the existing output-v3 `admin_operations` envelope, so no JSON schema-version migration is required. The protected behavior contract is updated to make snapshot-only semantics explicit: automation must treat `result.lifecycle_state` as `unknown`, use `result.server_operation` only as the persisted operation type, and must not interpret `status` output as live progress. This PR must be marked `BREAKING` because it changes the protected CLI behavior contract.
 
 ### BREAKING output migration
 

--- a/docs/site-replication-resync.md
+++ b/docs/site-replication-resync.md
@@ -1,0 +1,49 @@
+# Site Replication Resync Snapshots
+
+`rc` exposes the RustFS site-replication resync handler through three bounded commands:
+
+```text
+rc admin replicate resync start ALIAS --site SITE --yes
+rc admin replicate resync status ALIAS --site SITE
+rc admin replicate resync cancel ALIAS --site SITE --yes
+```
+
+`SITE` must be an exact deployment ID or a unique exact display name. Deployment IDs take precedence. `start` and `cancel` require confirmation before alias loading or any network request. The commands reject an obvious self-target before mutation, while RustFS remains authoritative and may reject additional invalid target states.
+
+## Snapshot semantics
+
+The current RustFS `status` operation does not query live resync workers. It returns the persisted response from the last successful `start` or `cancel` handler invocation for the selected peer. `rc` therefore reports:
+
+- `snapshot_kind: persisted_last_operation` for `status`;
+- `snapshot_kind: mutation_response` for `start` and `cancel`;
+- `lifecycle_state: unknown` in every response;
+- the server operation and server status as snapshot fields, not as evidence that work is still running or has completed.
+
+The output uses the output-v3 `admin_operations` envelope. It retains the operation ID, every returned bucket status and error, the top-level error detail, and an allowlist of safe future lifecycle metadata. Credential-like and unknown extension fields are not projected.
+
+A non-empty error detail, an overall `failed` status, or any failed/error-bearing bucket makes the command exit with General `1`, even if the server's overall status string is `success`. The JSON result is still emitted so automation can inspect all bucket failures.
+
+## Current RustFS limitations
+
+These limitations apply to the current `/rustfs/admin/v3/site-replication/resync/op` implementation:
+
+- Every `start` creates a new UUID and can overlap an existing resync job.
+- Repeated `cancel` is not idempotent and can replace the previous snapshot with failed or partial results.
+- Bucket side effects occur before the site snapshot is saved. A crash or snapshot-save failure is not atomic and can leave effects without the corresponding snapshot.
+- Successful mutation snapshots survive fresh clients and server restarts, but `status` still does not query the live resync pool.
+- `status` lists all buckets before reading the snapshot, so an unrelated list-buckets failure can block the read.
+- Later runtime progress and failures are not aggregated into the saved snapshot.
+- `start` and `cancel` iterate all buckets synchronously. Responses are unpaginated and are accepted only up to the client response limit.
+
+Do not repeatedly invoke `start` or `cancel` as a recovery strategy. After a timeout or connection loss, the mutation outcome is unknown because a signed request may have reached RustFS. Inspect the persisted snapshot and the storage state before deciding whether another mutation is safe.
+
+## Bounds and transport behavior
+
+- Serialized peer request: 1 MiB maximum.
+- Successful response: 8 MiB maximum.
+- Error response: 64 KiB maximum.
+- Redirects are not followed.
+- Signed PUT requests are sent once and are never automatically retried.
+- A transport failure during `start` or `cancel` exits with Network `3` and reports an unknown outcome.
+
+Other exits are Usage `2`, Auth `4`, NotFound `5`, Conflict `6`, Unsupported `7`, and General `1` for malformed, oversized, partial, or all-bucket-failure responses.


### PR DESCRIPTION
Closes rustfs/backlog#1419

Parent: rustfs/backlog#1411
Roadmap: rustfs/backlog#1381, rustfs/backlog#1361
Depends on: rustfs/cli#290 and rustfs/backlog#1418

## Background

RustFS beta10 exposes `PUT /rustfs/admin/v3/site-replication/resync/op`, but its status response is a persisted snapshot of the last start or cancel handler invocation rather than live worker state. Without a typed and bounded CLI workflow, users can overstate lifecycle progress or blindly retry a mutation whose side effects may already have happened.

## Solution

- add `rc admin replicate resync start|status|cancel` with exact peer selection and pre-network `--yes` confirmation for mutations
- send the complete typed peer document using the exact beta10 query and body contract
- expose operation IDs, ordered per-bucket results, top-level details, and safe future metadata through output-v3 `admin_operations`
- label status as `persisted_last_operation` and lifecycle as `unknown`
- preserve partial/all-bucket failures in output and return General exit 1
- bound requests and responses, disable redirect replay, and distinguish local request rejection from an attempted mutation
- report disconnects, malformed/oversized mutation responses, and unclassified server failures as unknown outcomes with no blind retry guidance
- redact credentials recursively without changing the unredacted protocol success/failure classification
- document current RustFS overlap, cancellation, persistence, atomicity, and live-status limitations

## BREAKING contract note

This PR updates the protected `docs/reference/rc/` behavior contract and is intentionally marked **BREAKING**. The new commands are additive and use the existing output-v3 `admin_operations` schema, so no schema-version migration is required. Automation must treat `result.lifecycle_state` as `unknown` and must not interpret resync status snapshots as live progress.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace -- --test-threads=1` — 1230 passed, 0 failed, 1 ignored
- independent final review — no actionable findings
