### PR TITLE
feat(undo): restore versioned PUT and DELETE operations

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -49,6 +49,7 @@ mod sql;
 mod stat;
 mod tag;
 mod tree;
+mod undo;
 mod version;
 mod watch;
 
@@ -253,6 +254,9 @@ pub enum Commands {
     /// Deprecated: use `rc object remove`
     Rm(rm::RmArgs),
 
+    /// Restore a versioned PUT or DELETE operation without removing data history
+    Undo(undo::UndoArgs),
+
     /// Stream stdin to an object
     Pipe(pipe::PipeArgs),
 
@@ -416,6 +420,13 @@ pub async fn execute(cli: Cli) -> ExitCode {
         }
         Commands::Rm(args) => {
             rm::execute(args, output_options.resolve(OutputBehavior::HumanDefault)).await
+        }
+        Commands::Undo(args) => {
+            undo::execute(
+                args,
+                output_options.resolve(OutputBehavior::StructuredDefault),
+            )
+            .await
         }
         Commands::Pipe(args) => {
             pipe::execute(args, output_options.resolve(OutputBehavior::HumanDefault)).await

--- a/crates/cli/src/commands/undo.rs
+++ b/crates/cli/src/commands/undo.rs
@@ -1,0 +1,1045 @@
+//! Safe, history-preserving undo for versioned object PUT and DELETE operations.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use clap::Args;
+use futures::stream::{self, StreamExt as _};
+use rc_core::{
+    AliasManager, CopyObjectOptions, DeleteRequestOptions, Error, ListObjectVersionsOptions,
+    ObjectInfo, ObjectStore, ObjectVersion, ObjectVersionListResult, ParsedPath, RemotePath,
+    UndoAction, UndoObjectResult, UndoOutcome, UndoPlan, UndoPlanItem, parse_path,
+    plan_object_undo,
+};
+use rc_s3::S3Client;
+use serde::Serialize;
+
+use crate::exit_code::ExitCode;
+use crate::output::{
+    Formatter, OutputConfig, V3ErrorEnvelope, V3PartialErrorEnvelope, V3SuccessEnvelope,
+};
+
+const DEFAULT_UNDO_CONCURRENCY: usize = 4;
+const MAX_UNDO_CONCURRENCY: usize = 64;
+const UNDO_AFTER_HELP: &str = "\
+Examples:
+  rc undo local/my-bucket/report.txt --dry-run
+  rc undo local/my-bucket/report.txt
+  rc undo local/my-bucket/report.txt --version-id VERSION_ID
+  rc undo local/my-bucket/reports/ --recursive --concurrency 4";
+
+/// Restore a versioned object operation without deleting data versions.
+#[derive(Args, Clone, Debug)]
+#[command(after_help = UNDO_AFTER_HELP)]
+pub struct UndoArgs {
+    /// Object or prefix path (alias/bucket/key)
+    pub path: String,
+
+    /// Restore this exact data version or remove this exact current delete marker
+    #[arg(long, value_name = "VERSION_ID")]
+    pub version_id: Option<String>,
+
+    /// Plan all reversible objects under the prefix
+    #[arg(short, long)]
+    pub recursive: bool,
+
+    /// Show the complete plan without making changes
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Maximum number of object mutations in flight
+    #[arg(long, default_value_t = DEFAULT_UNDO_CONCURRENCY)]
+    pub concurrency: usize,
+}
+
+#[derive(Debug, Serialize)]
+struct UndoCommandData {
+    operation: &'static str,
+    outcome: &'static str,
+    dry_run: bool,
+    results: Vec<UndoObjectResult>,
+    summary: UndoSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct UndoSummary {
+    planned: usize,
+    succeeded: usize,
+    failed: usize,
+}
+
+#[async_trait]
+trait UndoStore: Send + Sync {
+    async fn versioning(&self, bucket: &str) -> rc_core::Result<Option<bool>>;
+
+    async fn list_versions_page(
+        &self,
+        path: &RemotePath,
+        options: &ListObjectVersionsOptions,
+    ) -> rc_core::Result<ObjectVersionListResult>;
+
+    async fn remove_version(
+        &self,
+        path: &RemotePath,
+        options: DeleteRequestOptions,
+    ) -> rc_core::Result<()>;
+
+    async fn copy_version(
+        &self,
+        path: &RemotePath,
+        options: &CopyObjectOptions,
+    ) -> rc_core::Result<ObjectInfo>;
+}
+
+#[async_trait]
+impl UndoStore for S3Client {
+    async fn versioning(&self, bucket: &str) -> rc_core::Result<Option<bool>> {
+        ObjectStore::get_versioning(self, bucket).await
+    }
+
+    async fn list_versions_page(
+        &self,
+        path: &RemotePath,
+        options: &ListObjectVersionsOptions,
+    ) -> rc_core::Result<ObjectVersionListResult> {
+        ObjectStore::list_object_versions_page_with_options(self, path, options).await
+    }
+
+    async fn remove_version(
+        &self,
+        path: &RemotePath,
+        options: DeleteRequestOptions,
+    ) -> rc_core::Result<()> {
+        ObjectStore::delete_object_with_options(self, path, options).await?;
+        Ok(())
+    }
+
+    async fn copy_version(
+        &self,
+        path: &RemotePath,
+        options: &CopyObjectOptions,
+    ) -> rc_core::Result<ObjectInfo> {
+        ObjectStore::copy_object_with_options(self, path, path, options, None).await
+    }
+}
+
+/// Execute the undo command.
+pub async fn execute(args: UndoArgs, output_config: OutputConfig) -> ExitCode {
+    let formatter = Formatter::new(output_config);
+    if let Err(error) = validate_args(&args) {
+        return fail(&formatter, ExitCode::UsageError, &error);
+    }
+    let path = match parse_remote_scope(&args) {
+        Ok(path) => path,
+        Err(error) => return fail(&formatter, ExitCode::UsageError, &error),
+    };
+    let alias_manager = match AliasManager::new() {
+        Ok(manager) => manager,
+        Err(error) => {
+            return fail(
+                &formatter,
+                ExitCode::GeneralError,
+                &format!("Failed to load aliases: {error}"),
+            );
+        }
+    };
+    let alias = match alias_manager.get(&path.alias) {
+        Ok(alias) => alias,
+        Err(error) => return fail(&formatter, exit_code(&error), &error.to_string()),
+    };
+    let client = match S3Client::new(alias).await {
+        Ok(client) => Arc::new(client),
+        Err(error) => {
+            return fail(
+                &formatter,
+                exit_code(&error),
+                &format!("Failed to create S3 client: {error}"),
+            );
+        }
+    };
+
+    let report = match run_undo(client, &path, &args).await {
+        Ok(report) => report,
+        Err(error) => return fail(&formatter, exit_code(&error), &error.to_string()),
+    };
+    render_report(&formatter, report)
+}
+
+fn validate_args(args: &UndoArgs) -> Result<(), String> {
+    if args.version_id.as_deref().is_some_and(str::is_empty) {
+        return Err("--version-id cannot be empty".to_string());
+    }
+    if args.version_id.is_some() && args.recursive {
+        return Err("--version-id cannot be combined with --recursive".to_string());
+    }
+    if args.concurrency == 0 || args.concurrency > MAX_UNDO_CONCURRENCY {
+        return Err(format!(
+            "--concurrency must be between 1 and {MAX_UNDO_CONCURRENCY}"
+        ));
+    }
+    Ok(())
+}
+
+fn parse_remote_scope(args: &UndoArgs) -> Result<RemotePath, String> {
+    let ParsedPath::Remote(path) = parse_path(&args.path).map_err(|error| error.to_string())?
+    else {
+        return Err("Undo requires a remote path in the form alias/bucket/key".to_string());
+    };
+    if path.key.is_empty() && !args.recursive {
+        return Err("Bucket undo requires --recursive".to_string());
+    }
+    if !args.recursive && path.key.ends_with('/') {
+        return Err("Prefix undo requires --recursive".to_string());
+    }
+    Ok(path)
+}
+
+async fn run_undo<S: UndoStore + 'static>(
+    store: Arc<S>,
+    path: &RemotePath,
+    args: &UndoArgs,
+) -> rc_core::Result<UndoCommandData> {
+    match store.versioning(&path.bucket).await? {
+        Some(true) => {}
+        Some(false) => {
+            return Err(Error::UnsupportedFeature(format!(
+                "Undo requires enabled bucket versioning; versioning is suspended for {}",
+                path.bucket
+            )));
+        }
+        None => {
+            return Err(Error::UnsupportedFeature(format!(
+                "Undo requires enabled bucket versioning; {} is unversioned",
+                path.bucket
+            )));
+        }
+    }
+
+    let history = list_all_versions(store.as_ref(), path).await?;
+    let (plan, mut results) = build_plan(path, history, args);
+    if plan.items.is_empty() && results.is_empty() {
+        return Err(Error::NotFound(format!(
+            "No object version history found for {}",
+            path
+        )));
+    }
+    let planned = plan.items.len();
+
+    if args.dry_run {
+        results.extend(plan.items.into_iter().map(|plan| UndoObjectResult {
+            key: plan.key.clone(),
+            plan: Some(plan),
+            outcome: UndoOutcome::Planned,
+        }));
+    } else {
+        let alias = path.alias.clone();
+        let bucket = path.bucket.clone();
+        let mut executed = stream::iter(plan.items.into_iter().map(|plan| {
+            let store = Arc::clone(&store);
+            let alias = alias.clone();
+            let bucket = bucket.clone();
+            async move { execute_plan_item(store.as_ref(), &alias, &bucket, plan).await }
+        }))
+        .buffer_unordered(args.concurrency)
+        .collect::<Vec<_>>()
+        .await;
+        results.append(&mut executed);
+    }
+    results.sort_by(|left, right| left.key.cmp(&right.key));
+
+    let failed = results
+        .iter()
+        .filter(|result| matches!(result.outcome, UndoOutcome::Failed { .. }))
+        .count();
+    let succeeded = results
+        .iter()
+        .filter(|result| {
+            matches!(
+                result.outcome,
+                UndoOutcome::DeleteMarkerRemoved | UndoOutcome::VersionRestored { .. }
+            )
+        })
+        .count();
+    let outcome = if failed > 0 && (succeeded > 0 || (args.dry_run && planned > 0)) {
+        "partial"
+    } else if failed > 0 {
+        "failed"
+    } else if args.dry_run {
+        "planned"
+    } else {
+        "success"
+    };
+
+    Ok(UndoCommandData {
+        operation: "undo",
+        outcome,
+        dry_run: args.dry_run,
+        results,
+        summary: UndoSummary {
+            planned,
+            succeeded,
+            failed,
+        },
+    })
+}
+
+fn build_plan(
+    path: &RemotePath,
+    history: Vec<ObjectVersion>,
+    args: &UndoArgs,
+) -> (UndoPlan, Vec<UndoObjectResult>) {
+    let mut by_key = BTreeMap::<String, Vec<ObjectVersion>>::new();
+    for version in history {
+        if (args.recursive && version.key.starts_with(&path.key))
+            || (!args.recursive && version.key == path.key)
+        {
+            by_key.entry(version.key.clone()).or_default().push(version);
+        }
+    }
+    if !args.recursive && !by_key.contains_key(&path.key) {
+        by_key.insert(path.key.clone(), Vec::new());
+    }
+
+    let mut plan = Vec::new();
+    let mut failures = Vec::new();
+    for (key, versions) in by_key {
+        match plan_object_undo(&key, &versions, args.version_id.as_deref()) {
+            Ok(item) => plan.push(item),
+            Err(error) => failures.push(planning_failure(key, &error)),
+        }
+    }
+    (UndoPlan::new(plan), failures)
+}
+
+async fn execute_plan_item<S: UndoStore>(
+    store: &S,
+    alias: &str,
+    bucket: &str,
+    plan: UndoPlanItem,
+) -> UndoObjectResult {
+    let path = RemotePath::new(alias, bucket, &plan.key);
+    // S3 has no destination-version compare-and-swap for CopyObject or DeleteObject. Rechecking
+    // immediately before mutation fails closed for observed changes, while the remaining
+    // protocol-level race is tracked by rustfs/backlog#1438.
+    let current = match list_all_versions(store, &path).await {
+        Ok(history) => current_version_id(&plan.key, &history),
+        Err(error) => return failed_result(plan, &error),
+    };
+    let current = match current {
+        Ok(current) => current,
+        Err(error) => return failed_result(plan, &error),
+    };
+    if current != plan.expected_latest_version_id {
+        let error = Error::Conflict(format!(
+            "Object changed after undo planning; expected current version '{}', found '{}'",
+            plan.expected_latest_version_id, current
+        ));
+        return failed_result(plan, &error);
+    }
+
+    let result = match &plan.action {
+        UndoAction::RemoveDeleteMarker {
+            marker_version_id,
+            revealed_version_id,
+        } => store
+            .remove_version(
+                &path,
+                DeleteRequestOptions {
+                    version_id: Some(marker_version_id.clone()),
+                    bypass_governance: false,
+                    force_delete: false,
+                },
+            )
+            .await
+            .map(|()| {
+                (
+                    UndoOutcome::DeleteMarkerRemoved,
+                    revealed_version_id.clone(),
+                )
+            }),
+        UndoAction::RestoreVersion { source_version_id } => {
+            let options = CopyObjectOptions {
+                source_version_id: Some(source_version_id.clone()),
+            };
+            store.copy_version(&path, &options).await.and_then(|info| {
+                let created_version_id = info.version_id.ok_or_else(|| {
+                    Error::Conflict(format!(
+                        "Versioned CopyObject did not return a destination version ID for {}",
+                        plan.key
+                    ))
+                })?;
+                Ok((
+                    UndoOutcome::VersionRestored {
+                        created_version_id: Some(created_version_id.clone()),
+                    },
+                    created_version_id,
+                ))
+            })
+        }
+    };
+
+    match result {
+        Ok((outcome, expected_current)) => {
+            let observed_current = match list_all_versions(store, &path).await {
+                Ok(history) => current_version_id(&plan.key, &history),
+                Err(error) => return failed_result(plan, &error),
+            };
+            match observed_current {
+                Ok(observed) if observed == expected_current => UndoObjectResult {
+                    key: plan.key.clone(),
+                    plan: Some(plan),
+                    outcome,
+                },
+                Ok(observed) => {
+                    let error = Error::Conflict(format!(
+                        "Undo mutation completed but the current version changed; expected '{}', found '{}'",
+                        expected_current, observed
+                    ));
+                    failed_result(plan, &error)
+                }
+                Err(error) => failed_result(plan, &error),
+            }
+        }
+        Err(error) => failed_result(plan, &error),
+    }
+}
+
+fn current_version_id(key: &str, history: &[ObjectVersion]) -> rc_core::Result<String> {
+    let mut latest = history
+        .iter()
+        .filter(|version| version.key == key && version.is_latest);
+    let version = latest
+        .next()
+        .ok_or_else(|| Error::Conflict(format!("No current version found for {key}")))?;
+    if latest.next().is_some() {
+        return Err(Error::Conflict(format!(
+            "Multiple current versions were reported for {key}"
+        )));
+    }
+    Ok(version.version_id.clone())
+}
+
+async fn list_all_versions<S: UndoStore>(
+    store: &S,
+    path: &RemotePath,
+) -> rc_core::Result<Vec<ObjectVersion>> {
+    let mut items = Vec::new();
+    let mut key_marker = None;
+    let mut version_id_marker = None;
+    loop {
+        let page = store
+            .list_versions_page(
+                path,
+                &ListObjectVersionsOptions {
+                    max_keys: Some(1000),
+                    key_marker: key_marker.clone(),
+                    version_id_marker: version_id_marker.clone(),
+                },
+            )
+            .await?;
+        items.extend(page.items);
+        if !page.truncated {
+            return Ok(items);
+        }
+        let next_key_marker = page.continuation_token.ok_or_else(|| {
+            Error::Network(
+                "S3 returned a truncated version listing without a key marker".to_string(),
+            )
+        })?;
+        let next_version_id_marker = page.version_id_marker;
+        if key_marker.as_deref() == Some(next_key_marker.as_str())
+            && version_id_marker == next_version_id_marker
+        {
+            return Err(Error::Network(
+                "S3 returned a truncated version listing without advancing its markers".to_string(),
+            ));
+        }
+        key_marker = Some(next_key_marker);
+        version_id_marker = next_version_id_marker;
+    }
+}
+
+fn failed_result(plan: UndoPlanItem, error: &Error) -> UndoObjectResult {
+    let blocked_version_id = is_lock_conflict(error).then(|| match &plan.action {
+        UndoAction::RemoveDeleteMarker {
+            marker_version_id, ..
+        } => marker_version_id.clone(),
+        UndoAction::RestoreVersion { source_version_id } => source_version_id.clone(),
+    });
+    let message = blocked_version_id.as_ref().map_or_else(
+        || error.to_string(),
+        |version_id| format!("{error} (blocked version: {version_id})"),
+    );
+    UndoObjectResult {
+        key: plan.key.clone(),
+        plan: Some(plan),
+        outcome: UndoOutcome::Failed {
+            error_type: error_type(exit_code(error)).to_string(),
+            message,
+            blocked_version_id,
+        },
+    }
+}
+
+fn planning_failure(key: String, error: &Error) -> UndoObjectResult {
+    UndoObjectResult {
+        key,
+        plan: None,
+        outcome: UndoOutcome::Failed {
+            error_type: error_type(exit_code(error)).to_string(),
+            message: error.to_string(),
+            blocked_version_id: None,
+        },
+    }
+}
+
+fn exit_code(error: &Error) -> ExitCode {
+    if is_lock_conflict(error) {
+        ExitCode::Conflict
+    } else {
+        ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError)
+    }
+}
+
+fn is_lock_conflict(error: &Error) -> bool {
+    if matches!(error, Error::GovernanceDenied { .. }) {
+        return true;
+    }
+    let message = error.to_string().to_ascii_lowercase();
+    [
+        "legal hold",
+        "legalhold",
+        "retention",
+        "object lock",
+        "governance",
+        "worm",
+    ]
+    .iter()
+    .any(|needle| message.contains(needle))
+}
+
+fn error_type(code: ExitCode) -> &'static str {
+    match code {
+        ExitCode::Success | ExitCode::GeneralError => "general_error",
+        ExitCode::UsageError => "usage_error",
+        ExitCode::NetworkError => "network_error",
+        ExitCode::AuthError => "auth_error",
+        ExitCode::NotFound => "not_found",
+        ExitCode::Conflict => "conflict",
+        ExitCode::UnsupportedFeature => "unsupported_feature",
+        ExitCode::Interrupted => "interrupted",
+    }
+}
+
+fn report_exit_code(report: &UndoCommandData) -> ExitCode {
+    report
+        .results
+        .iter()
+        .filter_map(|result| match &result.outcome {
+            UndoOutcome::Failed { error_type, .. } => Some(match error_type.as_str() {
+                "usage_error" => ExitCode::UsageError,
+                "network_error" => ExitCode::NetworkError,
+                "auth_error" => ExitCode::AuthError,
+                "not_found" => ExitCode::NotFound,
+                "conflict" => ExitCode::Conflict,
+                "unsupported_feature" => ExitCode::UnsupportedFeature,
+                "interrupted" => ExitCode::Interrupted,
+                _ => ExitCode::GeneralError,
+            }),
+            _ => None,
+        })
+        .next()
+        .unwrap_or(ExitCode::Success)
+}
+
+fn format_dry_run(plan: &UndoPlanItem) -> String {
+    match &plan.action {
+        UndoAction::RemoveDeleteMarker {
+            marker_version_id,
+            revealed_version_id,
+        } => format!(
+            "Would remove delete marker '{}' for {} (expected current '{}'; reveals '{}')",
+            marker_version_id, plan.key, plan.expected_latest_version_id, revealed_version_id
+        ),
+        UndoAction::RestoreVersion { source_version_id } => format!(
+            "Would restore {} from version '{}' (expected current '{}')",
+            plan.key, source_version_id, plan.expected_latest_version_id
+        ),
+    }
+}
+
+fn render_report(formatter: &Formatter, report: UndoCommandData) -> ExitCode {
+    let code = report_exit_code(&report);
+    if formatter.is_json() {
+        if code == ExitCode::Success {
+            formatter.json(&V3SuccessEnvelope::versioned_objects(report));
+        } else {
+            formatter.json_error(&V3PartialErrorEnvelope::versioned_objects(
+                code,
+                "One or more object undo operations failed",
+                Some("versioned_object_undo"),
+                report,
+            ));
+        }
+    } else {
+        for result in &report.results {
+            match &result.outcome {
+                UndoOutcome::Planned => {
+                    if let Some(plan) = &result.plan {
+                        formatter.println(&format_dry_run(plan));
+                    }
+                }
+                UndoOutcome::DeleteMarkerRemoved => {
+                    formatter.success(&format!("Restored deleted object: {}", result.key));
+                }
+                UndoOutcome::VersionRestored { .. } => {
+                    formatter.success(&format!("Restored object version: {}", result.key));
+                }
+                UndoOutcome::Failed { message, .. } => {
+                    formatter.error(&format!("Failed to undo {}: {message}", result.key));
+                }
+            }
+        }
+    }
+    code
+}
+
+fn fail(formatter: &Formatter, code: ExitCode, message: &str) -> ExitCode {
+    if formatter.is_json() {
+        formatter.json_error(&V3ErrorEnvelope::versioned_objects(
+            code,
+            message,
+            Some("versioned_object_undo"),
+        ));
+        code
+    } else {
+        formatter.fail(code, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use jiff::Timestamp;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct FakeStore {
+        versioning: Mutex<Option<bool>>,
+        listings: Mutex<Vec<Vec<ObjectVersion>>>,
+        removed: Mutex<Vec<String>>,
+        copied: Mutex<Vec<String>>,
+        fail_copy: Mutex<bool>,
+    }
+
+    impl FakeStore {
+        fn with_listings(listings: Vec<Vec<ObjectVersion>>) -> Self {
+            Self {
+                versioning: Mutex::new(Some(true)),
+                listings: Mutex::new(listings),
+                ..Self::default()
+            }
+        }
+    }
+
+    #[async_trait]
+    impl UndoStore for FakeStore {
+        async fn versioning(&self, _bucket: &str) -> rc_core::Result<Option<bool>> {
+            Ok(*self.versioning.lock().expect("versioning lock"))
+        }
+
+        async fn list_versions_page(
+            &self,
+            _path: &RemotePath,
+            _options: &ListObjectVersionsOptions,
+        ) -> rc_core::Result<ObjectVersionListResult> {
+            let items = self.listings.lock().expect("listings lock").remove(0);
+            Ok(ObjectVersionListResult {
+                items,
+                truncated: false,
+                continuation_token: None,
+                version_id_marker: None,
+            })
+        }
+
+        async fn remove_version(
+            &self,
+            _path: &RemotePath,
+            options: DeleteRequestOptions,
+        ) -> rc_core::Result<()> {
+            self.removed
+                .lock()
+                .expect("removed lock")
+                .push(options.version_id.expect("exact version"));
+            Ok(())
+        }
+
+        async fn copy_version(
+            &self,
+            _path: &RemotePath,
+            options: &CopyObjectOptions,
+        ) -> rc_core::Result<ObjectInfo> {
+            if *self.fail_copy.lock().expect("failure lock") {
+                return Err(Error::Auth("copy denied".to_string()));
+            }
+            self.copied
+                .lock()
+                .expect("copied lock")
+                .push(options.source_version_id.clone().expect("source version"));
+            let mut info = ObjectInfo::file("report.txt", 12);
+            info.version_id = Some("restored-v4".to_string());
+            Ok(info)
+        }
+    }
+
+    fn version(id: &str, modified: &str, latest: bool, marker: bool) -> ObjectVersion {
+        ObjectVersion {
+            key: "report.txt".to_string(),
+            version_id: id.to_string(),
+            is_latest: latest,
+            is_delete_marker: marker,
+            last_modified: Some(modified.parse::<Timestamp>().expect("valid timestamp")),
+            size_bytes: (!marker).then_some(12),
+            etag: None,
+        }
+    }
+
+    fn restore_plan() -> UndoPlanItem {
+        UndoPlanItem {
+            key: "report.txt".to_string(),
+            expected_latest_version_id: "v2".to_string(),
+            action: UndoAction::RestoreVersion {
+                source_version_id: "v1".to_string(),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn concurrent_new_version_is_stale_and_performs_no_mutation() {
+        let store = FakeStore::with_listings(vec![vec![
+            version("v3", "2026-07-23T03:00:00Z", true, false),
+            version("v2", "2026-07-23T02:00:00Z", false, false),
+        ]]);
+
+        let result = execute_plan_item(&store, "local", "bucket", restore_plan()).await;
+
+        assert!(matches!(result.outcome, UndoOutcome::Failed { .. }));
+        assert!(store.copied.lock().expect("copied lock").is_empty());
+        assert!(store.removed.lock().expect("removed lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn overwrite_restore_reports_created_version() {
+        let store = FakeStore::with_listings(vec![
+            vec![
+                version("v2", "2026-07-23T02:00:00Z", true, false),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+            vec![
+                version("restored-v4", "2026-07-23T04:00:00Z", true, false),
+                version("v2", "2026-07-23T02:00:00Z", false, false),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+        ]);
+
+        let result = execute_plan_item(&store, "local", "bucket", restore_plan()).await;
+
+        assert!(matches!(
+            result.outcome,
+            UndoOutcome::VersionRestored {
+                created_version_id: Some(ref id)
+            } if id == "restored-v4"
+        ));
+        assert_eq!(
+            *store.copied.lock().expect("copied lock"),
+            ["v1".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn access_denial_is_preserved_as_per_object_failure() {
+        let store = FakeStore::with_listings(vec![vec![
+            version("v2", "2026-07-23T02:00:00Z", true, false),
+            version("v1", "2026-07-23T01:00:00Z", false, false),
+        ]]);
+        *store.fail_copy.lock().expect("failure lock") = true;
+
+        let result = execute_plan_item(&store, "local", "bucket", restore_plan()).await;
+
+        assert!(matches!(
+            result.outcome,
+            UndoOutcome::Failed { ref error_type, .. } if error_type == "auth_error"
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_marker_execution_removes_only_the_planned_marker() {
+        let store = FakeStore::with_listings(vec![
+            vec![
+                version("marker-v2", "2026-07-23T02:00:00Z", true, true),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+            vec![version("v1", "2026-07-23T01:00:00Z", true, false)],
+        ]);
+        let plan = UndoPlanItem {
+            key: "report.txt".to_string(),
+            expected_latest_version_id: "marker-v2".to_string(),
+            action: UndoAction::RemoveDeleteMarker {
+                marker_version_id: "marker-v2".to_string(),
+                revealed_version_id: "v1".to_string(),
+            },
+        };
+
+        let result = execute_plan_item(&store, "local", "bucket", plan).await;
+
+        assert!(matches!(result.outcome, UndoOutcome::DeleteMarkerRemoved));
+        assert_eq!(
+            *store.removed.lock().expect("removed lock"),
+            ["marker-v2".to_string()]
+        );
+        assert!(store.copied.lock().expect("copied lock").is_empty());
+    }
+
+    #[tokio::test]
+    async fn retrying_the_same_plan_after_success_does_not_copy_twice() {
+        let store = FakeStore::with_listings(vec![
+            vec![
+                version("v2", "2026-07-23T02:00:00Z", true, false),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+            vec![
+                version("restored-v4", "2026-07-23T04:00:00Z", true, false),
+                version("v2", "2026-07-23T02:00:00Z", false, false),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+            vec![
+                version("restored-v4", "2026-07-23T04:00:00Z", true, false),
+                version("v2", "2026-07-23T02:00:00Z", false, false),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+        ]);
+        let plan = restore_plan();
+
+        let first = execute_plan_item(&store, "local", "bucket", plan.clone()).await;
+        let retry = execute_plan_item(&store, "local", "bucket", plan).await;
+
+        assert!(matches!(first.outcome, UndoOutcome::VersionRestored { .. }));
+        assert!(matches!(
+            retry.outcome,
+            UndoOutcome::Failed { ref error_type, .. } if error_type == "conflict"
+        ));
+        assert_eq!(
+            *store.copied.lock().expect("copied lock"),
+            ["v1".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_version_after_mutation_fails_the_postcondition() {
+        let store = FakeStore::with_listings(vec![
+            vec![
+                version("v2", "2026-07-23T02:00:00Z", true, false),
+                version("v1", "2026-07-23T01:00:00Z", false, false),
+            ],
+            vec![
+                version("external-v5", "2026-07-23T05:00:00Z", true, false),
+                version("restored-v4", "2026-07-23T04:00:00Z", false, false),
+                version("v2", "2026-07-23T02:00:00Z", false, false),
+            ],
+        ]);
+
+        let result = execute_plan_item(&store, "local", "bucket", restore_plan()).await;
+
+        assert!(matches!(
+            result.outcome,
+            UndoOutcome::Failed { ref error_type, .. } if error_type == "conflict"
+        ));
+        assert_eq!(
+            *store.copied.lock().expect("copied lock"),
+            ["v1".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn suspended_and_unversioned_buckets_are_refused_before_listing() {
+        let args = UndoArgs {
+            path: "local/bucket/report.txt".to_string(),
+            version_id: None,
+            recursive: false,
+            dry_run: true,
+            concurrency: 1,
+        };
+        let path = RemotePath::new("local", "bucket", "report.txt");
+
+        for status in [Some(false), None] {
+            let store = Arc::new(FakeStore::default());
+            *store.versioning.lock().expect("versioning lock") = status;
+            let error = run_undo(store, &path, &args)
+                .await
+                .expect_err("unsafe bucket state must fail");
+            assert!(matches!(error, Error::UnsupportedFeature(_)));
+        }
+    }
+
+    #[tokio::test]
+    async fn recursive_dry_run_returns_the_complete_plan_without_mutations() {
+        let mut report_v2 = version("report-v2", "2026-07-23T02:00:00Z", true, false);
+        report_v2.key = "reports/report.txt".to_string();
+        let mut report_v1 = version("report-v1", "2026-07-23T01:00:00Z", false, false);
+        report_v1.key = "reports/report.txt".to_string();
+        let mut log_marker = version("log-marker", "2026-07-23T02:00:00Z", true, true);
+        log_marker.key = "reports/log.txt".to_string();
+        let mut log_v1 = version("log-v1", "2026-07-23T01:00:00Z", false, false);
+        log_v1.key = "reports/log.txt".to_string();
+        let store = Arc::new(FakeStore::with_listings(vec![vec![
+            report_v2, report_v1, log_marker, log_v1,
+        ]]));
+        let args = UndoArgs {
+            path: "local/bucket/reports/".to_string(),
+            version_id: None,
+            recursive: true,
+            dry_run: true,
+            concurrency: 2,
+        };
+        let path = RemotePath::new("local", "bucket", "reports/");
+
+        let report = run_undo(Arc::clone(&store), &path, &args)
+            .await
+            .expect("recursive dry-run");
+
+        assert_eq!(report.summary.planned, 2);
+        assert_eq!(report.summary.succeeded, 0);
+        assert_eq!(report.summary.failed, 0);
+        assert!(
+            report
+                .results
+                .iter()
+                .all(|result| matches!(result.outcome, UndoOutcome::Planned))
+        );
+        assert!(store.copied.lock().expect("copied lock").is_empty());
+        assert!(store.removed.lock().expect("removed lock").is_empty());
+    }
+
+    #[test]
+    fn partial_report_returns_the_failed_objects_exit_code() {
+        let success_plan = restore_plan();
+        let failed_plan = UndoPlanItem {
+            key: "private.txt".to_string(),
+            expected_latest_version_id: "private-v2".to_string(),
+            action: UndoAction::RestoreVersion {
+                source_version_id: "private-v1".to_string(),
+            },
+        };
+        let report = UndoCommandData {
+            operation: "undo",
+            outcome: "partial",
+            dry_run: false,
+            results: vec![
+                UndoObjectResult {
+                    key: success_plan.key.clone(),
+                    plan: Some(success_plan),
+                    outcome: UndoOutcome::VersionRestored {
+                        created_version_id: Some("restored-v4".to_string()),
+                    },
+                },
+                UndoObjectResult {
+                    key: failed_plan.key.clone(),
+                    plan: Some(failed_plan),
+                    outcome: UndoOutcome::Failed {
+                        error_type: "auth_error".to_string(),
+                        message: "copy denied".to_string(),
+                        blocked_version_id: None,
+                    },
+                },
+            ],
+            summary: UndoSummary {
+                planned: 2,
+                succeeded: 1,
+                failed: 1,
+            },
+        };
+
+        assert_eq!(report_exit_code(&report), ExitCode::AuthError);
+    }
+
+    #[test]
+    fn legal_hold_failures_are_conflicts_with_the_blocked_version() {
+        let plan = UndoPlanItem {
+            key: "report.txt".to_string(),
+            expected_latest_version_id: "marker-v2".to_string(),
+            action: UndoAction::RemoveDeleteMarker {
+                marker_version_id: "marker-v2".to_string(),
+                revealed_version_id: "v1".to_string(),
+            },
+        };
+        let result = failed_result(
+            plan,
+            &Error::Auth("Legal hold prevents version deletion".to_string()),
+        );
+
+        assert!(matches!(
+            result.outcome,
+            UndoOutcome::Failed {
+                ref error_type,
+                blocked_version_id: Some(ref version_id),
+                ref message,
+            } if error_type == "conflict"
+                && version_id == "marker-v2"
+                && message.contains("blocked version: marker-v2")
+        ));
+    }
+
+    #[test]
+    fn dry_run_text_identifies_action_and_both_version_roles() {
+        let restore = format_dry_run(&restore_plan());
+        assert!(restore.contains("Would restore report.txt from version 'v1'"));
+        assert!(restore.contains("expected current 'v2'"));
+
+        let marker = format_dry_run(&UndoPlanItem {
+            key: "report.txt".to_string(),
+            expected_latest_version_id: "marker-v2".to_string(),
+            action: UndoAction::RemoveDeleteMarker {
+                marker_version_id: "marker-v2".to_string(),
+                revealed_version_id: "v1".to_string(),
+            },
+        });
+        assert!(marker.contains("remove delete marker 'marker-v2'"));
+        assert!(marker.contains("reveals 'v1'"));
+    }
+
+    #[test]
+    fn command_errors_have_stable_usage_and_conflict_exit_codes() {
+        assert_eq!(
+            exit_code(&Error::InvalidPath("bad selector".to_string())),
+            ExitCode::UsageError
+        );
+        assert_eq!(
+            exit_code(&Error::Conflict("stale plan".to_string())),
+            ExitCode::Conflict
+        );
+    }
+
+    #[test]
+    fn selectors_and_concurrency_fail_with_usage_errors() {
+        let args = UndoArgs {
+            path: "local/bucket/report.txt".to_string(),
+            version_id: Some("v1".to_string()),
+            recursive: true,
+            dry_run: false,
+            concurrency: 4,
+        };
+        assert!(validate_args(&args).is_err());
+        assert!(
+            validate_args(&UndoArgs {
+                version_id: None,
+                recursive: false,
+                concurrency: 0,
+                ..args
+            })
+            .is_err()
+        );
+    }
+}

--- a/crates/cli/tests/undo_command.rs
+++ b/crates/cli/tests/undo_command.rs
@@ -1,0 +1,48 @@
+use clap::Parser;
+use rustfs_cli::commands::{Cli, Commands};
+
+#[test]
+fn undo_parses_safe_selection_and_execution_controls() {
+    let cli = Cli::try_parse_from([
+        "rc",
+        "undo",
+        "local/archive/reports/",
+        "--recursive",
+        "--dry-run",
+        "--concurrency",
+        "3",
+    ])
+    .expect("parse undo");
+
+    match cli.command {
+        Commands::Undo(args) => {
+            assert_eq!(args.path, "local/archive/reports/");
+            assert!(args.recursive);
+            assert!(args.dry_run);
+            assert_eq!(args.concurrency, 3);
+            assert!(args.version_id.is_none());
+        }
+        other => panic!("expected undo command, got {other:?}"),
+    }
+}
+
+#[test]
+fn undo_parses_explicit_version_for_one_object() {
+    let cli = Cli::try_parse_from([
+        "rc",
+        "undo",
+        "local/archive/report.txt",
+        "--version-id",
+        "v1",
+    ])
+    .expect("parse explicit undo version");
+
+    match cli.command {
+        Commands::Undo(args) => {
+            assert_eq!(args.version_id.as_deref(), Some("v1"));
+            assert!(!args.recursive);
+            assert!(!args.dry_run);
+        }
+        other => panic!("expected undo command, got {other:?}"),
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -24,6 +24,7 @@ pub mod retry;
 pub mod select;
 pub mod traits;
 pub mod transfer;
+pub mod undo;
 pub mod watch;
 
 pub use alias::{
@@ -60,7 +61,7 @@ pub use select::{
     SelectSseCustomerOptions,
 };
 pub use traits::{
-    BucketNotification, Capabilities, CreateBucketOptions, DeleteObjectFailure,
+    BucketNotification, Capabilities, CopyObjectOptions, CreateBucketOptions, DeleteObjectFailure,
     DeleteObjectsResult, DeleteRequestOptions, DeletedObject, ListObjectVersionsOptions,
     ListOptions, ListResult, NotificationTarget, ObjectInfo, ObjectReadOptions, ObjectStore,
     ObjectVersion, ObjectVersionIdentifier, ObjectVersionListResult,
@@ -68,5 +69,8 @@ pub use traits::{
 pub use transfer::{
     TransferCandidate, TransferControls, TransferExecutor, TransferOutcome, TransferOutcomeState,
     TransferPlan, TransferReport, TransferSelection, TransferSummary,
+};
+pub use undo::{
+    UndoAction, UndoObjectResult, UndoOutcome, UndoPlan, UndoPlanItem, plan_object_undo,
 };
 pub use watch::{WatchApi, WatchEvent, WatchFrame, WatchRequest, WatchSource, WatchStream};

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -124,6 +124,25 @@ pub struct ObjectReadOptions {
     pub version_id: Option<String>,
 }
 
+/// Request options for a server-side object copy.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CopyObjectOptions {
+    /// Exact historical source version to copy. `None` selects the current source.
+    pub source_version_id: Option<String>,
+}
+
+impl CopyObjectOptions {
+    /// Build copy options while rejecting an ambiguous empty source version identifier.
+    pub fn for_source_version(source_version_id: Option<String>) -> Result<Self> {
+        if source_version_id.as_deref().is_some_and(str::is_empty) {
+            return Err(Error::InvalidPath(
+                "Source version ID cannot be empty".to_string(),
+            ));
+        }
+        Ok(Self { source_version_id })
+    }
+}
+
 impl ObjectReadOptions {
     /// Build read options while rejecting ambiguous empty version identifiers.
     pub fn for_version(version_id: Option<String>) -> Result<Self> {
@@ -566,6 +585,23 @@ pub trait ObjectStore: Send + Sync {
         dst: &RemotePath,
         encryption: Option<&ObjectEncryptionRequest>,
     ) -> Result<ObjectInfo>;
+
+    /// Copy the current object or one exact historical source version.
+    async fn copy_object_with_options(
+        &self,
+        src: &RemotePath,
+        dst: &RemotePath,
+        options: &CopyObjectOptions,
+        encryption: Option<&ObjectEncryptionRequest>,
+    ) -> Result<ObjectInfo> {
+        if options.source_version_id.is_some() {
+            return Err(Error::UnsupportedFeature(
+                "Exact-version server-side copy is not implemented by this object store"
+                    .to_string(),
+            ));
+        }
+        self.copy_object(src, dst, encryption).await
+    }
 
     /// Generate a presigned URL for an object
     async fn presign_get(&self, path: &RemotePath, expires_secs: u64) -> Result<String>;

--- a/crates/core/src/undo.rs
+++ b/crates/core/src/undo.rs
@@ -1,0 +1,239 @@
+//! Pure planning models for safe undo of versioned object operations.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, ObjectVersion, Result};
+
+/// A history-preserving mutation selected by the undo planner.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum UndoAction {
+    /// Remove the current delete marker so the prior data version becomes visible.
+    RemoveDeleteMarker {
+        /// Exact marker version that may be removed.
+        marker_version_id: String,
+        /// Data version expected to become current after marker removal.
+        revealed_version_id: String,
+    },
+    /// Copy an existing data version onto the same key as a new version.
+    RestoreVersion {
+        /// Exact historical data version to copy.
+        source_version_id: String,
+    },
+}
+
+/// One object mutation together with the current-version precondition observed during planning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UndoPlanItem {
+    /// Object key within the bucket.
+    pub key: String,
+    /// Version that must still be current immediately before execution.
+    pub expected_latest_version_id: String,
+    /// History-preserving action to perform.
+    pub action: UndoAction,
+}
+
+/// Deterministic collection of object undo actions.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UndoPlan {
+    /// Planned actions, ordered by object key.
+    pub items: Vec<UndoPlanItem>,
+}
+
+impl UndoPlan {
+    /// Build a deterministic plan from independently planned objects.
+    pub fn new(mut items: Vec<UndoPlanItem>) -> Self {
+        items.sort_by(|left, right| left.key.cmp(&right.key));
+        Self { items }
+    }
+}
+
+/// Result state for one planned object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum UndoOutcome {
+    /// The action was selected but not executed.
+    Planned,
+    /// The exact delete marker was removed.
+    DeleteMarkerRemoved,
+    /// A historical data version was copied into a new current version.
+    VersionRestored {
+        /// Destination version created by the copy, when reported by the backend.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        created_version_id: Option<String>,
+    },
+    /// Execution was refused or failed.
+    Failed {
+        /// Stable error category suitable for structured output.
+        error_type: String,
+        /// Human-readable failure detail.
+        message: String,
+        /// Exact version blocked by Object Lock or retention policy, when known.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        blocked_version_id: Option<String>,
+    },
+}
+
+/// Per-object result that retains the exact plan used for execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UndoObjectResult {
+    /// Object key represented by this result.
+    pub key: String,
+    /// Planned action and expected-current precondition, when planning succeeded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan: Option<UndoPlanItem>,
+    /// Planning or execution result.
+    pub outcome: UndoOutcome,
+}
+
+/// Plan a safe undo for one key from its complete, newest-first version history.
+///
+/// Without an explicit version, only a latest delete marker over a data version or a latest data
+/// version immediately preceded by another data version is reversible. An explicit data version
+/// selects that historical version for restoration. An explicit delete marker must be current.
+pub fn plan_object_undo(
+    key: &str,
+    history: &[ObjectVersion],
+    explicit_version_id: Option<&str>,
+) -> Result<UndoPlanItem> {
+    if key.is_empty() {
+        return Err(Error::InvalidPath(
+            "Undo object key cannot be empty".to_string(),
+        ));
+    }
+    if explicit_version_id.is_some_and(str::is_empty) {
+        return Err(Error::InvalidPath(
+            "Undo version ID cannot be empty".to_string(),
+        ));
+    }
+
+    let mut versions = history
+        .iter()
+        .filter(|version| version.key == key)
+        .collect::<Vec<_>>();
+    if versions.is_empty() {
+        return Err(Error::NotFound(format!(
+            "No object version history found for {key}"
+        )));
+    }
+
+    let latest = exactly_one_latest(key, &versions)?.clone();
+
+    if let Some(version_id) = explicit_version_id {
+        let selected = versions
+            .iter()
+            .copied()
+            .find(|version| version.version_id == version_id)
+            .ok_or_else(|| Error::VersionNotFound {
+                path: key.to_string(),
+                version_id: version_id.to_string(),
+            })?;
+
+        if !selected.is_delete_marker {
+            if selected.is_latest {
+                return Err(Error::Conflict(format!(
+                    "Version '{version_id}' is already current for {key}"
+                )));
+            }
+            return Ok(UndoPlanItem {
+                key: key.to_string(),
+                expected_latest_version_id: latest.version_id.clone(),
+                action: UndoAction::RestoreVersion {
+                    source_version_id: version_id.to_string(),
+                },
+            });
+        }
+        if !selected.is_latest {
+            return Err(Error::Conflict(format!(
+                "Delete marker '{version_id}' is not current for {key}"
+            )));
+        }
+    }
+
+    versions.sort_by_key(|version| std::cmp::Reverse(version.last_modified));
+    ensure_unambiguous_order(key, &versions)?;
+    let current_index = versions
+        .iter()
+        .position(|version| version.is_latest)
+        .ok_or_else(|| Error::Conflict(format!("No current version found for {key}")))?;
+    if current_index != 0 {
+        return Err(Error::Conflict(format!(
+            "Version history ordering disagrees with the current version for {key}"
+        )));
+    }
+    let previous = versions.get(1).copied().ok_or_else(|| {
+        Error::Conflict(format!(
+            "Current version has no reversible predecessor for {key}"
+        ))
+    })?;
+
+    let action = if latest.is_delete_marker {
+        if previous.is_delete_marker {
+            return Err(Error::Conflict(format!(
+                "Current delete marker is preceded by another delete marker for {key}"
+            )));
+        }
+        UndoAction::RemoveDeleteMarker {
+            marker_version_id: latest.version_id.clone(),
+            revealed_version_id: previous.version_id.clone(),
+        }
+    } else {
+        if previous.is_delete_marker {
+            return Err(Error::Conflict(format!(
+                "Current data version is preceded by a delete marker for {key}"
+            )));
+        }
+        UndoAction::RestoreVersion {
+            source_version_id: previous.version_id.clone(),
+        }
+    };
+
+    Ok(UndoPlanItem {
+        key: key.to_string(),
+        expected_latest_version_id: latest.version_id.clone(),
+        action,
+    })
+}
+
+fn exactly_one_latest<'a>(key: &str, versions: &'a [&ObjectVersion]) -> Result<&'a ObjectVersion> {
+    let mut latest = versions.iter().copied().filter(|version| version.is_latest);
+    let selected = latest
+        .next()
+        .ok_or_else(|| Error::Conflict(format!("No current version found for {key}")))?;
+    if latest.next().is_some() {
+        return Err(Error::Conflict(format!(
+            "Multiple current versions were reported for {key}"
+        )));
+    }
+    Ok(selected)
+}
+
+fn ensure_unambiguous_order(key: &str, versions: &[&ObjectVersion]) -> Result<()> {
+    let current = versions
+        .first()
+        .and_then(|version| version.last_modified)
+        .ok_or_else(|| {
+            Error::Conflict(format!(
+                "Version history is missing modification time for {key}"
+            ))
+        })?;
+    let previous = versions
+        .get(1)
+        .and_then(|version| version.last_modified)
+        .ok_or_else(|| {
+            Error::Conflict(format!(
+                "Version history is missing a predecessor time for {key}"
+            ))
+        })?;
+    if current == previous
+        || versions
+            .get(2)
+            .and_then(|version| version.last_modified)
+            .is_some_and(|next| next == previous)
+    {
+        return Err(Error::Conflict(format!(
+            "Version history ordering is ambiguous for {key}"
+        )));
+    }
+    Ok(())
+}

--- a/crates/core/tests/undo_planner.rs
+++ b/crates/core/tests/undo_planner.rs
@@ -1,0 +1,185 @@
+use jiff::Timestamp;
+use rc_core::{CopyObjectOptions, ObjectVersion, UndoAction, plan_object_undo};
+
+fn version(
+    key: &str,
+    version_id: &str,
+    modified: &str,
+    is_latest: bool,
+    is_delete_marker: bool,
+) -> ObjectVersion {
+    ObjectVersion {
+        key: key.to_string(),
+        version_id: version_id.to_string(),
+        is_latest,
+        is_delete_marker,
+        last_modified: Some(modified.parse::<Timestamp>().expect("valid timestamp")),
+        size_bytes: (!is_delete_marker).then_some(12),
+        etag: (!is_delete_marker).then(|| format!("etag-{version_id}")),
+    }
+}
+
+#[test]
+fn latest_delete_marker_plans_exact_marker_removal() {
+    let history = vec![
+        version(
+            "report.txt",
+            "marker-v3",
+            "2026-07-23T03:00:00Z",
+            true,
+            true,
+        ),
+        version(
+            "report.txt",
+            "data-v2",
+            "2026-07-23T02:00:00Z",
+            false,
+            false,
+        ),
+    ];
+
+    let plan = plan_object_undo("report.txt", &history, None).expect("reversible delete");
+
+    assert_eq!(plan.expected_latest_version_id, "marker-v3");
+    assert_eq!(
+        plan.action,
+        UndoAction::RemoveDeleteMarker {
+            marker_version_id: "marker-v3".to_string(),
+            revealed_version_id: "data-v2".to_string(),
+        }
+    );
+}
+
+#[test]
+fn latest_overwrite_plans_previous_data_version_restore() {
+    let history = vec![
+        version("report.txt", "data-v3", "2026-07-23T03:00:00Z", true, false),
+        version(
+            "report.txt",
+            "data-v2",
+            "2026-07-23T02:00:00Z",
+            false,
+            false,
+        ),
+        version(
+            "report.txt",
+            "data-v1",
+            "2026-07-23T01:00:00Z",
+            false,
+            false,
+        ),
+    ];
+
+    let plan = plan_object_undo("report.txt", &history, None).expect("reversible overwrite");
+
+    assert_eq!(plan.expected_latest_version_id, "data-v3");
+    assert_eq!(
+        plan.action,
+        UndoAction::RestoreVersion {
+            source_version_id: "data-v2".to_string(),
+        }
+    );
+}
+
+#[test]
+fn explicit_historical_data_version_is_restored() {
+    let history = vec![
+        version("report.txt", "data-v3", "2026-07-23T03:00:00Z", true, false),
+        version(
+            "report.txt",
+            "data-v2",
+            "2026-07-23T02:00:00Z",
+            false,
+            false,
+        ),
+        version(
+            "report.txt",
+            "data-v1",
+            "2026-07-23T01:00:00Z",
+            false,
+            false,
+        ),
+    ];
+
+    let plan = plan_object_undo("report.txt", &history, Some("data-v1")).expect("explicit restore");
+
+    assert_eq!(
+        plan.action,
+        UndoAction::RestoreVersion {
+            source_version_id: "data-v1".to_string(),
+        }
+    );
+}
+
+#[test]
+fn missing_or_ambiguous_history_is_rejected() {
+    let first_put = vec![version(
+        "report.txt",
+        "data-v1",
+        "2026-07-23T01:00:00Z",
+        true,
+        false,
+    )];
+    assert!(plan_object_undo("report.txt", &first_put, None).is_err());
+
+    let two_latest = vec![
+        version("report.txt", "data-v2", "2026-07-23T02:00:00Z", true, false),
+        version("report.txt", "data-v1", "2026-07-23T01:00:00Z", true, false),
+    ];
+    assert!(plan_object_undo("report.txt", &two_latest, None).is_err());
+
+    let tied_predecessors = vec![
+        version("report.txt", "data-v3", "2026-07-23T03:00:00Z", true, false),
+        version(
+            "report.txt",
+            "data-v2a",
+            "2026-07-23T02:00:00Z",
+            false,
+            false,
+        ),
+        version(
+            "report.txt",
+            "data-v2b",
+            "2026-07-23T02:00:00Z",
+            false,
+            false,
+        ),
+    ];
+    assert!(plan_object_undo("report.txt", &tied_predecessors, None).is_err());
+}
+
+#[test]
+fn overwrite_after_delete_marker_is_refused_instead_of_guessing() {
+    let history = vec![
+        version("report.txt", "data-v3", "2026-07-23T03:00:00Z", true, false),
+        version(
+            "report.txt",
+            "marker-v2",
+            "2026-07-23T02:00:00Z",
+            false,
+            true,
+        ),
+        version(
+            "report.txt",
+            "data-v1",
+            "2026-07-23T01:00:00Z",
+            false,
+            false,
+        ),
+    ];
+
+    let error = plan_object_undo("report.txt", &history, None).expect_err("ambiguous undo");
+    assert!(error.to_string().contains("delete marker"));
+}
+
+#[test]
+fn copy_options_reject_empty_source_version_ids() {
+    assert!(CopyObjectOptions::for_source_version(Some(String::new())).is_err());
+    assert_eq!(
+        CopyObjectOptions::for_source_version(Some("data-v1".to_string()))
+            .expect("valid source version")
+            .source_version_id
+            .as_deref(),
+        Some("data-v1")
+    );
+}

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -31,14 +31,15 @@ pub use rc_core::DeleteRequestOptions;
 use rc_core::admin::KmsDiagnosticStore;
 use rc_core::{
     Alias, BucketEncryption, BucketNotification, BucketObjectLockConfiguration, Capabilities,
-    CorsRule, CreateBucketOptions, DefaultRetention, DeleteObjectFailure, DeleteObjectsResult,
-    DeletedObject, Error, LegalHoldStatus, LifecycleRule, ListObjectVersionsOptions, ListOptions,
-    ListResult, NotificationTarget, ObjectEncryptionRequest, ObjectInfo, ObjectLockOptions,
-    ObjectReadOptions, ObjectRetention, ObjectStore, ObjectVersion, ObjectVersionIdentifier,
-    ObjectVersionListResult, RemotePath, ReplicationConfiguration, ReplicationResyncStartOptions,
-    ReplicationResyncStartResult, ReplicationResyncState, ReplicationResyncStatus,
-    ReplicationResyncTargetStatus, RequestHeader, Result, RetentionDuration, RetentionDurationUnit,
-    RetentionMode, SelectOptions, global_request_headers,
+    CopyObjectOptions, CorsRule, CreateBucketOptions, DefaultRetention, DeleteObjectFailure,
+    DeleteObjectsResult, DeletedObject, Error, LegalHoldStatus, LifecycleRule,
+    ListObjectVersionsOptions, ListOptions, ListResult, NotificationTarget,
+    ObjectEncryptionRequest, ObjectInfo, ObjectLockOptions, ObjectReadOptions, ObjectRetention,
+    ObjectStore, ObjectVersion, ObjectVersionIdentifier, ObjectVersionListResult, RemotePath,
+    ReplicationConfiguration, ReplicationResyncStartOptions, ReplicationResyncStartResult,
+    ReplicationResyncState, ReplicationResyncStatus, ReplicationResyncTargetStatus, RequestHeader,
+    Result, RetentionDuration, RetentionDurationUnit, RetentionMode, SelectOptions,
+    global_request_headers,
 };
 use reqwest::Method;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
@@ -595,6 +596,23 @@ fn apply_object_encryption_to_copy_request(
             .ssekms_key_id(key_id),
         None => request,
     }
+}
+
+fn encoded_copy_source(src: &RemotePath, source_version_id: Option<&str>) -> String {
+    let encoded_key = src
+        .key
+        .split('/')
+        .map(|segment| urlencoding::encode(segment).into_owned())
+        .collect::<Vec<_>>()
+        .join("/");
+    let mut copy_source = format!("{}/{encoded_key}", urlencoding::encode(&src.bucket));
+
+    if let Some(version_id) = source_version_id {
+        copy_source.push_str("?versionId=");
+        copy_source.push_str(&urlencoding::encode(version_id));
+    }
+
+    copy_source
 }
 
 fn sdk_retention_mode(mode: RetentionMode) -> aws_sdk_s3::types::ObjectLockRetentionMode {
@@ -1291,7 +1309,7 @@ impl S3Client {
                 is_delete_marker: false,
                 last_modified: v
                     .last_modified()
-                    .and_then(|dt| Timestamp::from_second(dt.secs()).ok()),
+                    .and_then(|timestamp| core_timestamp(timestamp).ok()),
                 size_bytes: v.size(),
                 etag: v.e_tag().map(|s| s.trim_matches('"').to_string()),
             });
@@ -1305,7 +1323,7 @@ impl S3Client {
                 is_delete_marker: true,
                 last_modified: m
                     .last_modified()
-                    .and_then(|dt| Timestamp::from_second(dt.secs()).ok()),
+                    .and_then(|timestamp| core_timestamp(timestamp).ok()),
                 size_bytes: None,
                 etag: None,
             });
@@ -3576,9 +3594,18 @@ impl ObjectStore for S3Client {
         dst: &RemotePath,
         encryption: Option<&ObjectEncryptionRequest>,
     ) -> Result<ObjectInfo> {
-        // Build copy source: bucket/key
-        let copy_source = format!("{}/{}", src.bucket, src.key);
+        self.copy_object_with_options(src, dst, &CopyObjectOptions::default(), encryption)
+            .await
+    }
 
+    async fn copy_object_with_options(
+        &self,
+        src: &RemotePath,
+        dst: &RemotePath,
+        options: &CopyObjectOptions,
+        encryption: Option<&ObjectEncryptionRequest>,
+    ) -> Result<ObjectInfo> {
+        let copy_source = encoded_copy_source(src, options.source_version_id.as_deref());
         let response = apply_object_encryption_to_copy_request(
             self.inner
                 .copy_object()
@@ -3589,13 +3616,8 @@ impl ObjectStore for S3Client {
         )
         .send()
         .await
-        .map_err(|e| {
-            let err_str = e.to_string();
-            if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
-                Error::NotFound(src.to_string())
-            } else {
-                Error::Network(err_str)
-            }
+        .map_err(|error| {
+            Self::map_object_request_error(&error, src, options.source_version_id.as_deref())
         })?;
 
         // Get size from head_object since copy doesn't return it
@@ -7308,6 +7330,131 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn copy_object_url_encodes_source_path() {
+        let response = http::Response::builder()
+            .status(500)
+            .header("x-amz-error-code", "InternalError")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>Something went wrong.</Message>
+</Error>"#,
+            ))
+            .expect("build copy object response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+        let src = RemotePath::new("test", "source-bucket", "dir one/a+b?#.txt");
+        let dst = RemotePath::new("test", "destination-bucket", "dst.txt");
+
+        let _ = client.copy_object(&src, &dst, None).await;
+
+        let request = request_receiver.expect_request();
+        assert_eq!(
+            request.headers().get("x-amz-copy-source"),
+            Some("source-bucket/dir%20one/a%2Bb%3F%23.txt")
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_object_with_options_selects_url_encoded_source_version() {
+        let response = http::Response::builder()
+            .status(500)
+            .header("x-amz-error-code", "InternalError")
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+  <Code>InternalError</Code>
+  <Message>Something went wrong.</Message>
+</Error>"#,
+            ))
+            .expect("build copy object response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+        let src = RemotePath::new("test", "source-bucket", "dir one/a+b?#.txt");
+        let dst = RemotePath::new("test", "destination-bucket", "dst.txt");
+        let options = CopyObjectOptions::for_source_version(Some("v 1+/=?#%".to_string()))
+            .expect("valid source version ID");
+
+        let _ = client
+            .copy_object_with_options(&src, &dst, &options, None)
+            .await;
+
+        let request = request_receiver.expect_request();
+        assert_eq!(
+            request.headers().get("x-amz-copy-source"),
+            Some("source-bucket/dir%20one/a%2Bb%3F%23.txt?versionId=v%201%2B%2F%3D%3F%23%25")
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_object_with_options_preserves_source_and_destination_versions() {
+        let copy_response = http::Response::builder()
+            .status(200)
+            .header("content-type", "application/xml")
+            .header("x-amz-version-id", "destination-v3")
+            .header("x-amz-copy-source-version-id", "source-v1")
+            .body(SdkBody::from(
+                r#"<CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><ETag>"copied-etag"</ETag><LastModified>2026-07-23T00:00:00Z</LastModified></CopyObjectResult>"#,
+            ))
+            .expect("build copy object response");
+        let head_response = http::Response::builder()
+            .status(200)
+            .header("content-length", "7")
+            .header("etag", "\"copied-etag\"")
+            .header("x-amz-version-id", "destination-v3")
+            .body(SdkBody::empty())
+            .expect("build head object response");
+        let (client, replay) =
+            test_s3_client_with_response_sequence(vec![copy_response, head_response]);
+        let src = RemotePath::new("test", "source-bucket", "src.txt");
+        let dst = RemotePath::new("test", "destination-bucket", "dst.txt");
+        let options = CopyObjectOptions::for_source_version(Some("source-v1".to_string()))
+            .expect("valid source version ID");
+
+        let result = client
+            .copy_object_with_options(&src, &dst, &options, None)
+            .await
+            .expect("copy exact source version");
+
+        assert_eq!(result.version_id.as_deref(), Some("destination-v3"));
+        assert_eq!(result.source_version_id.as_deref(), Some("source-v1"));
+        assert_eq!(result.etag.as_deref(), Some("copied-etag"));
+        let requests = replay.actual_requests().collect::<Vec<_>>();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].headers().get("x-amz-copy-source"),
+            Some("source-bucket/src.txt?versionId=source-v1")
+        );
+    }
+
+    #[tokio::test]
+    async fn copy_object_with_options_maps_missing_source_version() {
+        let response = http::Response::builder()
+            .status(404)
+            .header("x-amz-error-code", "NoSuchVersion")
+            .body(SdkBody::from(
+                "<Error><Code>NoSuchVersion</Code><Message>missing</Message></Error>",
+            ))
+            .expect("build missing source version response");
+        let (client, _) = test_s3_client(Some(response));
+        let src = RemotePath::new("test", "source-bucket", "src.txt");
+        let dst = RemotePath::new("test", "destination-bucket", "dst.txt");
+        let options = CopyObjectOptions::for_source_version(Some("missing-v1".to_string()))
+            .expect("valid source version ID");
+
+        let result = client
+            .copy_object_with_options(&src, &dst, &options, None)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(Error::VersionNotFound {
+                version_id,
+                ..
+            }) if version_id == "missing-v1"
+        ));
+    }
+
+    #[tokio::test]
     async fn delete_object_wrapper_uses_default_options_without_rustfs_header() {
         let (client, request_receiver) = test_s3_client(None);
         let path = RemotePath::new("test", "bucket", "key.txt");
@@ -7453,6 +7600,57 @@ mod tests {
         assert!(delete_marker.is_delete_marker);
         assert_eq!(delete_marker.size_bytes, None);
         assert_eq!(delete_marker.etag, None);
+    }
+
+    #[tokio::test]
+    async fn list_object_versions_orders_same_second_entries_by_nanoseconds() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>bucket</Name>
+  <Prefix>logs/a.txt</Prefix>
+  <MaxKeys>25</MaxKeys>
+  <IsTruncated>false</IsTruncated>
+  <Version>
+    <Key>logs/a.txt</Key>
+    <VersionId>data-v1</VersionId>
+    <IsLatest>false</IsLatest>
+    <LastModified>2026-07-23T03:00:00.100Z</LastModified>
+    <ETag>"etag-a"</ETag>
+    <Size>12</Size>
+    <StorageClass>STANDARD</StorageClass>
+  </Version>
+  <DeleteMarker>
+    <Key>logs/a.txt</Key>
+    <VersionId>marker-v2</VersionId>
+    <IsLatest>true</IsLatest>
+    <LastModified>2026-07-23T03:00:00.900Z</LastModified>
+  </DeleteMarker>
+</ListVersionsResult>"#,
+            ))
+            .expect("build list object versions response");
+        let (client, _) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "bucket", "logs/a.txt");
+
+        let result = client
+            .list_object_versions_page(&path, Some(25))
+            .await
+            .expect("list object versions page");
+
+        assert_eq!(
+            result
+                .items
+                .iter()
+                .map(|version| version.version_id.as_str())
+                .collect::<Vec<_>>(),
+            ["marker-v2", "data-v1"]
+        );
+        assert!(
+            result.items[0].last_modified > result.items[1].last_modified,
+            "nanosecond precision must be preserved for safe undo ordering"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related issue

Closes rustfs/backlog#1369.

Server-side atomic destination preconditions remain tracked by rustfs/backlog#1438.

## Background and impact

RustFS supports object version history, exact delete-marker deletion, and copying a historical source version, but `rc` did not provide a safe workflow for recovering from an accidental versioned PUT or DELETE. Operators had to compose low-level requests manually and could easily delete the wrong marker, overwrite a concurrent update, or lose per-object failure context.

## Root cause

The core object-store abstraction exposed version listing and version-aware deletion but did not expose an exact historical source version for `CopyObject`. There was also no deterministic undo planner or command-level current-version validation.

## Solution

- Add `CopyObjectOptions` and a backward-compatible exact-source-version copy abstraction.
- Encode CopySource keys and version IDs correctly in the S3 adapter and preserve returned source/destination version metadata.
- Preserve nanosecond precision when combining data versions and delete markers.
- Add a pure planner for reversible latest operations and explicit historical versions.
- Add `rc undo` with single-object and recursive prefix modes, dry run, explicit version selection, and bounded concurrency.
- Require bucket versioning to be enabled; refuse suspended, unversioned, missing, or ambiguous histories.
- Build the complete plan before mutation, revalidate the current version immediately before each action, and verify the resulting current version afterward.
- Preserve object history: delete undo removes only the exact current marker; overwrite undo creates a new version by self-copying the selected historical version.
- Emit per-object v3 plan/results, stable partial-failure exit codes, and blocked version IDs for Object Lock, retention, and legal-hold failures.

## Concurrency boundary

The current S3/RustFS contract has no destination-current compare-and-swap for `CopyObject` or version-specific `DeleteObject`. The preflight and postcondition checks detect observed concurrent changes and report a conflict, but the mutation itself is not atomic and a conflict detected afterward cannot be rolled back. This PR therefore does not claim transactional or exactly-once semantics. The server prerequisite is rustfs/backlog#1438.

## Validation

- `cargo fmt --all --check`
- `CARGO_BUILD_JOBS=2 cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test --workspace`
- `git diff --check`

Tests cover delete-marker restoration, overwrite restoration, explicit versions, dry run, recursive planning, bounded execution, missing and ambiguous history, suspended and unversioned buckets, stale plans before mutation, concurrent changes after mutation, plan-level retry, partial failure, access denial, legal hold, stable exit codes, pagination markers, nanosecond version ordering, CopySource encoding, and missing historical source versions.
