### PR TITLE
feat(rc-admin)!: add safe server configuration management

### DIFF
--- a/crates/cli/src/commands/admin/config.rs
+++ b/crates/cli/src/commands/admin/config.rs
@@ -1,0 +1,1375 @@
+//! RustFS server configuration commands with client-side preflight planning.
+
+use clap::{Args, Subcommand};
+use rc_core::Error;
+use rc_core::admin::{
+    ConfigApi, ConfigDiff, ConfigDocument, ConfigHistoryEntry, ModuleSwitches,
+    config_document_fields, config_import_diff, config_mutation_diff, redact_config_document,
+    validate_config_directive, validate_config_import,
+};
+use serde::Serialize;
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
+
+use super::get_admin_client;
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+#[derive(Subcommand, Debug)]
+#[command(disable_help_subcommand = true)]
+pub enum ConfigCommands {
+    /// Read a subsystem or target configuration
+    Get(GetArgs),
+    /// Set one or more keys after showing a preflight diff
+    Set(SetArgs),
+    /// Delete a target or selected keys after showing a preflight diff
+    Delete(DeleteArgs),
+    /// Show server-provided configuration help
+    Help(HelpArgs),
+    /// List configuration mutation history
+    History(HistoryArgs),
+    /// Replace configuration from a history entry
+    Restore(RestoreArgs),
+    /// Export the full server configuration to a file
+    Export(ExportArgs),
+    /// Replace the full server configuration from a file
+    Import(ImportArgs),
+    /// Inspect or update event notification and audit module switches
+    #[command(name = "module-switch", subcommand)]
+    ModuleSwitch(ModuleSwitchCommands),
+}
+
+#[derive(Args, Debug)]
+pub struct GetArgs {
+    pub alias: String,
+    pub selector: String,
+}
+
+#[derive(Args, Debug)]
+pub struct SetArgs {
+    pub alias: String,
+    pub scope: String,
+    /// Assignments as KEY=VALUE or KEY=@PATH for protected value-file input
+    #[arg(required = true)]
+    pub assignments: Vec<String>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct DeleteArgs {
+    pub alias: String,
+    pub scope: String,
+    pub keys: Vec<String>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct HelpArgs {
+    pub alias: String,
+    pub subsystem: Option<String>,
+    pub key: Option<String>,
+    #[arg(long)]
+    pub env: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct HistoryArgs {
+    pub alias: String,
+    #[arg(long, default_value_t = 10, value_parser = parse_positive_usize)]
+    pub count: usize,
+}
+
+#[derive(Args, Debug)]
+pub struct RestoreArgs {
+    pub alias: String,
+    pub restore_id: String,
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm replacement of the complete server configuration
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ExportArgs {
+    pub alias: String,
+    #[arg(long)]
+    pub file: PathBuf,
+}
+
+#[derive(Args, Debug)]
+pub struct ImportArgs {
+    pub alias: String,
+    #[arg(long)]
+    pub file: PathBuf,
+    #[arg(long)]
+    pub dry_run: bool,
+    /// Confirm replacement of the complete server configuration
+    #[arg(long)]
+    pub yes: bool,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ModuleSwitchCommands {
+    Get(ModuleSwitchGetArgs),
+    Set(ModuleSwitchSetArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ModuleSwitchGetArgs {
+    pub alias: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ModuleSwitchSetArgs {
+    pub alias: String,
+    #[arg(long, value_parser = parse_on_off)]
+    pub notify: Option<bool>,
+    #[arg(long, value_parser = parse_on_off)]
+    pub audit: Option<bool>,
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+fn parse_on_off(value: &str) -> Result<bool, String> {
+    match value.to_ascii_lowercase().as_str() {
+        "on" | "true" => Ok(true),
+        "off" | "false" => Ok(false),
+        _ => Err("expected on or off".to_string()),
+    }
+}
+
+fn parse_positive_usize(value: &str) -> Result<usize, String> {
+    let parsed = value
+        .parse::<usize>()
+        .map_err(|_| "expected a positive integer".to_string())?;
+    if parsed == 0 {
+        return Err("expected a positive integer".to_string());
+    }
+    Ok(parsed)
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigOutput<T> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: AdminOperationsData<T>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperationsData<T> {
+    operations: Vec<AdminOperation<T>>,
+}
+
+#[derive(Debug, Serialize)]
+struct AdminOperation<T> {
+    operation: &'static str,
+    resource: &'static str,
+    state: &'static str,
+    operation_id: Option<String>,
+    changed: bool,
+    result: T,
+}
+
+#[derive(Debug, Serialize)]
+struct OperationData<T> {
+    operation: &'static str,
+    result: T,
+}
+
+#[derive(Debug, Serialize)]
+struct MutationData {
+    operation: &'static str,
+    dry_run: bool,
+    applied_dynamically: Option<bool>,
+    diff: ConfigDiff,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    warning: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExportData {
+    operation: &'static str,
+    path: String,
+    redacted: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct HistoryOutputEntry {
+    restore_id: String,
+    create_time: String,
+    data: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SwitchDiff {
+    notify_before: bool,
+    notify_after: bool,
+    audit_before: bool,
+    audit_after: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ConfigErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: ConfigErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum ConfigErrorDetail {
+    Unsupported {
+        #[serde(rename = "type")]
+        error_type: &'static str,
+        message: String,
+        retryable: bool,
+        capability: &'static str,
+        server: Option<&'static str>,
+        suggestion: Option<&'static str>,
+    },
+    Standard {
+        #[serde(rename = "type")]
+        error_type: &'static str,
+        message: String,
+        retryable: bool,
+        suggestion: Option<&'static str>,
+    },
+}
+
+const RESTORE_SAFETY_WARNING: &str = "RustFS rebuilds the complete configuration from this history document; unrelated current values are removed. This unsafe server behavior is tracked by rustfs/backlog#1398.";
+const RESTORE_PREVIEW_UNAVAILABLE_WARNING: &str = "The history entry is outside the latest 1000 records returned by RustFS. The restore was applied by ID, but a client-side diff was unavailable.";
+const HELP_METADATA_WARNING: &str = "Server configuration help metadata is unavailable; validation is deferred to the mutation endpoint.";
+const MAX_CONFIG_VALUE_BYTES: u64 = 1024 * 1024;
+
+pub async fn execute(command: ConfigCommands, formatter: &Formatter) -> ExitCode {
+    let alias = command.alias();
+    let client = match get_admin_client(alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_with_api(command, &client, formatter).await
+}
+
+impl ConfigCommands {
+    fn alias(&self) -> &str {
+        match self {
+            Self::Get(args) => &args.alias,
+            Self::Set(args) => &args.alias,
+            Self::Delete(args) => &args.alias,
+            Self::Help(args) => &args.alias,
+            Self::History(args) => &args.alias,
+            Self::Restore(args) => &args.alias,
+            Self::Export(args) => &args.alias,
+            Self::Import(args) => &args.alias,
+            Self::ModuleSwitch(ModuleSwitchCommands::Get(args)) => &args.alias,
+            Self::ModuleSwitch(ModuleSwitchCommands::Set(args)) => &args.alias,
+        }
+    }
+}
+
+async fn execute_with_api(
+    command: ConfigCommands,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    let result = match command {
+        ConfigCommands::Get(args) => get(args, api, formatter).await,
+        ConfigCommands::Set(args) => set(args, api, formatter).await,
+        ConfigCommands::Delete(args) => delete(args, api, formatter).await,
+        ConfigCommands::Help(args) => help(args, api, formatter).await,
+        ConfigCommands::History(args) => history(args, api, formatter).await,
+        ConfigCommands::Restore(args) => restore(args, api, formatter).await,
+        ConfigCommands::Export(args) => export(args, api, formatter).await,
+        ConfigCommands::Import(args) => import(args, api, formatter).await,
+        ConfigCommands::ModuleSwitch(command) => module_switch(command, api, formatter).await,
+    };
+    match result {
+        Ok(()) => ExitCode::Success,
+        Err(error) => emit_error(&error, formatter),
+    }
+}
+
+async fn get(args: GetArgs, api: &dyn ConfigApi, formatter: &Formatter) -> rc_core::Result<()> {
+    validate_selector(&args.selector)?;
+    let document = api.get_config(&args.selector).await?;
+    let content = redact_config_document(&document.content);
+    output(
+        formatter,
+        false,
+        OperationData {
+            operation: "config.get",
+            result: &content,
+        },
+        || formatter.println(&content),
+    );
+    Ok(())
+}
+
+async fn set(args: SetArgs, api: &dyn ConfigApi, formatter: &Formatter) -> rc_core::Result<()> {
+    let assignments = resolve_assignments(&args.assignments)?;
+    let directive = format!("{} {}", args.scope, assignments.join(" "));
+    validate_config_directive(&directive, false)?;
+    let warning = validate_server_keys(api, &args.scope).await?;
+    let current = api.get_config(&args.scope).await?;
+    let diff = config_mutation_diff(&current.content, &directive, false)?;
+    let applied = if args.dry_run {
+        None
+    } else {
+        Some(api.set_config(&directive).await?.applied_dynamically)
+    };
+    emit_mutation(
+        "config.set",
+        args.dry_run,
+        applied,
+        diff,
+        warning.map(str::to_string),
+        None,
+        formatter,
+    );
+    Ok(())
+}
+
+async fn delete(
+    args: DeleteArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    let directive = if args.keys.is_empty() {
+        args.scope.clone()
+    } else {
+        format!("{} {}", args.scope, args.keys.join(" "))
+    };
+    validate_config_directive(&directive, true)?;
+    let warning = validate_server_keys(api, &args.scope).await?;
+    let current = api.get_config(&args.scope).await?;
+    let diff = config_mutation_diff(&current.content, &directive, true)?;
+    let applied = if args.dry_run {
+        None
+    } else {
+        Some(api.delete_config(&directive).await?.applied_dynamically)
+    };
+    emit_mutation(
+        "config.delete",
+        args.dry_run,
+        applied,
+        diff,
+        warning.map(str::to_string),
+        None,
+        formatter,
+    );
+    Ok(())
+}
+
+async fn help(args: HelpArgs, api: &dyn ConfigApi, formatter: &Formatter) -> rc_core::Result<()> {
+    let result = api
+        .config_help(args.subsystem.as_deref(), args.key.as_deref(), args.env)
+        .await?;
+    output(
+        formatter,
+        false,
+        OperationData {
+            operation: "config.help",
+            result: &result,
+        },
+        || {
+            formatter.println(&format!("{}: {}", result.subsystem, result.description));
+            for key in &result.keys {
+                formatter.println(&format!(
+                    "{} ({}) - {}",
+                    key.key, key.value_type, key.description
+                ));
+            }
+        },
+    );
+    Ok(())
+}
+
+async fn history(
+    args: HistoryArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    let entries = api
+        .config_history(args.count)
+        .await?
+        .into_iter()
+        .map(redact_history_entry)
+        .collect::<Vec<_>>();
+    output(
+        formatter,
+        false,
+        OperationData {
+            operation: "config.history",
+            result: &entries,
+        },
+        || {
+            for entry in &entries {
+                formatter.println(&format!("{} {}", entry.restore_id, entry.create_time));
+                if let Some(data) = &entry.data {
+                    formatter.println(data);
+                }
+            }
+        },
+    );
+    Ok(())
+}
+
+async fn restore(
+    args: RestoreArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    validate_restore_id(&args.restore_id)?;
+    if !args.dry_run && !args.yes {
+        return Err(Error::Config(
+            "Restore replaces the complete server configuration; pass --yes to confirm".to_string(),
+        ));
+    }
+    let history = api.config_history(1000).await?;
+    let document = history
+        .iter()
+        .find(|entry| entry.restore_id == args.restore_id)
+        .and_then(|entry| entry.data.as_deref());
+    let Some(document) = document else {
+        if args.dry_run {
+            return Err(Error::NotFound(
+                "Configuration history entry is unavailable in the latest 1000 records; a dry-run diff cannot be built"
+                    .to_string(),
+            ));
+        }
+        api.restore_config(&args.restore_id).await?;
+        emit_mutation(
+            "config.restore",
+            false,
+            None,
+            ConfigDiff {
+                changes: Vec::new(),
+                replaces_full_config: true,
+            },
+            Some(RESTORE_PREVIEW_UNAVAILABLE_WARNING.to_string()),
+            Some(true),
+            formatter,
+        );
+        return Ok(());
+    };
+    validate_config_directive(document, false)?;
+    let current = api.get_full_config().await?;
+    let diff = config_import_diff(&current.content, document)?;
+    if !args.dry_run {
+        api.restore_config(&args.restore_id).await?;
+    }
+    emit_mutation(
+        "config.restore",
+        args.dry_run,
+        None,
+        diff,
+        Some(RESTORE_SAFETY_WARNING.to_string()),
+        None,
+        formatter,
+    );
+    Ok(())
+}
+
+async fn export(
+    args: ExportArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    let document = api.get_full_config().await?;
+    let content = redact_config_document(&document.content);
+    write_private_file(&args.file, content.as_bytes())?;
+    let data = ExportData {
+        operation: "config.export",
+        path: args.file.display().to_string(),
+        redacted: true,
+    };
+    output(formatter, false, data, || {
+        formatter.success(&format!(
+            "Configuration exported to {}",
+            args.file.display()
+        ));
+    });
+    Ok(())
+}
+
+async fn import(
+    args: ImportArgs,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    if !args.dry_run && !args.yes {
+        return Err(Error::Config(
+            "Import replaces the complete server configuration; pass --yes to confirm".to_string(),
+        ));
+    }
+    let content = std::fs::read_to_string(&args.file).map_err(|error| {
+        Error::Io(std::io::Error::new(
+            error.kind(),
+            format!("failed to read configuration import: {error}"),
+        ))
+    })?;
+    validate_config_directive(&content, false)?;
+    validate_config_import(&content)?;
+    let help_warning = validate_server_document(api, &content).await?;
+    let current = api.get_full_config().await?;
+    let diff = config_import_diff(&current.content, &content)?;
+    if !args.dry_run {
+        api.import_config(&ConfigDocument { content }).await?;
+    }
+    emit_mutation(
+        "config.import",
+        args.dry_run,
+        None,
+        diff,
+        combine_warnings(
+            Some("Import replaces the complete server configuration."),
+            help_warning,
+        ),
+        None,
+        formatter,
+    );
+    Ok(())
+}
+
+async fn module_switch(
+    command: ModuleSwitchCommands,
+    api: &dyn ConfigApi,
+    formatter: &Formatter,
+) -> rc_core::Result<()> {
+    match command {
+        ModuleSwitchCommands::Get(_) => {
+            let switches = api.get_module_switches().await?;
+            output(
+                formatter,
+                false,
+                OperationData {
+                    operation: "config.module-switch.get",
+                    result: &switches,
+                },
+                || print_switches(&switches, formatter),
+            );
+        }
+        ModuleSwitchCommands::Set(args) => {
+            if args.notify.is_none() && args.audit.is_none() {
+                return Err(Error::Config(
+                    "At least one of --notify or --audit is required".to_string(),
+                ));
+            }
+            let current = api.get_module_switches().await?;
+            let requested = requested_switches(&current, args.notify, args.audit);
+            let diff = switch_diff(&current, &requested);
+            if !args.dry_run {
+                api.set_module_switches(&requested).await?;
+            }
+            output(
+                formatter,
+                !args.dry_run
+                    && (diff.notify_before != diff.notify_after
+                        || diff.audit_before != diff.audit_after),
+                OperationData {
+                    operation: "config.module-switch.set",
+                    result: &diff,
+                },
+                || {
+                    formatter.println(&format!(
+                        "notify: {} -> {}; audit: {} -> {}{}",
+                        diff.notify_before,
+                        diff.notify_after,
+                        diff.audit_before,
+                        diff.audit_after,
+                        if args.dry_run { " (dry-run)" } else { "" }
+                    ));
+                },
+            );
+        }
+    }
+    Ok(())
+}
+
+fn output<T: Serialize>(formatter: &Formatter, changed: bool, data: T, human: impl FnOnce()) {
+    if formatter.is_json() {
+        formatter.json(&ConfigOutput {
+            schema_version: 3,
+            output_type: "admin_operations",
+            status: "success",
+            data: AdminOperationsData {
+                operations: vec![AdminOperation {
+                    operation: "server-config",
+                    resource: "rustfs-server-configuration",
+                    state: "succeeded",
+                    operation_id: None,
+                    changed,
+                    result: data,
+                }],
+            },
+        });
+    } else {
+        human();
+    }
+}
+
+fn emit_mutation(
+    operation: &'static str,
+    dry_run: bool,
+    applied_dynamically: Option<bool>,
+    diff: ConfigDiff,
+    warning: Option<String>,
+    changed_override: Option<bool>,
+    formatter: &Formatter,
+) {
+    let data = MutationData {
+        operation,
+        dry_run,
+        applied_dynamically,
+        diff,
+        warning,
+    };
+    let changed = changed_override.unwrap_or(!dry_run && !data.diff.changes.is_empty());
+    output(formatter, changed, &data, || {
+        if let Some(warning) = &data.warning {
+            formatter.warning(warning);
+        }
+        formatter.println(if dry_run {
+            "Preflight diff:"
+        } else {
+            "Applied diff:"
+        });
+        for change in &data.diff.changes {
+            formatter.println(&format!(
+                "{} {}: {} -> {}",
+                change.scope,
+                change.key,
+                change.before.as_deref().unwrap_or("<unset>"),
+                change.after.as_deref().unwrap_or("<unset>")
+            ));
+        }
+        if data.diff.changes.is_empty() {
+            formatter.println("No changes.");
+        }
+    });
+}
+
+fn redact_history_entry(entry: ConfigHistoryEntry) -> HistoryOutputEntry {
+    HistoryOutputEntry {
+        restore_id: entry.restore_id,
+        create_time: entry.create_time,
+        data: entry.data.map(|data| redact_config_document(&data)),
+    }
+}
+
+fn validate_selector(selector: &str) -> rc_core::Result<()> {
+    validate_config_directive(selector, true)
+}
+
+fn validate_restore_id(restore_id: &str) -> rc_core::Result<()> {
+    if restore_id.is_empty()
+        || !restore_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        return Err(Error::Config(
+            "Invalid configuration restore ID".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+async fn validate_server_keys(
+    api: &dyn ConfigApi,
+    scope: &str,
+) -> rc_core::Result<Option<&'static str>> {
+    let subsystem = scope.split_once(':').map_or(scope, |(value, _)| value);
+    advisory_help(api, subsystem).await
+}
+
+async fn validate_server_document(
+    api: &dyn ConfigApi,
+    document: &str,
+) -> rc_core::Result<Option<&'static str>> {
+    let subsystems = config_document_fields(document)?
+        .into_iter()
+        .map(|(subsystem, _)| subsystem)
+        .collect::<BTreeSet<_>>();
+    let mut warning = None;
+    for subsystem in subsystems {
+        warning = warning.or(advisory_help(api, &subsystem).await?);
+    }
+    Ok(warning)
+}
+
+async fn advisory_help(
+    api: &dyn ConfigApi,
+    subsystem: &str,
+) -> rc_core::Result<Option<&'static str>> {
+    match api.config_help(Some(subsystem), None, false).await {
+        Ok(_) => Ok(None),
+        Err(Error::NotFound(_) | Error::UnsupportedFeature(_) | Error::Config(_)) => {
+            Ok(Some(HELP_METADATA_WARNING))
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn print_switches(switches: &ModuleSwitches, formatter: &Formatter) {
+    formatter.println(&format!(
+        "notify: {} (source: {}, persisted: {})",
+        switches.notify_enabled, switches.notify_source, switches.persisted_notify_enabled
+    ));
+    formatter.println(&format!(
+        "audit: {} (source: {}, persisted: {})",
+        switches.audit_enabled, switches.audit_source, switches.persisted_audit_enabled
+    ));
+}
+
+fn requested_switches(
+    current: &ModuleSwitches,
+    notify: Option<bool>,
+    audit: Option<bool>,
+) -> ModuleSwitches {
+    let mut requested = current.clone();
+    requested.notify_enabled = notify.unwrap_or(current.persisted_notify_enabled);
+    requested.audit_enabled = audit.unwrap_or(current.persisted_audit_enabled);
+    requested
+}
+
+fn switch_diff(current: &ModuleSwitches, requested: &ModuleSwitches) -> SwitchDiff {
+    SwitchDiff {
+        notify_before: current.persisted_notify_enabled,
+        notify_after: requested.notify_enabled,
+        audit_before: current.persisted_audit_enabled,
+        audit_after: requested.audit_enabled,
+    }
+}
+
+fn combine_warnings(first: Option<&str>, second: Option<&str>) -> Option<String> {
+    match (first, second) {
+        (Some(first), Some(second)) => Some(format!("{first} {second}")),
+        (Some(warning), None) | (None, Some(warning)) => Some(warning.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn resolve_assignments(assignments: &[String]) -> rc_core::Result<Vec<String>> {
+    assignments
+        .iter()
+        .map(|assignment| {
+            let Some((key, value)) = assignment.split_once('=') else {
+                return Ok(assignment.clone());
+            };
+            let Some(path) = value.strip_prefix('@') else {
+                return Ok(assignment.clone());
+            };
+            if path.is_empty() {
+                return Err(Error::Config(
+                    "A value-file assignment must use KEY=@PATH".to_string(),
+                ));
+            }
+            let value = read_protected_value_file(Path::new(path))?;
+            Ok(format!(
+                "{key}=\"{}\"",
+                value.replace('\\', "\\\\").replace('"', "\\\"")
+            ))
+        })
+        .collect()
+}
+
+fn read_protected_value_file(path: &Path) -> rc_core::Result<Zeroizing<String>> {
+    let path_metadata = std::fs::symlink_metadata(path).map_err(|_| {
+        Error::InvalidPath("Failed to inspect configuration value file".to_string())
+    })?;
+    if path_metadata.file_type().is_symlink() || !path_metadata.is_file() {
+        return Err(Error::InvalidPath(
+            "Configuration value input must be a regular file, not a symlink".to_string(),
+        ));
+    }
+    let file = File::open(path)
+        .map_err(|_| Error::InvalidPath("Failed to open configuration value file".to_string()))?;
+    let file_metadata = file.metadata().map_err(|_| {
+        Error::InvalidPath("Failed to inspect opened configuration value file".to_string())
+    })?;
+    if !file_metadata.is_file() {
+        return Err(Error::InvalidPath(
+            "Configuration value input must remain a regular file while opening".to_string(),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        if path_metadata.dev() != file_metadata.dev() || path_metadata.ino() != file_metadata.ino()
+        {
+            return Err(Error::InvalidPath(
+                "Configuration value file changed while being opened".to_string(),
+            ));
+        }
+        if file_metadata.permissions().mode() & 0o077 != 0 {
+            return Err(Error::InvalidPath(
+                "Configuration value file cannot grant group or other permissions".to_string(),
+            ));
+        }
+    }
+    let mut bytes = Zeroizing::new(Vec::new());
+    file.take(MAX_CONFIG_VALUE_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| Error::InvalidPath("Failed to read configuration value file".to_string()))?;
+    if bytes.len() as u64 > MAX_CONFIG_VALUE_BYTES {
+        return Err(Error::InvalidPath(format!(
+            "Configuration value exceeds the {MAX_CONFIG_VALUE_BYTES} byte limit"
+        )));
+    }
+    while matches!(bytes.last(), Some(b'\n' | b'\r')) {
+        bytes.pop();
+    }
+    let value = std::str::from_utf8(&bytes)
+        .map_err(|_| Error::InvalidPath("Configuration value must be UTF-8".to_string()))?;
+    if value.contains(['\n', '\r', '\0']) {
+        return Err(Error::InvalidPath(
+            "Configuration value must contain a single text line".to_string(),
+        ));
+    }
+    Ok(Zeroizing::new(value.to_string()))
+}
+
+fn write_private_file(path: &Path, contents: &[u8]) -> rc_core::Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    use std::io::Write;
+    file.write_all(contents)?;
+    Ok(())
+}
+
+fn emit_error(error: &Error, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    if formatter.is_json() {
+        let detail = if matches!(error, Error::UnsupportedFeature(_)) {
+            ConfigErrorDetail::Unsupported {
+                error_type: "unsupported_feature",
+                message: error.to_string(),
+                retryable: false,
+                capability: "admin.server-configuration",
+                server: Some("rustfs"),
+                suggestion: Some("Verify the RustFS server version and advertised capabilities."),
+            }
+        } else {
+            let (error_type, retryable, suggestion) = config_error_metadata(code);
+            ConfigErrorDetail::Standard {
+                error_type,
+                message: error.to_string(),
+                retryable,
+                suggestion,
+            }
+        };
+        formatter.json_error(&ConfigErrorOutput {
+            schema_version: 3,
+            output_type: "admin_operations",
+            status: "error",
+            error: detail,
+        });
+    } else {
+        formatter.error_with_code(code, &error.to_string());
+    }
+    code
+}
+
+const fn config_error_metadata(code: ExitCode) -> (&'static str, bool, Option<&'static str>) {
+    match code {
+        ExitCode::UsageError => (
+            "usage_error",
+            false,
+            Some("Review the command arguments and server configuration help."),
+        ),
+        ExitCode::NetworkError => (
+            "network_error",
+            true,
+            Some("Verify the server endpoint and retry."),
+        ),
+        ExitCode::AuthError => (
+            "auth_error",
+            false,
+            Some("Verify the alias credentials and ConfigUpdate permission."),
+        ),
+        ExitCode::NotFound => (
+            "not_found",
+            false,
+            Some("Verify the requested subsystem, target, or history identifier."),
+        ),
+        ExitCode::Conflict => (
+            "conflict",
+            false,
+            Some("Refresh the configuration and retry the preflight."),
+        ),
+        ExitCode::Interrupted => ("interrupted", true, Some("Retry the operation.")),
+        ExitCode::Success | ExitCode::GeneralError | ExitCode::UnsupportedFeature => {
+            ("general_error", false, None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    struct TestApi {
+        mutations: AtomicUsize,
+        help_calls: AtomicUsize,
+        help_missing: bool,
+        history_has_entry: bool,
+    }
+
+    fn test_api() -> TestApi {
+        TestApi {
+            mutations: AtomicUsize::new(0),
+            help_calls: AtomicUsize::new(0),
+            help_missing: false,
+            history_has_entry: true,
+        }
+    }
+
+    #[async_trait]
+    impl ConfigApi for TestApi {
+        async fn get_config(&self, _selector: &str) -> rc_core::Result<ConfigDocument> {
+            Ok(ConfigDocument {
+                content: "scanner speed=default cycle=10".to_string(),
+            })
+        }
+
+        async fn get_full_config(&self) -> rc_core::Result<ConfigDocument> {
+            Ok(ConfigDocument {
+                content:
+                    "scanner speed=default cycle=10\nidentity_openid client_secret=super-secret"
+                        .to_string(),
+            })
+        }
+
+        async fn set_config(
+            &self,
+            _directive: &str,
+        ) -> rc_core::Result<rc_core::admin::ConfigMutationResult> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(rc_core::admin::ConfigMutationResult {
+                applied_dynamically: true,
+            })
+        }
+
+        async fn delete_config(
+            &self,
+            _directive: &str,
+        ) -> rc_core::Result<rc_core::admin::ConfigMutationResult> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(rc_core::admin::ConfigMutationResult {
+                applied_dynamically: false,
+            })
+        }
+
+        async fn config_help(
+            &self,
+            _subsystem: Option<&str>,
+            _key: Option<&str>,
+            _env_only: bool,
+        ) -> rc_core::Result<rc_core::admin::ConfigHelp> {
+            self.help_calls.fetch_add(1, Ordering::SeqCst);
+            if self.help_missing {
+                return Err(Error::NotFound("help metadata missing".to_string()));
+            }
+            Ok(rc_core::admin::ConfigHelp {
+                subsystem: "scanner".to_string(),
+                description: "scanner".to_string(),
+                multiple_targets: false,
+                keys: Vec::new(),
+            })
+        }
+
+        async fn config_history(&self, _count: usize) -> rc_core::Result<Vec<ConfigHistoryEntry>> {
+            if !self.history_has_entry {
+                return Ok(Vec::new());
+            }
+            Ok(vec![ConfigHistoryEntry {
+                restore_id: "restore-1".to_string(),
+                create_time: "2026-07-21T00:00:00Z".to_string(),
+                data: Some("scanner speed=fast".to_string()),
+            }])
+        }
+
+        async fn restore_config(&self, _restore_id: &str) -> rc_core::Result<()> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn import_config(&self, _document: &ConfigDocument) -> rc_core::Result<()> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn get_module_switches(&self) -> rc_core::Result<ModuleSwitches> {
+            Ok(ModuleSwitches {
+                notify_enabled: false,
+                audit_enabled: false,
+                persisted_notify_enabled: false,
+                persisted_audit_enabled: false,
+                notify_source: "console".to_string(),
+                audit_source: "console".to_string(),
+            })
+        }
+
+        async fn set_module_switches(
+            &self,
+            switches: &ModuleSwitches,
+        ) -> rc_core::Result<ModuleSwitches> {
+            self.mutations.fetch_add(1, Ordering::SeqCst);
+            Ok(switches.clone())
+        }
+    }
+
+    fn test_formatter() -> Formatter {
+        Formatter::new(crate::output::OutputConfig {
+            json: false,
+            no_color: true,
+            no_progress: true,
+            quiet: true,
+        })
+    }
+
+    #[tokio::test]
+    async fn set_dry_run_does_not_mutate() {
+        let api = test_api();
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["speed=fast".to_string()],
+                dry_run: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn set_success_mutates_once() {
+        let api = test_api();
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["speed=fast".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn malformed_set_returns_usage_without_mutation() {
+        let api = test_api();
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["speed".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::UsageError);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn delete_success_and_invalid_input_have_distinct_exit_codes() {
+        let api = test_api();
+        let success = execute_with_api(
+            ConfigCommands::Delete(DeleteArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                keys: vec!["speed".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        let invalid = execute_with_api(
+            ConfigCommands::Delete(DeleteArgs {
+                alias: "local".to_string(),
+                scope: ":bad".to_string(),
+                keys: Vec::new(),
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(success, ExitCode::Success);
+        assert_eq!(invalid, ExitCode::UsageError);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn confirmed_restore_mutates_once() {
+        let api = test_api();
+        let code = execute_with_api(
+            ConfigCommands::Restore(RestoreArgs {
+                alias: "local".to_string(),
+                restore_id: "restore-1".to_string(),
+                dry_run: false,
+                yes: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn import_requires_confirmation_before_file_access() {
+        let api = test_api();
+        let code = execute_with_api(
+            ConfigCommands::Import(ImportArgs {
+                alias: "local".to_string(),
+                file: PathBuf::from("missing-secret-config"),
+                dry_run: false,
+                yes: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::UsageError);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn confirmed_import_mutates_once() {
+        let api = test_api();
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("config.txt");
+        std::fs::write(&path, "scanner speed=fast").expect("write import file");
+        let code = execute_with_api(
+            ConfigCommands::Import(ImportArgs {
+                alias: "local".to_string(),
+                file: path,
+                dry_run: false,
+                yes: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn module_switch_dry_run_and_apply_have_distinct_mutation_counts() {
+        let api = test_api();
+        let dry_run = execute_with_api(
+            ConfigCommands::ModuleSwitch(ModuleSwitchCommands::Set(ModuleSwitchSetArgs {
+                alias: "local".to_string(),
+                notify: Some(true),
+                audit: None,
+                dry_run: true,
+            })),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        let applied = execute_with_api(
+            ConfigCommands::ModuleSwitch(ModuleSwitchCommands::Set(ModuleSwitchSetArgs {
+                alias: "local".to_string(),
+                notify: Some(true),
+                audit: None,
+                dry_run: false,
+            })),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+        assert_eq!(dry_run, ExitCode::Success);
+        assert_eq!(applied, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn export_refuses_to_overwrite_an_existing_file() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("config.txt");
+        std::fs::write(&path, "existing").expect("create existing file");
+
+        let error = write_private_file(&path, b"replacement")
+            .expect_err("export must not overwrite an existing file");
+        assert_eq!(error.exit_code(), ExitCode::GeneralError.as_i32());
+        assert_eq!(
+            std::fs::read_to_string(path).expect("read existing file"),
+            "existing"
+        );
+    }
+
+    #[tokio::test]
+    async fn export_always_redacts_secret_values() {
+        let api = test_api();
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("config.txt");
+
+        let code = execute_with_api(
+            ConfigCommands::Export(ExportArgs {
+                alias: "local".to_string(),
+                file: path.clone(),
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::Success);
+        let content = std::fs::read_to_string(path).expect("read exported configuration");
+        assert!(content.contains("*redacted*"));
+        assert!(!content.contains("super-secret"));
+    }
+
+    #[test]
+    fn partial_module_switch_update_preserves_persisted_values() {
+        let current = ModuleSwitches {
+            notify_enabled: true,
+            audit_enabled: false,
+            persisted_notify_enabled: false,
+            persisted_audit_enabled: true,
+            notify_source: "environment".to_string(),
+            audit_source: "environment".to_string(),
+        };
+
+        let requested = requested_switches(&current, Some(true), None);
+
+        assert!(requested.notify_enabled);
+        assert!(requested.audit_enabled);
+    }
+
+    #[test]
+    fn module_switch_diff_uses_only_persisted_state() {
+        let current = ModuleSwitches {
+            notify_enabled: true,
+            audit_enabled: true,
+            persisted_notify_enabled: false,
+            persisted_audit_enabled: false,
+            notify_source: "environment".to_string(),
+            audit_source: "environment".to_string(),
+        };
+        let requested = requested_switches(&current, Some(true), None);
+
+        let diff = switch_diff(&current, &requested);
+
+        assert!(!diff.notify_before);
+        assert!(diff.notify_after);
+        assert!(!diff.audit_before);
+        assert!(!diff.audit_after);
+    }
+
+    #[test]
+    fn value_file_assignment_quotes_secret_without_exposing_it_in_errors() {
+        let directory = tempfile::tempdir().expect("create temp directory");
+        let path = directory.path().join("client-secret");
+        std::fs::write(&path, "secret with spaces\n").expect("write secret file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .expect("protect secret file");
+        }
+        let assignment = format!("client_secret=@{}", path.display());
+
+        let resolved = resolve_assignments(&[assignment]).expect("resolve assignment");
+
+        assert_eq!(resolved, vec![r#"client_secret="secret with spaces""#]);
+    }
+
+    #[tokio::test]
+    async fn server_key_validation_uses_one_help_request_per_subsystem() {
+        let api = test_api();
+
+        validate_server_keys(&api, "scanner")
+            .await
+            .expect("batch help validation");
+
+        assert_eq!(api.help_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn missing_help_metadata_is_advisory_for_mutations() {
+        let api = TestApi {
+            help_missing: true,
+            ..test_api()
+        };
+
+        let code = execute_with_api(
+            ConfigCommands::Set(SetArgs {
+                alias: "local".to_string(),
+                scope: "scanner".to_string(),
+                assignments: vec!["future_key=value".to_string()],
+                dry_run: false,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.help_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn confirmed_restore_applies_when_preview_entry_is_outside_history_window() {
+        let api = TestApi {
+            history_has_entry: false,
+            ..test_api()
+        };
+
+        let code = execute_with_api(
+            ConfigCommands::Restore(RestoreArgs {
+                alias: "local".to_string(),
+                restore_id: "restore-old".to_string(),
+                dry_run: false,
+                yes: true,
+            }),
+            &api,
+            &test_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::Success);
+        assert_eq!(api.mutations.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn restore_warning_links_known_server_safety_limitation() {
+        assert!(RESTORE_SAFETY_WARNING.contains("rustfs/backlog#1398"));
+        assert!(RESTORE_SAFETY_WARNING.contains("unrelated current values are removed"));
+    }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -5,6 +5,7 @@
 
 mod access_key;
 mod capabilities;
+mod config;
 mod decommission;
 mod diagnostics;
 mod expand;
@@ -40,6 +41,10 @@ pub enum AdminCommands {
     /// Read bounded snapshots or run explicitly confirmed RustFS diagnostic probes
     #[command(subcommand)]
     Diagnostics(diagnostics::DiagnosticsCommands),
+
+    /// Manage RustFS server configuration
+    #[command(subcommand)]
+    Config(config::ConfigCommands),
 
     /// Query bounded RustFS realtime metrics
     Metrics(metrics::MetricsArgs),
@@ -112,6 +117,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
     match cmd {
         AdminCommands::Capabilities(args) => capabilities::execute(args, &formatter).await,
         AdminCommands::Diagnostics(command) => diagnostics::execute(command, &formatter).await,
+        AdminCommands::Config(config_cmd) => config::execute(config_cmd, &formatter).await,
         AdminCommands::Metrics(args) => metrics::execute(args, &formatter).await,
         AdminCommands::Kms(kms_cmd) => kms::execute(kms_cmd, &formatter).await,
         AdminCommands::Scanner(scanner_cmd) => scanner::execute(scanner_cmd, &formatter).await,

--- a/crates/cli/tests/admin_config.rs
+++ b/crates/cli/tests/admin_config.rs
@@ -1,0 +1,438 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{
+    rc_binary, rc_host_alias, start_admin_sequence_test_server, start_admin_test_server,
+};
+
+const SCANNER_HELP: &str = r#"{"subSys":"scanner","description":"scanner settings","multipleTargets":false,"keysHelp":[{"key":"speed","type":"string","description":"scanner speed","optional":true,"multipleTargets":false}]}"#;
+
+fn run(args: &[&str], endpoint: &str, config_dir: &tempfile::TempDir) -> std::process::Output {
+    Command::new(rc_binary())
+        .args(args)
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(endpoint))
+        .output()
+        .expect("run rc command")
+}
+
+fn assert_valid_v3(value: &serde_json::Value) {
+    let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("schemas/output_v3.json");
+    let schema = std::fs::read_to_string(&schema_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", schema_path.display()));
+    let schema: serde_json::Value =
+        serde_json::from_str(&schema).expect("output v3 schema should parse");
+    let validator = jsonschema::validator_for(&schema).expect("output v3 schema should compile");
+    let errors = validator
+        .iter_errors(value)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "config output must satisfy output v3:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn config_get_defensively_redacts_server_output() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_test_server("identity_openid client_id=console client_secret=server-secret");
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "get",
+            "myalias",
+            "identity_openid",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    assert!(stdout.contains("*redacted*"));
+    assert!(!stdout.contains("server-secret"));
+    let value: serde_json::Value = serde_json::from_str(&stdout).expect("JSON output");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "admin_operations");
+    assert_eq!(value["data"]["operations"][0]["changed"], false);
+    assert_valid_v3(&value);
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured request");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/get-config-kv?key=identity_openid"
+    );
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_history_redacts_secret_bearing_data() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(
+        r#"[{"RestoreID":"restore-1","CreateTime":"2026-07-21T00:00:00Z","Data":"identity_openid client_secret=history-secret"}]"#,
+    );
+
+    let output = run(
+        &[
+            "--json", "admin", "config", "history", "myalias", "--count", "5",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    assert!(stdout.contains("*redacted*"));
+    assert!(!stdout.contains("history-secret"));
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured request");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/list-config-history-kv?count=5"
+    );
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_set_dry_run_never_sends_mutation() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", SCANNER_HELP),
+        ("200 OK", "scanner speed=default"),
+    ]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "set",
+            "myalias",
+            "scanner",
+            "speed=fast",
+            "--dry-run",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let first = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("help request");
+    let second = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("config request");
+    assert_eq!(first.method, "GET");
+    assert!(first.target.starts_with("/rustfs/admin/v3/help-config-kv?"));
+    assert_eq!(second.method, "GET");
+    assert_eq!(second.target, "/rustfs/admin/v3/get-config-kv?key=scanner");
+    assert!(receiver.recv_timeout(Duration::from_millis(100)).is_err());
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_set_success_has_read_preflight_before_mutation() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", SCANNER_HELP),
+        ("200 OK", "scanner speed=default"),
+        ("200 OK", ""),
+    ]);
+
+    let output = run(
+        &["admin", "config", "set", "myalias", "scanner", "speed=fast"],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let requests = (0..3)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured request")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(requests[0].method, "GET");
+    assert_eq!(requests[1].method, "GET");
+    assert_eq!(requests[2].method, "PUT");
+    assert_eq!(requests[2].target, "/rustfs/admin/v3/set-config-kv");
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_set_reads_secret_from_protected_value_file() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let secret_file = config_dir.path().join("client-secret");
+    std::fs::write(&secret_file, "value-file-secret\n").expect("write secret file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&secret_file, std::fs::Permissions::from_mode(0o600))
+            .expect("protect secret file");
+    }
+    let assignment = format!("client_secret=@{}", secret_file.display());
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", SCANNER_HELP),
+        ("200 OK", "identity_openid client_secret=old"),
+        ("200 OK", ""),
+    ]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "set",
+            "myalias",
+            "identity_openid",
+            &assignment,
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("JSON config set output");
+    assert_valid_v3(&value);
+    assert!(
+        !output
+            .stdout
+            .windows(17)
+            .any(|value| value == b"value-file-secret")
+    );
+    assert!(
+        !output
+            .stderr
+            .windows(17)
+            .any(|value| value == b"value-file-secret")
+    );
+    let requests = (0..3)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured request")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(requests[2].method, "PUT");
+    assert_eq!(
+        String::from_utf8(requests[2].body.clone()).expect("UTF-8 request body"),
+        r#"identity_openid client_secret="value-file-secret""#
+    );
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn module_switch_set_reports_persisted_plane_under_environment_override() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let state = r#"{"notify_enabled":false,"audit_enabled":true,"persisted_notify_enabled":false,"persisted_audit_enabled":false,"notify_source":"config","audit_source":"environment"}"#;
+    let updated = r#"{"notify_enabled":true,"audit_enabled":false,"persisted_notify_enabled":true,"persisted_audit_enabled":false,"notify_source":"config","audit_source":"config"}"#;
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", state), ("200 OK", updated)]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "module-switch",
+            "set",
+            "myalias",
+            "--notify",
+            "on",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("JSON module switch output");
+    assert_valid_v3(&value);
+    let operation = &value["data"]["operations"][0];
+    assert_eq!(operation["changed"], true);
+    assert_eq!(operation["result"]["result"]["notify_before"], false);
+    assert_eq!(operation["result"]["result"]["notify_after"], true);
+    assert_eq!(operation["result"]["result"]["audit_before"], false);
+    assert_eq!(operation["result"]["result"]["audit_after"], false);
+    let requests = (0..2)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured request")
+        })
+        .collect::<Vec<_>>();
+    let body: serde_json::Value =
+        serde_json::from_slice(&requests[1].body).expect("module switch request JSON");
+    assert_eq!(body["notify_enabled"], true);
+    assert_eq!(body["audit_enabled"], false);
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn confirmed_restore_applies_by_id_when_preview_is_outside_history_window() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", "[]"), ("200 OK", "")]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "restore",
+            "myalias",
+            "restore-old",
+            "--yes",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("JSON restore output");
+    assert_valid_v3(&value);
+    let operation = &value["data"]["operations"][0];
+    assert_eq!(operation["changed"], true);
+    assert!(
+        operation["result"]["warning"]
+            .as_str()
+            .expect("restore warning")
+            .contains("diff was unavailable")
+    );
+    let requests = (0..2)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured request")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        requests[0].target,
+        "/rustfs/admin/v3/list-config-history-kv?count=1000"
+    );
+    assert_eq!(requests[1].method, "PUT");
+    assert_eq!(
+        requests[1].target,
+        "/rustfs/admin/v3/restore-config-history-kv?restoreId=restore-old"
+    );
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn config_access_denial_never_echoes_submitted_secret() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![(
+        "403 Forbidden",
+        r#"{"message":"server echoed submitted-secret in a forbidden response"}"#,
+    )]);
+
+    let output = run(
+        &[
+            "admin",
+            "config",
+            "set",
+            "myalias",
+            "identity_openid",
+            "client_secret=submitted-secret",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert_eq!(output.status.code(), Some(4));
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    assert!(!stderr.contains("submitted-secret"));
+    assert!(stderr.contains("denied configuration access"));
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn unsupported_module_switch_has_deterministic_exit_code() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) =
+        start_admin_sequence_test_server(vec![("404 Not Found", r#"{"message":"missing route"}"#)]);
+
+    let output = run(
+        &[
+            "--json",
+            "admin",
+            "config",
+            "module-switch",
+            "get",
+            "myalias",
+        ],
+        &endpoint,
+        &config_dir,
+    );
+
+    assert_eq!(output.status.code(), Some(7));
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    assert!(stderr.contains("does not advertise module switch operations"));
+    let value: serde_json::Value = serde_json::from_str(&stderr).expect("JSON error output");
+    assert_valid_v3(&value);
+    handle.join().expect("server finished");
+}
+
+#[test]
+fn restore_requires_confirmation_without_contacting_server() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args(["admin", "config", "restore", "myalias", "restore-1"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_myalias",
+            "http://ACCESS_KEY:SECRET_KEY@127.0.0.1:1",
+        )
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("pass --yes"));
+}

--- a/crates/core/src/admin/configuration.rs
+++ b/crates/core/src/admin/configuration.rs
@@ -1,0 +1,558 @@
+//! Safe contracts and planning helpers for RustFS server configuration.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::error::{Error, Result};
+
+/// A server configuration document. Its contents are intentionally omitted from debug output.
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct ConfigDocument {
+    pub content: String,
+}
+
+impl std::fmt::Debug for ConfigDocument {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConfigDocument")
+            .field("content", &"<redacted>")
+            .finish()
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Deserialize)]
+pub struct ConfigHistoryEntry {
+    #[serde(rename = "RestoreID")]
+    pub restore_id: String,
+    #[serde(rename = "CreateTime")]
+    pub create_time: String,
+    #[serde(rename = "Data", default)]
+    pub data: Option<String>,
+}
+
+impl std::fmt::Debug for ConfigHistoryEntry {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ConfigHistoryEntry")
+            .field("restore_id", &self.restore_id)
+            .field("create_time", &self.create_time)
+            .field("data", &self.data.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigHelp {
+    #[serde(rename = "subSys")]
+    pub subsystem: String,
+    pub description: String,
+    #[serde(rename = "multipleTargets")]
+    pub multiple_targets: bool,
+    #[serde(rename = "keysHelp")]
+    pub keys: Vec<ConfigHelpEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigHelpEntry {
+    pub key: String,
+    #[serde(rename = "type")]
+    pub value_type: String,
+    pub description: String,
+    pub optional: bool,
+    #[serde(rename = "multipleTargets")]
+    pub multiple_targets: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfigMutationResult {
+    pub applied_dynamically: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModuleSwitches {
+    pub notify_enabled: bool,
+    pub audit_enabled: bool,
+    pub persisted_notify_enabled: bool,
+    pub persisted_audit_enabled: bool,
+    pub notify_source: String,
+    pub audit_source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfigChange {
+    pub scope: String,
+    pub key: String,
+    pub before: Option<String>,
+    pub after: Option<String>,
+    pub sensitive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ConfigDiff {
+    pub changes: Vec<ConfigChange>,
+    pub replaces_full_config: bool,
+}
+
+/// RustFS Admin API configuration operations.
+#[async_trait]
+pub trait ConfigApi: Send + Sync {
+    async fn get_config(&self, selector: &str) -> Result<ConfigDocument>;
+    async fn get_full_config(&self) -> Result<ConfigDocument>;
+    async fn set_config(&self, directive: &str) -> Result<ConfigMutationResult>;
+    async fn delete_config(&self, directive: &str) -> Result<ConfigMutationResult>;
+    async fn config_help(
+        &self,
+        subsystem: Option<&str>,
+        key: Option<&str>,
+        env_only: bool,
+    ) -> Result<ConfigHelp>;
+    async fn config_history(&self, count: usize) -> Result<Vec<ConfigHistoryEntry>>;
+    async fn restore_config(&self, restore_id: &str) -> Result<()>;
+    async fn import_config(&self, document: &ConfigDocument) -> Result<()>;
+    async fn get_module_switches(&self) -> Result<ModuleSwitches>;
+    async fn set_module_switches(&self, switches: &ModuleSwitches) -> Result<ModuleSwitches>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedDirective {
+    scope: String,
+    entries: Vec<(String, Option<String>)>,
+}
+
+fn tokenize(line: &str) -> Result<Vec<String>> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut quote = None;
+    let mut escaped = false;
+
+    for character in line.chars() {
+        if escaped {
+            current.push(character);
+            escaped = false;
+        } else if character == '\\' {
+            escaped = true;
+        } else if let Some(active_quote) = quote {
+            if character == active_quote {
+                quote = None;
+            } else {
+                current.push(character);
+            }
+        } else {
+            match character {
+                '\'' | '"' => quote = Some(character),
+                value if value.is_whitespace() => {
+                    if !current.is_empty() {
+                        tokens.push(std::mem::take(&mut current));
+                    }
+                }
+                _ => current.push(character),
+            }
+        }
+    }
+
+    if quote.is_some() {
+        return Err(Error::Config(
+            "Configuration contains an unterminated quoted value".to_string(),
+        ));
+    }
+    if escaped {
+        current.push('\\');
+    }
+    if !current.is_empty() {
+        tokens.push(current);
+    }
+    Ok(tokens)
+}
+
+fn valid_name(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || "_-.:".contains(character))
+}
+
+fn parse_directives(input: &str, allow_bare_keys: bool) -> Result<Vec<ParsedDirective>> {
+    let mut directives = Vec::new();
+    for line in input.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let tokens = tokenize(line)?;
+        let Some(scope) = tokens.first() else {
+            continue;
+        };
+        if !valid_name(scope) || scope.starts_with(':') || scope.ends_with(':') {
+            return Err(Error::Config("Invalid configuration scope".to_string()));
+        }
+
+        let mut entries = Vec::new();
+        for token in tokens.iter().skip(1) {
+            let (key, value) = match token.split_once('=') {
+                Some((key, value)) => (key, Some(value.to_string())),
+                None if allow_bare_keys => (token.as_str(), None),
+                None => {
+                    return Err(Error::Config(
+                        "Configuration assignments must use key=value syntax".to_string(),
+                    ));
+                }
+            };
+            if !valid_name(key) || key.contains(':') {
+                return Err(Error::Config("Invalid configuration key".to_string()));
+            }
+            entries.push((key.to_string(), value));
+        }
+        directives.push(ParsedDirective {
+            scope: scope.to_string(),
+            entries,
+        });
+    }
+    if directives.is_empty() {
+        return Err(Error::Config(
+            "Configuration document must include at least one directive".to_string(),
+        ));
+    }
+    Ok(directives)
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.trim().to_ascii_lowercase().replace(['-', '.'], "_");
+    key.contains("secret")
+        || key.contains("password")
+        || key.contains("passphrase")
+        || key.split('_').any(|part| part == "token")
+        || key.split('_').any(|part| part == "credential")
+        || matches!(
+            key.as_str(),
+            "access_key"
+                | "account_key"
+                | "api_key"
+                | "client_key"
+                | "private_key"
+                | "master_key"
+                | "signing_key"
+                | "encryption_key"
+                | "session_key"
+                | "connection_string"
+                | "conn_string"
+                | "dsn"
+                | "authorization"
+                | "auth_header"
+                | "cookie"
+        )
+}
+
+fn redacted_value(key: &str, value: &str) -> String {
+    if is_sensitive_key(key) && !value.is_empty() {
+        "*redacted*".to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+fn document_map(input: &str, allow_bare_keys: bool) -> Result<BTreeMap<(String, String), String>> {
+    let mut values = BTreeMap::new();
+    for directive in parse_directives(input, allow_bare_keys)? {
+        for (key, value) in directive.entries {
+            if let Some(value) = value {
+                values.insert((directive.scope.clone(), key), value);
+            }
+        }
+    }
+    Ok(values)
+}
+
+/// Validate the syntax accepted by the RustFS config mutation endpoints.
+pub fn validate_config_directive(input: &str, allow_bare_keys: bool) -> Result<()> {
+    parse_directives(input, allow_bare_keys).map(|_| ())
+}
+
+/// Return subsystem/key pairs without exposing configuration values.
+pub fn config_document_fields(input: &str) -> Result<Vec<(String, String)>> {
+    let mut fields = Vec::new();
+    for directive in parse_directives(input, false)? {
+        let subsystem = directive
+            .scope
+            .split_once(':')
+            .map_or(directive.scope.as_str(), |(value, _)| value)
+            .to_string();
+        for (key, _) in directive.entries {
+            fields.push((subsystem.clone(), key));
+        }
+    }
+    Ok(fields)
+}
+
+/// Reject redacted placeholders before a full replacement can overwrite live secrets.
+pub fn validate_config_import(input: &str) -> Result<()> {
+    for directive in parse_directives(input, false)? {
+        for (key, value) in directive.entries {
+            if is_sensitive_key(&key) && value.as_deref() == Some("*redacted*") {
+                return Err(Error::Config(
+                    "Redacted secret placeholders cannot be imported".to_string(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Redact secret-bearing fields in a RustFS line-oriented configuration document.
+pub fn redact_config_document(input: &str) -> String {
+    input
+        .lines()
+        .filter_map(redact_config_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn redact_config_line(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+    match parse_directives(trimmed, true) {
+        Ok(mut directives) if directives.len() == 1 => {
+            let directive = directives
+                .pop()
+                .expect("one parsed directive was checked above");
+            let entries = directive
+                .entries
+                .into_iter()
+                .map(|(key, value)| match value {
+                    Some(value) => format!(
+                        "{key}=\"{}\"",
+                        escape_config_value(&redacted_value(&key, &value))
+                    ),
+                    None => key,
+                })
+                .collect::<Vec<_>>();
+            Some(if entries.is_empty() {
+                directive.scope
+            } else {
+                format!("{} {}", directive.scope, entries.join(" "))
+            })
+        }
+        _ => Some(redact_unparseable_line(trimmed)),
+    }
+}
+
+fn redact_unparseable_line(line: &str) -> String {
+    for (delimiter_index, _) in line.match_indices('=') {
+        let prefix = &line[..delimiter_index];
+        let end = prefix.trim_end().len();
+        let start = prefix[..end]
+            .rfind(|character: char| {
+                !(character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.'))
+            })
+            .map_or(0, |index| index + 1);
+        if is_sensitive_key(&prefix[start..end]) {
+            return format!("{}=\"*redacted*\"", &line[..delimiter_index]);
+        }
+    }
+    line.to_string()
+}
+
+fn escape_config_value(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+fn change(
+    scope: String,
+    key: String,
+    before: Option<String>,
+    after: Option<String>,
+) -> ConfigChange {
+    let sensitive = is_sensitive_key(&key);
+    let before = before.map(|value| redacted_value(&key, &value));
+    let after = after.map(|value| redacted_value(&key, &value));
+    ConfigChange {
+        scope,
+        key,
+        before,
+        after,
+        sensitive,
+    }
+}
+
+/// Build a client-side preflight diff for a set or delete mutation.
+pub fn config_mutation_diff(current: &str, directive: &str, delete: bool) -> Result<ConfigDiff> {
+    let current_values = document_map(current, false)?;
+    let directives = parse_directives(directive, delete)?;
+    let mut changes = Vec::new();
+
+    for directive in directives {
+        if delete && directive.entries.is_empty() {
+            for ((scope, key), before) in current_values
+                .iter()
+                .filter(|((scope, _), _)| scope == &directive.scope)
+            {
+                changes.push(change(
+                    scope.clone(),
+                    key.clone(),
+                    Some(before.clone()),
+                    None,
+                ));
+            }
+            continue;
+        }
+
+        for (key, after) in directive.entries {
+            let before = current_values
+                .get(&(directive.scope.clone(), key.clone()))
+                .cloned();
+            if delete {
+                if before.is_some() {
+                    changes.push(change(directive.scope.clone(), key, before, None));
+                }
+            } else if before != after {
+                changes.push(change(directive.scope.clone(), key, before, after));
+            }
+        }
+    }
+
+    Ok(ConfigDiff {
+        changes,
+        replaces_full_config: false,
+    })
+}
+
+/// Build a client-side preflight diff for a full configuration replacement.
+pub fn config_import_diff(current: &str, replacement: &str) -> Result<ConfigDiff> {
+    let current_values = document_map(current, false)?;
+    let replacement_values = document_map(replacement, false)?;
+    let keys = current_values
+        .keys()
+        .chain(replacement_values.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut changes = Vec::new();
+    for (scope, key) in keys {
+        let before = current_values.get(&(scope.clone(), key.clone())).cloned();
+        let after = replacement_values
+            .get(&(scope.clone(), key.clone()))
+            .cloned();
+        if before != after {
+            changes.push(change(scope, key, before, after));
+        }
+    }
+    Ok(ConfigDiff {
+        changes,
+        replaces_full_config: true,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_assignments_without_echoing_secret_values() {
+        assert!(validate_config_directive("scanner speed=fast", false).is_ok());
+        let error = validate_config_directive("identity_openid client_secret", false)
+            .expect_err("missing assignment must fail");
+        assert!(!error.to_string().contains("super-secret"));
+    }
+
+    #[test]
+    fn redacts_secret_fields_and_preserves_non_secret_values() {
+        let redacted = redact_config_document(
+            "identity_openid client_id=console client_secret=super-secret\nscanner speed=fast",
+        );
+        assert!(redacted.contains("client_id=\"console\""));
+        assert!(redacted.contains("client_secret=\"*redacted*\""));
+        assert!(redacted.contains("speed=\"fast\""));
+        assert!(!redacted.contains("super-secret"));
+    }
+
+    #[test]
+    fn redacts_connection_and_key_credentials_conservatively() {
+        let redacted = redact_config_document(
+            "notify_postgres connection_string=postgres://user:pass@db dsn=postgres://db \
+             api_key=api-secret account_key=account-secret access_key=access-secret",
+        );
+
+        for secret in [
+            "postgres://user:pass@db",
+            "postgres://db",
+            "api-secret",
+            "account-secret",
+            "access-secret",
+        ] {
+            assert!(!redacted.contains(secret));
+        }
+        assert_eq!(redacted.matches("*redacted*").count(), 5);
+    }
+
+    #[test]
+    fn malformed_lines_are_preserved_unless_they_contain_secrets() {
+        let redacted = redact_config_document(
+            "scanner speed=\"unfinished\nidentity_openid client_secret=must-not-leak \"unterminated",
+        );
+
+        assert!(redacted.contains("scanner speed=\"unfinished"));
+        assert!(redacted.contains("client_secret=\"*redacted*\""));
+        assert!(!redacted.contains("must-not-leak"));
+        assert!(!redacted.contains("unterminated"));
+        assert!(!redacted.contains("<redacted invalid configuration>"));
+    }
+
+    #[test]
+    fn set_diff_redacts_both_secret_sides() {
+        let diff = config_mutation_diff(
+            "identity_openid client_secret=old client_id=console",
+            "identity_openid client_secret=new",
+            false,
+        )
+        .expect("build set diff");
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].before.as_deref(), Some("*redacted*"));
+        assert_eq!(diff.changes[0].after.as_deref(), Some("*redacted*"));
+    }
+
+    #[test]
+    fn delete_diff_reports_only_present_keys() {
+        let diff =
+            config_mutation_diff("scanner speed=fast cycle=10", "scanner speed missing", true)
+                .expect("build delete diff");
+        assert_eq!(diff.changes.len(), 1);
+        assert_eq!(diff.changes[0].key, "speed");
+        assert_eq!(diff.changes[0].after, None);
+    }
+
+    #[test]
+    fn full_target_delete_reports_every_present_key() {
+        let diff = config_mutation_diff("scanner speed=fast cycle=10", "scanner", true)
+            .expect("build full target delete diff");
+
+        assert_eq!(diff.changes.len(), 2);
+        assert!(diff.changes.iter().all(|change| change.after.is_none()));
+    }
+
+    #[test]
+    fn import_diff_reports_additions_changes_and_removals() {
+        let diff = config_import_diff("scanner speed=fast cycle=10", "scanner speed=slow delay=1")
+            .expect("build import diff");
+        assert!(diff.replaces_full_config);
+        assert_eq!(diff.changes.len(), 3);
+    }
+
+    #[test]
+    fn redaction_preserves_quoted_value_semantics() {
+        let redacted = redact_config_document(
+            r#"identity_openid client_id="console app" client_secret="s3cr\"et""#,
+        );
+        assert!(redacted.contains(r#"client_id="console app""#));
+        assert!(redacted.contains(r#"client_secret="*redacted*""#));
+        assert!(validate_config_directive(&redacted, false).is_ok());
+    }
+
+    #[test]
+    fn import_rejects_redacted_secret_placeholders() {
+        let error = validate_config_import(
+            r#"identity_openid client_id="console" client_secret="*redacted*""#,
+        )
+        .expect_err("redacted secrets must not be imported");
+        assert_eq!(error.exit_code(), 2);
+    }
+}

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -5,6 +5,7 @@
 
 mod capabilities;
 mod cluster;
+mod configuration;
 mod diagnostics;
 mod kms;
 mod kms_diagnostic;
@@ -27,6 +28,12 @@ pub use cluster::{
     PoolDecommissionInfo, PoolErasureSetInfo, PoolStatus, PoolTarget, RebalanceCleanupWarnings,
     RebalancePoolProgress, RebalancePoolStatus, RebalanceStartResult, RebalanceStatus, ServerInfo,
     UsageInfo,
+};
+pub use configuration::{
+    ConfigApi, ConfigChange, ConfigDiff, ConfigDocument, ConfigHelp, ConfigHelpEntry,
+    ConfigHistoryEntry, ConfigMutationResult, ModuleSwitches, config_document_fields,
+    config_import_diff, config_mutation_diff, redact_config_document, validate_config_directive,
+    validate_config_import,
 };
 pub use diagnostics::{
     ClientDevnullRequest, ClientDevnullResult, ClusterComponentSnapshot, ClusterComponentSnapshots,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -16,18 +16,19 @@ use futures::StreamExt;
 use rc_core::admin::{
     AccessKeyInfo, AdminApi, BucketQuota, CapabilityApi, CapabilityAvailability, CapabilityEntry,
     CapabilityReport, ClusterInfo, ClusterSnapshotDocument, ClusterSnapshotMetadata,
-    ClusterSnapshotSummary, CreateServiceAccountRequest, DecommissionPoolStatus,
-    DecommissionStatus, DetailedHealthSnapshot, DiagnosticCapability, DiagnosticReadApi,
-    ExtensionsCatalog, Group, GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest,
-    HealStatus, HealTaskRequest, KmsApi, KmsBackendKind, KmsCacheSummary,
-    KmsCancelKeyDeletionResult, KmsConfigSummary, KmsConfigureRequest, KmsCreateKeyRequest,
-    KmsCreateKeyResult, KmsDeleteKeyRequest, KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState,
-    KmsKeyUsage, KmsServiceState, KmsStatus, MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES,
-    MAX_METRICS_RESPONSE_BYTES, MAX_METRICS_SAMPLES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
+    ClusterSnapshotSummary, ConfigApi, ConfigDocument, ConfigHelp, ConfigHistoryEntry,
+    ConfigMutationResult, CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus,
+    DetailedHealthSnapshot, DiagnosticCapability, DiagnosticReadApi, ExtensionsCatalog, Group,
+    GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus, HealTaskRequest,
+    KmsApi, KmsBackendKind, KmsCacheSummary, KmsCancelKeyDeletionResult, KmsConfigSummary,
+    KmsConfigureRequest, KmsCreateKeyRequest, KmsCreateKeyResult, KmsDeleteKeyRequest,
+    KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState, KmsKeyUsage, KmsServiceState, KmsStatus,
+    MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
+    MAX_METRICS_SAMPLES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REQUEST_BYTES,
-    MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, MetricsBatch, MetricsQuery, ObservabilityApi,
-    PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RealtimeMetrics,
-    RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
+    MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, MetricsBatch, MetricsQuery, ModuleSwitches,
+    ObservabilityApi, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
+    RealtimeMetrics, RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
     ReplicationDiffApi, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
     ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
     SiteReplicationInfo, SiteReplicationPeer, SiteReplicationResyncOperation,
@@ -67,6 +68,8 @@ struct CapabilityCacheKey {
 
 static CAPABILITY_CACHE: OnceLock<Mutex<HashMap<CapabilityCacheKey, CapabilityReport>>> =
     OnceLock::new();
+
+const MAX_CONFIG_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
 fn capability_cache() -> &'static Mutex<HashMap<CapabilityCacheKey, CapabilityReport>> {
     CAPABILITY_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
@@ -687,6 +690,68 @@ impl AdminClient {
         }
 
         Ok(())
+    }
+
+    async fn config_request(
+        &self,
+        method: Method,
+        path: &str,
+        query: Option<&[(&str, &str)]>,
+        body: Option<Zeroizing<Vec<u8>>>,
+    ) -> Result<(HeaderMap, Zeroizing<Vec<u8>>)> {
+        let mut url = self.admin_url(path);
+        if let Some(query) = query {
+            let query_string = query
+                .iter()
+                .map(|(key, value)| {
+                    format!(
+                        "{}={}",
+                        urlencoding::encode(key),
+                        urlencoding::encode(value)
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("&");
+            if !query_string.is_empty() {
+                url.push('?');
+                url.push_str(&query_string);
+            }
+        }
+
+        let body_bytes = body
+            .as_ref()
+            .map(|value| value.as_slice())
+            .unwrap_or_default();
+        let headers = self.request_headers(body_bytes)?;
+        let signed_headers = self
+            .sign_request(&method, &url, &headers, body_bytes)
+            .await?;
+        let mut request = self.http_client.request(method, &url);
+        for (name, value) in &signed_headers {
+            request = request.header(name, value);
+        }
+        if let Some(body) = body {
+            request = request.body(Bytes::from_owner(SensitiveRequestBody(body)));
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|_| Error::Network("Configuration request failed".to_string()))?;
+        let status = response.status();
+        let headers = response.headers().clone();
+        let response_body = Zeroizing::new(
+            read_bounded_response_body(
+                response,
+                MAX_CONFIG_RESPONSE_BYTES,
+                "configuration response",
+            )
+            .await?,
+        );
+        if !status.is_success() {
+            return Err(safe_config_error(status));
+        }
+        Ok((headers, response_body))
     }
 
     /// Extract host from endpoint
@@ -2545,6 +2610,159 @@ impl DiagnosticReadApi for AdminClient {
 }
 
 #[async_trait]
+impl ConfigApi for AdminClient {
+    async fn get_config(&self, selector: &str) -> Result<ConfigDocument> {
+        let (_, body) = self
+            .config_request(
+                Method::GET,
+                "/get-config-kv",
+                Some(&[("key", selector)]),
+                None,
+            )
+            .await?;
+        let content = std::str::from_utf8(body.as_slice())
+            .map_err(|_| Error::General("Server returned invalid configuration text".to_string()))?
+            .to_string();
+        Ok(ConfigDocument { content })
+    }
+
+    async fn get_full_config(&self) -> Result<ConfigDocument> {
+        let (_, body) = self
+            .config_request(Method::GET, "/config", None, None)
+            .await?;
+        let content = std::str::from_utf8(body.as_slice())
+            .map_err(|_| Error::General("Server returned invalid configuration text".to_string()))?
+            .to_string();
+        Ok(ConfigDocument { content })
+    }
+
+    async fn set_config(&self, directive: &str) -> Result<ConfigMutationResult> {
+        let (headers, _) = self
+            .config_request(
+                Method::PUT,
+                "/set-config-kv",
+                None,
+                Some(Zeroizing::new(directive.as_bytes().to_vec())),
+            )
+            .await?;
+        Ok(ConfigMutationResult {
+            applied_dynamically: config_applied(&headers),
+        })
+    }
+
+    async fn delete_config(&self, directive: &str) -> Result<ConfigMutationResult> {
+        let (headers, _) = self
+            .config_request(
+                Method::DELETE,
+                "/del-config-kv",
+                None,
+                Some(Zeroizing::new(directive.as_bytes().to_vec())),
+            )
+            .await?;
+        Ok(ConfigMutationResult {
+            applied_dynamically: config_applied(&headers),
+        })
+    }
+
+    async fn config_help(
+        &self,
+        subsystem: Option<&str>,
+        key: Option<&str>,
+        env_only: bool,
+    ) -> Result<ConfigHelp> {
+        let mut query = Vec::new();
+        if let Some(subsystem) = subsystem {
+            query.push(("subSys", subsystem));
+        }
+        if let Some(key) = key {
+            query.push(("key", key));
+        }
+        if env_only {
+            query.push(("env", "true"));
+        }
+        let (_, body) = self
+            .config_request(Method::GET, "/help-config-kv", Some(&query), None)
+            .await?;
+        serde_json::from_slice(body.as_slice())
+            .map_err(|_| Error::General("Server returned invalid configuration help".to_string()))
+    }
+
+    async fn config_history(&self, count: usize) -> Result<Vec<ConfigHistoryEntry>> {
+        let count = count.to_string();
+        let (_, body) = self
+            .config_request(
+                Method::GET,
+                "/list-config-history-kv",
+                Some(&[("count", count.as_str())]),
+                None,
+            )
+            .await?;
+        serde_json::from_slice(body.as_slice()).map_err(|_| {
+            Error::General("Server returned invalid configuration history".to_string())
+        })
+    }
+
+    async fn restore_config(&self, restore_id: &str) -> Result<()> {
+        self.config_request(
+            Method::PUT,
+            "/restore-config-history-kv",
+            Some(&[("restoreId", restore_id)]),
+            None,
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn import_config(&self, document: &ConfigDocument) -> Result<()> {
+        self.config_request(
+            Method::PUT,
+            "/config",
+            None,
+            Some(Zeroizing::new(document.content.as_bytes().to_vec())),
+        )
+        .await
+        .map(|_| ())
+    }
+
+    async fn get_module_switches(&self) -> Result<ModuleSwitches> {
+        let (_, body) = self
+            .config_request(Method::GET, "/module-switches", None, None)
+            .await
+            .map_err(|error| match error {
+                Error::NotFound(_) => Error::UnsupportedFeature(
+                    "Server does not advertise module switch operations".to_string(),
+                ),
+                other => other,
+            })?;
+        serde_json::from_slice(body.as_slice())
+            .map_err(|_| Error::General("Server returned invalid module switch state".to_string()))
+    }
+
+    async fn set_module_switches(&self, switches: &ModuleSwitches) -> Result<ModuleSwitches> {
+        let body = Zeroizing::new(
+            serde_json::to_vec(&serde_json::json!({
+                "notify_enabled": switches.notify_enabled,
+                "audit_enabled": switches.audit_enabled,
+            }))
+            .map_err(|_| Error::General("Failed to encode module switch request".to_string()))?,
+        );
+        let (_, response) = self
+            .config_request(Method::PUT, "/module-switches", None, Some(body))
+            .await?;
+        serde_json::from_slice(response.as_slice())
+            .map_err(|_| Error::General("Server returned invalid module switch state".to_string()))
+    }
+}
+
+fn config_applied(headers: &HeaderMap) -> bool {
+    headers
+        .get("x-rustfs-config-applied")
+        .or_else(|| headers.get("x-minio-config-applied"))
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+}
+
+#[async_trait]
 impl ObservabilityApi for AdminClient {
     async fn scanner_status(&self) -> Result<ScannerStatus> {
         self.request(Method::GET, "/scanner/status", None, None)
@@ -2677,6 +2895,30 @@ fn observability_route_error(error: Error, feature: &str) -> Error {
             Error::UnsupportedFeature(format!("{feature} is unavailable on this RustFS server"))
         }
         error => error,
+    }
+}
+
+fn safe_config_error(status: StatusCode) -> Error {
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+            Error::Auth("Server denied configuration access".to_string())
+        }
+        StatusCode::NOT_FOUND => Error::NotFound(
+            "Configuration API route or requested resource was not found".to_string(),
+        ),
+        StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED => {
+            Error::Conflict("Server configuration changed before mutation".to_string())
+        }
+        StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+            "Server does not implement this configuration operation".to_string(),
+        ),
+        StatusCode::BAD_REQUEST => Error::Config(
+            "Server rejected the configuration request; review `rc admin config help`".to_string(),
+        ),
+        _ => Error::Network(format!(
+            "Configuration request failed with HTTP {}",
+            status.as_u16()
+        )),
     }
 }
 

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -39,6 +39,8 @@ rc admin group <ls|add|info|rm|enable|disable|add-members|rm-members> ...
 rc admin service-account <ls|create|info|rm> ...
 rc admin service <restart|stop|freeze|unfreeze> <ALIAS>
 rc admin diagnostics client-devnull <ALIAS> [--size <SIZE>] [--timeout <DURATION>] [--concurrency <N>] --yes
+rc admin config <get|set|delete|help|history|restore|export|import> ...
+rc admin config module-switch <get|set> ...
 rc admin replicate add <ALIAS> <ALIAS> [<ALIAS>...]
 rc admin replicate <info|status> <ALIAS> [OPTIONS]
 rc admin replicate edit <ALIAS> --site <DEPLOYMENT_ID|NAME> [EDIT OPTIONS] --yes
@@ -66,6 +68,7 @@ rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 | `group` | Manage IAM groups and group membership. |
 | `service-account` | Manage service accounts. |
 | `service` | Control the server process: restart, stop, freeze, unfreeze. |
+| `config` | Inspect, plan, export, and mutate RustFS server configuration. |
 | `replicate` | Manage site replication across clusters. |
 
 ## Examples
@@ -375,6 +378,31 @@ Use `rc admin pool list <ALIAS>` or `rc admin pool status <ALIAS>` to find pool 
 | `rc admin service unfreeze <ALIAS>` | Clear the service freeze flag. |
 
 The server response reports whether the action was `accepted` and whether it is `effective` on the current build. RustFS has no in-process supervisor, so `restart` and `stop` both perform a graceful stop; `restart` relies on the process manager to bring the server back up.
+
+## Server Configuration Workflow
+
+`rc admin config` manages the RustFS server configuration behind an alias. It does not modify the local `rc` alias configuration.
+
+| Command | Description |
+| --- | --- |
+| `rc admin config get <ALIAS> <SUBSYSTEM[:TARGET]>` | Read a subsystem or named target. Secret-bearing fields are redacted again by the client before output. |
+| `rc admin config set <ALIAS> <SUBSYSTEM[:TARGET]> <KEY=VALUE\|KEY=@PATH>... [--dry-run]` | Consult server help once per subsystem, read the current state, calculate a redacted diff, and apply the directive unless `--dry-run` is set. `KEY=@PATH` keeps a value out of process arguments. |
+| `rc admin config delete <ALIAS> <SUBSYSTEM[:TARGET]> [KEY...] [--dry-run]` | Delete selected keys or the complete target after a redacted preflight diff. |
+| `rc admin config help <ALIAS> [SUBSYSTEM] [KEY] [--env]` | Show server-provided subsystem, key, or environment-variable help. |
+| `rc admin config history <ALIAS> [--count <N>]` | List recent history. History data is classified and redacted locally because server records can contain submitted values. |
+| `rc admin config restore <ALIAS> <RESTORE_ID> [--dry-run] --yes` | Preview or apply a history entry as a complete configuration replacement. |
+| `rc admin config export <ALIAS> --file <PATH>` | Create a new, owner-private, redacted configuration file. Existing files are never overwritten. |
+| `rc admin config import <ALIAS> --file <PATH> [--dry-run] --yes` | Validate and preview a complete configuration replacement from a file. Redacted secret placeholders are rejected. |
+| `rc admin config module-switch get <ALIAS>` | Show effective and persisted notification/audit module switches and their sources. |
+| `rc admin config module-switch set <ALIAS> [--notify on\|off] [--audit on\|off] [--dry-run]` | Update one or both persisted switches. Omitted switches retain their persisted value even when an environment override changes the effective value. |
+
+All set, delete, import, restore, and module-switch dry runs are client-side and do not send a mutation request. RustFS beta.10 does not expose a revision, ETag, or other optimistic concurrency token for these routes, so `rc` does not claim atomic compare-and-set protection.
+
+Full imports and restores require `--yes`. RustFS beta.10 history entries contain the submitted directive rather than a complete pre-change snapshot. The server currently rebuilds its configuration from that directive during restore, which can remove unrelated settings. `rc` shows this as a complete replacement and warns about the unsafe server behavior tracked in [rustfs/backlog#1398](https://github.com/rustfs/backlog/issues/1398); a history restore must not be treated as preservation-safe rollback.
+
+Exports are always redacted because secret values are not a portable client output contract. Replace any required secret values through an approved secret-management workflow before importing; `rc` rejects the `*redacted*` placeholder for secret-bearing fields.
+
+Value files are limited to 1 MiB of single-line UTF-8 text. On Unix they must be regular, non-symlink files without group or other permissions; trailing line endings are removed. If server help metadata is incomplete or unavailable, `set`, `delete`, and `import` emit a warning and defer final validation to the mutation endpoint.
 
 ## Site Replication Workflow
 


### PR DESCRIPTION
## Related issues

Closes rustfs/backlog#1375

Replaces closed PR #283 after its stacked base was removed. Server-side safety limitations remain tracked in rustfs/backlog#1398 and rustfs/backlog#1399.

## Background and user impact

RustFS beta.10 exposes server configuration reads, mutations, history, restore, help, and module-switch routes, but `rc` lacked a safe workflow around them. Raw server documents may contain credentials, destructive replacements can remove unrelated settings, and the service does not expose revision or ETag tokens for optimistic concurrency.

## Solution

- Add `rc admin config get|set|delete|help|history|restore|export|import` and module-switch support.
- Compute deterministic, redacted dry-run diffs before mutations.
- Require explicit confirmation for restore and import replacement operations.
- Redact current secret fields plus conservative connection, DSN, API, account, and access-key names.
- Preserve unparseable non-secret lines while conservatively truncating malformed sensitive assignments.
- Support `KEY=@PATH` values with a 1 MiB limit, one-line UTF-8 validation, and Unix regular-file, non-symlink, private-permission checks.
- Keep sensitive values in bounded zeroizing request bodies and discard server error bodies.
- Fetch help once per subsystem; missing or incomplete metadata becomes a warning and the server remains authoritative.
- Base module-switch diffs on persisted state so environment overrides cannot create phantom compliance changes.
- Allow confirmed restore by an older history ID when its preview is outside the latest 1000 entries, while refusing dry-run because a safe diff is unavailable.
- Export with create-new semantics and owner-private permissions without overwriting existing files.

## Review follow-up from #283

All requested changes from `overtrue` are addressed:

- **MAJOR — mixed effective/persisted switch planes:** fixed; unit and integration coverage include environment overrides.
- **Secret values in positional argv:** added `KEY=@PATH` with bounded and permission-checked file input.
- **Fragile redaction denylist:** expanded conservative classification for connection strings, DSNs, API/account/access keys; server metadata remains tracked by #1399.
- **Restore limited to 1000 entries:** confirmed restore falls back to apply-by-ID with an explicit `diff unavailable` result; dry-run refuses unsafe previewless restore.
- **Sequential/fatal help validation:** one request per subsystem, with missing or incomplete metadata downgraded to warnings.
- **Unusable parse-failure placeholder:** best-effort per-line redaction preserves non-secret syntax and truncates sensitive malformed assignments.
- **Coverage gap:** added full-target delete diff coverage.

## BREAKING contract note

**BREAKING:** This PR updates the protected `docs/reference/rc/admin.md` command behavior contract. It does not change output v1/v2/v3 schemas, local config schema, or exit-code definitions. The new commands are additive and do not require data migration.

## Validation

Exact head: `ceb905d`

- `cargo fmt --all --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --workspace -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test --workspace`
- Core configuration unit tests: 10 passed
- CLI configuration unit tests: 17 passed
- CLI configuration integration tests: 10 passed
- Help contract tests: 3 passed
- Review thread audit on #283: 1 changes-requested review, 0 review threads; every finding above was re-audited after implementation

## Limitations

- RustFS does not expose revision or ETag tokens, so mutations cannot provide atomic compare-and-swap protection.
- The current history API has no cursor or by-ID preview endpoint. An older restore ID can be applied only after confirmation and cannot produce a safe dry-run diff.
- Server-side history storage and default redaction remain tracked by #1399; the CLI defensively redacts all displayed history.
- Preservation-safe server rollback semantics remain tracked by #1398. Users must review the diff or explicit `diff unavailable` warning before confirmation.
