### PR TITLE
feat(copy): add recursive same-endpoint remote copy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,6 +112,7 @@ jobs:
           if [[ "${{ matrix.version }}" == "1.0.0-beta.10" ]]; then
             TESTS+=(
               "multipart_operations::test_multipart_server_side_copy_direct_primitive"
+              "recursive_operations::test_recursive_copy"
             )
           fi
 

--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -6,15 +6,17 @@ use clap::Args;
 use jiff::Timestamp;
 use rc_core::alias::RetryConfig;
 use rc_core::{
-    AliasManager, Error, ObjectEncryptionRequest, ObjectStore as _, ParsedPath, RemotePath,
-    TransferCandidate, TransferControls, TransferExecutor, TransferOutcomeState, TransferPlan,
-    TransferSelection, parse_path,
+    AliasManager, CopyObjectOptions, Error, MultipartCopyCancellation, MultipartCopyOptions,
+    ObjectEncryptionRequest, ObjectInfo, ObjectStore as _, ParsedPath, RemotePath,
+    TransferCancellation, TransferCandidate, TransferControls, TransferExecutor,
+    TransferOutcomeState, TransferPlan, TransferSelection, parse_path,
 };
 use rc_s3::S3Client;
 use serde::Serialize;
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::exit_code::ExitCode;
 use crate::output::{Formatter, OutputConfig, ProgressBar, V3SuccessEnvelope};
@@ -31,7 +33,8 @@ const DEFAULT_TRANSFER_CONCURRENCY: usize = 4;
 const DEFAULT_RETRY_ATTEMPTS: u32 = 3;
 const DEFAULT_RETRY_INITIAL_BACKOFF_MS: u64 = 100;
 const DEFAULT_RETRY_MAX_BACKOFF_MS: u64 = 10_000;
-const MAX_SINGLE_COPY_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+#[cfg(test)]
+const MAX_SINGLE_COPY_SIZE: u64 = rc_core::S3_SINGLE_COPY_MAX_SIZE;
 
 /// Copy objects
 #[derive(Args, Clone, Debug)]
@@ -57,8 +60,18 @@ pub struct CpArgs {
     pub continue_on_error: bool,
 
     /// Overwrite destination if it exists
-    #[arg(long, default_value = "true")]
+    #[arg(
+        long,
+        default_value_t = true,
+        action = clap::ArgAction::Set,
+        num_args = 0..=1,
+        default_missing_value = "true"
+    )]
     pub overwrite: bool,
+
+    /// Skip remote destinations that already exist
+    #[arg(long)]
+    pub skip_existing: bool,
 
     /// Only show what would be copied (dry run)
     #[arg(long)]
@@ -138,6 +151,7 @@ impl CpArgs {
             preserve: false,
             continue_on_error: false,
             overwrite: true,
+            skip_existing: false,
             dry_run: false,
             storage_class: None,
             content_type: None,
@@ -305,6 +319,8 @@ pub async fn execute(args: CpArgs, output_config: OutputConfig) -> ExitCode {
 fn uses_transfer_planner(args: &CpArgs) -> bool {
     args.sources.len() > 1
         || args.recursive
+        || args.skip_existing
+        || !args.overwrite
         || !args.include.is_empty()
         || !args.exclude.is_empty()
         || args.newer_than.is_some()
@@ -365,9 +381,58 @@ enum CpOperation {
     RemoteToRemote {
         source: RemotePath,
         target: RemotePath,
+        source_info: Box<ObjectInfo>,
         encryption: Option<ObjectEncryptionRequest>,
     },
 }
+
+#[derive(Debug, Clone)]
+struct PlannedCopyDetail {
+    source_version_id: Option<String>,
+    destination_version_id: Option<String>,
+    upload_id: Option<String>,
+}
+
+type PlannedCopyDetails = Arc<AsyncMutex<HashMap<(String, String), PlannedCopyDetail>>>;
+
+#[derive(Debug)]
+struct PlannedCopyProgress {
+    positions: StdMutex<HashMap<(String, String), u64>>,
+    bar: Option<ProgressBar>,
+}
+
+impl PlannedCopyProgress {
+    fn new(output_config: OutputConfig, total: u64) -> Self {
+        Self {
+            positions: StdMutex::new(HashMap::new()),
+            bar: (total > 0).then(|| ProgressBar::new(output_config, total)),
+        }
+    }
+
+    fn reset(&self, key: &(String, String)) {
+        self.set(key, 0);
+    }
+
+    fn set(&self, key: &(String, String), bytes: u64) {
+        let mut positions = self
+            .positions
+            .lock()
+            .expect("planned copy progress lock should not be poisoned");
+        positions.insert(key.clone(), bytes);
+        let aggregate = positions.values().copied().fold(0_u64, u64::saturating_add);
+        if let Some(bar) = &self.bar {
+            bar.set_position(aggregate);
+        }
+    }
+
+    fn finish(&self) {
+        if let Some(bar) = &self.bar {
+            bar.finish_and_clear();
+        }
+    }
+}
+
+type SharedPlannedCopyProgress = Arc<PlannedCopyProgress>;
 
 #[allow(clippy::too_many_arguments)]
 async fn execute_transfer_plan(
@@ -400,7 +465,7 @@ async fn execute_transfer_plan(
         }
     };
 
-    let plan = TransferPlan::build(candidates, &selection);
+    let mut plan = TransferPlan::build(candidates, &selection);
     if let Err(error) = validate_plan_targets(&plan) {
         return formatter.fail(ExitCode::UsageError, &error.to_string());
     }
@@ -417,20 +482,6 @@ async fn execute_transfer_plan(
         return ExitCode::Success;
     }
 
-    if args.dry_run {
-        for item in &plan.items {
-            formatter.println(&format!(
-                "Would copy: {} -> {}",
-                formatter.style_file(&item.source),
-                formatter.style_file(&item.target)
-            ));
-        }
-        if args.summary || args.recursive || args.sources.len() > 1 {
-            print_transfer_summary(formatter, &plan.summary);
-        }
-        return ExitCode::Success;
-    }
-
     let clients = match create_planned_client_cache(&plan.items, alias_manager).await {
         Ok(clients) => Arc::new(clients),
         Err(error) => {
@@ -440,6 +491,58 @@ async fn execute_transfer_plan(
             );
         }
     };
+    let skipped_existing = if args.skip_existing || !args.overwrite {
+        match skip_existing_remote_targets(&mut plan, &clients).await {
+            Ok(skipped) => skipped,
+            Err(error) => {
+                return formatter.fail(
+                    exit_code_for_core_error(&error),
+                    &format!("Failed to inspect copy destinations: {error}"),
+                );
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    if args.dry_run {
+        for item in &plan.items {
+            formatter.println(&format!(
+                "Would copy: {} -> {}",
+                formatter.style_file(&item.source),
+                formatter.style_file(&item.target)
+            ));
+        }
+        for item in &skipped_existing {
+            print_skipped_existing(formatter, item, true);
+        }
+        if args.summary || args.recursive || args.sources.len() > 1 {
+            print_transfer_summary(formatter, &plan.summary);
+        }
+        return ExitCode::Success;
+    }
+
+    for item in &skipped_existing {
+        print_skipped_existing(formatter, item, false);
+    }
+    if plan.items.is_empty() {
+        if args.summary || args.recursive || args.sources.len() > 1 {
+            print_transfer_summary(formatter, &plan.summary);
+        }
+        return ExitCode::Success;
+    }
+
+    let total_bytes = plan
+        .items
+        .iter()
+        .filter_map(|item| {
+            if matches!(item.payload, CpOperation::RemoteToRemote { .. }) {
+                item.size_bytes
+            } else {
+                None
+            }
+        })
+        .sum::<u64>();
     let executor = match TransferExecutor::new(controls) {
         Ok(executor) => executor,
         Err(error) => {
@@ -447,30 +550,82 @@ async fn execute_transfer_plan(
         }
     };
     let operation_args = Arc::new(args.clone());
+    let transfer_cancellation = TransferCancellation::new();
+    let multipart_cancellation = MultipartCopyCancellation::new();
+    let signal_task = tokio::spawn({
+        let transfer_cancellation = transfer_cancellation.clone();
+        let multipart_cancellation = multipart_cancellation.clone();
+        async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                multipart_cancellation.cancel();
+                transfer_cancellation.cancel();
+            }
+        }
+    });
+    let copy_details = PlannedCopyDetails::default();
+    let copy_progress = Arc::new(PlannedCopyProgress::new(
+        formatter.output_config(),
+        total_bytes,
+    ));
     let report = executor
-        .execute(plan, {
+        .execute_with_cancellation(plan, transfer_cancellation, {
             let operation_args = Arc::clone(&operation_args);
             let clients = Arc::clone(&clients);
+            let multipart_cancellation = multipart_cancellation.clone();
+            let copy_details = Arc::clone(&copy_details);
+            let copy_progress = Arc::clone(&copy_progress);
             move |item| {
                 let operation_args = Arc::clone(&operation_args);
                 let clients = Arc::clone(&clients);
-                async move { execute_planned_operation(item, &operation_args, &clients).await }
+                let multipart_cancellation = multipart_cancellation.clone();
+                let copy_details = Arc::clone(&copy_details);
+                let copy_progress = Arc::clone(&copy_progress);
+                async move {
+                    execute_planned_operation(
+                        item,
+                        &operation_args,
+                        &clients,
+                        &multipart_cancellation,
+                        &copy_details,
+                        &copy_progress,
+                    )
+                    .await
+                }
             }
         })
         .await;
+    signal_task.abort();
+    let _ = signal_task.await;
+    copy_progress.finish();
 
+    let copy_details = copy_details.lock().await;
     for outcome in &report.outcomes {
         match &outcome.state {
             TransferOutcomeState::Success { bytes_transferred } => {
-                print_planned_success(formatter, &outcome.item, *bytes_transferred);
+                let key = (outcome.item.source.clone(), outcome.item.target.clone());
+                print_planned_success(
+                    formatter,
+                    &outcome.item,
+                    *bytes_transferred,
+                    copy_details.get(&key),
+                );
             }
             TransferOutcomeState::Failed { error } => {
                 formatter.error_with_code(exit_code_for_core_error(error), &error.to_string());
             }
-            TransferOutcomeState::Cancelled => formatter.warning(&format!(
-                "Cancelled before transfer: {}",
-                outcome.item.source
-            )),
+            TransferOutcomeState::Cancelled { error } => {
+                if let Some(error) = error {
+                    formatter.warning(&format!(
+                        "Cancelled transfer: {} ({error})",
+                        outcome.item.source
+                    ));
+                } else {
+                    formatter.warning(&format!(
+                        "Cancelled before transfer: {}",
+                        outcome.item.source
+                    ));
+                }
+            }
         }
     }
 
@@ -478,15 +633,22 @@ async fn execute_transfer_plan(
         print_transfer_summary(formatter, &report.summary);
     }
 
-    report
-        .first_failure()
-        .map_or(ExitCode::Success, exit_code_for_core_error)
+    if report.was_cancelled {
+        ExitCode::Interrupted
+    } else {
+        report
+            .first_failure()
+            .map_or(ExitCode::Success, exit_code_for_core_error)
+    }
 }
 
 async fn execute_planned_operation(
     item: TransferCandidate<CpOperation>,
     args: &CpArgs,
     clients: &HashMap<String, Arc<S3Client>>,
+    multipart_cancellation: &MultipartCopyCancellation,
+    copy_details: &PlannedCopyDetails,
+    copy_progress: &SharedPlannedCopyProgress,
 ) -> rc_core::Result<u64> {
     let client = planned_client(clients, operation_alias(&item.payload))?;
     match &item.payload {
@@ -501,16 +663,31 @@ async fn execute_planned_operation(
         CpOperation::RemoteToRemote {
             source,
             target,
+            source_info,
             encryption,
         } => {
-            perform_planned_remote_copy(
+            let progress_key = (item.source.clone(), item.target.clone());
+            copy_progress.reset(&progress_key);
+            let result = perform_planned_remote_copy(
                 client,
                 source,
                 target,
+                source_info,
                 encryption.as_ref(),
-                item.size_bytes,
+                multipart_cancellation,
+                &|bytes| copy_progress.set(&progress_key, bytes),
             )
-            .await
+            .await?;
+            copy_progress.set(&progress_key, result.bytes_copied);
+            copy_details.lock().await.insert(
+                (item.source, item.target),
+                PlannedCopyDetail {
+                    source_version_id: result.source_version_id,
+                    destination_version_id: result.destination_version_id,
+                    upload_id: result.upload_id,
+                },
+            );
+            Ok(result.bytes_copied)
         }
     }
 }
@@ -561,34 +738,105 @@ async fn perform_planned_download(
         .await
 }
 
+struct PlannedRemoteCopyResult {
+    bytes_copied: u64,
+    source_version_id: Option<String>,
+    destination_version_id: Option<String>,
+    upload_id: Option<String>,
+    object: ObjectInfo,
+}
+
 async fn perform_planned_remote_copy(
     client: &S3Client,
     source: &RemotePath,
     target: &RemotePath,
+    source_info: &ObjectInfo,
     encryption: Option<&ObjectEncryptionRequest>,
-    planned_size: Option<u64>,
-) -> rc_core::Result<u64> {
+    cancellation: &MultipartCopyCancellation,
+    on_progress: &(dyn Fn(u64) + Send + Sync),
+) -> rc_core::Result<PlannedRemoteCopyResult> {
     if source.alias != target.alias {
         return Err(Error::UnsupportedFeature(
             "Cross-alias S3-to-S3 copy is not supported".to_string(),
         ));
     }
-    if requires_multipart_copy(planned_size) {
-        return Err(Error::UnsupportedFeature(
-            "Objects larger than 5 GiB require multipart copy, which is not implemented"
-                .to_string(),
-        ));
-    }
-    let copied = client.copy_object(source, target, encryption).await?;
-    Ok(copied
+    let planned_size = source_info
         .size_bytes
         .and_then(|size| u64::try_from(size).ok())
-        .or(planned_size)
-        .unwrap_or_default())
+        .ok_or_else(|| Error::InvalidPath(format!("Source size is unavailable: {source}")))?;
+    if rc_core::requires_multipart_copy(planned_size) {
+        let current = client.head_object(source).await?;
+        if current.size_bytes != source_info.size_bytes
+            || source_info
+                .etag
+                .as_ref()
+                .zip(current.etag.as_ref())
+                .is_some_and(|(planned, current)| planned != current)
+        {
+            return Err(Error::Conflict(format!(
+                "Source changed after copy planning: {source}"
+            )));
+        }
+        let options = multipart_options_from_source(&current)?;
+        let copied = client
+            .multipart_copy(
+                source,
+                target,
+                &options,
+                cancellation,
+                encryption,
+                on_progress,
+            )
+            .await?;
+        return Ok(PlannedRemoteCopyResult {
+            bytes_copied: copied.bytes_copied,
+            source_version_id: options.source_version_id,
+            destination_version_id: copied.object.version_id.clone(),
+            upload_id: Some(copied.upload_id),
+            object: copied.object,
+        });
+    }
+    let options = CopyObjectOptions::for_source_version(source_info.version_id.clone())?;
+    let copied = client
+        .copy_object_with_options(source, target, &options, encryption)
+        .await?;
+    let bytes_copied = copied
+        .size_bytes
+        .and_then(|size| u64::try_from(size).ok())
+        .unwrap_or(planned_size);
+    on_progress(bytes_copied);
+    Ok(PlannedRemoteCopyResult {
+        bytes_copied,
+        source_version_id: copied
+            .source_version_id
+            .clone()
+            .or_else(|| source_info.version_id.clone()),
+        destination_version_id: copied.version_id.clone(),
+        upload_id: None,
+        object: copied,
+    })
 }
 
+#[cfg(test)]
 fn requires_multipart_copy(planned_size: Option<u64>) -> bool {
-    planned_size.is_some_and(|size| size > MAX_SINGLE_COPY_SIZE)
+    planned_size.is_some_and(rc_core::requires_multipart_copy)
+}
+
+fn multipart_options_from_source(source: &ObjectInfo) -> rc_core::Result<MultipartCopyOptions> {
+    let source_size = source
+        .size_bytes
+        .and_then(|size| u64::try_from(size).ok())
+        .ok_or_else(|| {
+            Error::InvalidPath("Multipart copy source size is unavailable".to_string())
+        })?;
+    let source_etag = source.etag.clone().ok_or_else(|| {
+        Error::InvalidPath("Multipart copy source ETag is unavailable".to_string())
+    })?;
+    let mut options = MultipartCopyOptions::new(source_size, source_etag)?;
+    options.source_version_id = source.version_id.clone();
+    options.content_type = source.content_type.clone();
+    options.metadata = source.metadata.clone().unwrap_or_default();
+    Ok(options)
 }
 
 fn operation_alias(operation: &CpOperation) -> &str {
@@ -657,6 +905,7 @@ fn print_planned_success(
     formatter: &Formatter,
     item: &TransferCandidate<CpOperation>,
     bytes_transferred: u64,
+    detail: Option<&PlannedCopyDetail>,
 ) {
     let size_bytes = i64::try_from(bytes_transferred).ok();
     let size_human = size_bytes.map(|size| humansize::format_size(size as u64, humansize::BINARY));
@@ -671,13 +920,42 @@ fn print_planned_success(
             source_version_id: None,
         });
     } else {
-        formatter.println(&format!(
+        let mut line = format!(
             "{} -> {} ({})",
             formatter.style_file(&item.source),
             formatter.style_file(&item.target),
             formatter.style_size(size_human.as_deref().unwrap_or_default())
-        ));
+        );
+        if let Some(detail) = detail {
+            if let Some(version_id) = &detail.source_version_id {
+                line.push_str(&format!(" source-version={version_id}"));
+            }
+            if let Some(version_id) = &detail.destination_version_id {
+                line.push_str(&format!(" destination-version={version_id}"));
+            }
+            if let Some(upload_id) = &detail.upload_id {
+                line.push_str(&format!(" upload-id={upload_id}"));
+            }
+        }
+        formatter.println(&line);
     }
+}
+
+fn print_skipped_existing(
+    formatter: &Formatter,
+    item: &TransferCandidate<CpOperation>,
+    dry_run: bool,
+) {
+    let action = if dry_run {
+        "Would skip existing"
+    } else {
+        "Skipped existing"
+    };
+    formatter.println(&format!(
+        "{action}: {} -> {}",
+        formatter.style_file(&item.source),
+        formatter.style_file(&item.target)
+    ));
 }
 
 fn print_transfer_summary(formatter: &Formatter, summary: &rc_core::TransferSummary) {
@@ -865,6 +1143,14 @@ async fn build_transfer_candidates(
 fn validate_plan_targets(plan: &TransferPlan<CpOperation>) -> rc_core::Result<()> {
     let mut targets = HashSet::with_capacity(plan.items.len());
     for candidate in &plan.items {
+        if let CpOperation::RemoteToRemote { source, target, .. } = &candidate.payload
+            && source == target
+        {
+            return Err(Error::InvalidPath(format!(
+                "Source and destination resolve to the same object '{}'",
+                candidate.source
+            )));
+        }
         if !targets.insert(candidate.target.clone()) {
             return Err(Error::InvalidPath(format!(
                 "Multiple sources resolve to the same destination '{}'",
@@ -873,6 +1159,37 @@ fn validate_plan_targets(plan: &TransferPlan<CpOperation>) -> rc_core::Result<()
         }
     }
     Ok(())
+}
+
+async fn skip_existing_remote_targets(
+    plan: &mut TransferPlan<CpOperation>,
+    clients: &HashMap<String, Arc<S3Client>>,
+) -> rc_core::Result<Vec<TransferCandidate<CpOperation>>> {
+    let mut retained = Vec::with_capacity(plan.items.len());
+    let mut skipped = Vec::new();
+    for candidate in plan.items.drain(..) {
+        let destination = match &candidate.payload {
+            CpOperation::LocalToRemote { target, .. }
+            | CpOperation::RemoteToRemote { target, .. } => Some(target),
+            CpOperation::RemoteToLocal { .. } => None,
+        };
+        let Some(destination) = destination else {
+            retained.push(candidate);
+            continue;
+        };
+        let client = planned_client(clients, &destination.alias)?;
+        match client.head_object(destination).await {
+            Ok(_) => skipped.push(candidate),
+            Err(Error::NotFound(_)) | Err(Error::VersionNotFound { .. }) => {
+                retained.push(candidate);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    plan.items = retained;
+    plan.summary.planned = plan.items.len();
+    plan.summary.skipped = plan.summary.skipped.saturating_add(skipped.len());
+    Ok(skipped)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1032,33 +1349,35 @@ async fn build_remote_candidates(
                 "Remote prefix copy requires -r/--recursive".to_string(),
             ));
         }
-        let ParsedPath::Local(target_root) = target else {
-            return Err(Error::UnsupportedFeature(
-                "Recursive S3-to-S3 copy is not implemented".to_string(),
-            ));
-        };
         if !target_is_container {
             return Err(Error::InvalidPath(
-                "Recursive copy requires a directory destination ending in '/'".to_string(),
+                "Recursive copy requires a directory or remote prefix destination ending in '/'"
+                    .to_string(),
             ));
         }
 
-        let source_root = if multiple_sources {
-            source
-                .key
-                .trim_end_matches('/')
-                .rsplit('/')
-                .next()
-                .filter(|value| !value.is_empty())
-                .unwrap_or(&source.bucket)
-        } else {
-            ""
-        };
+        let listing_source = recursive_listing_source(source);
+        if let ParsedPath::Remote(target) = target {
+            if source.alias != target.alias {
+                return Err(Error::UnsupportedFeature(
+                    "Cross-alias S3-to-S3 copy is not supported".to_string(),
+                ));
+            }
+            if remote_copy_scopes_overlap(&listing_source, target) {
+                return Err(Error::Conflict(format!(
+                    "Recursive source '{}' overlaps destination '{}'",
+                    listing_source, target
+                )));
+            }
+        }
+
+        let source_root = recursive_source_root(&listing_source, multiple_sources);
         let mut continuation_token = None;
+        let mut seen_tokens = HashSet::new();
         loop {
             let result = client
                 .list_objects(
-                    source,
+                    &listing_source,
                     rc_core::ListOptions {
                         recursive: true,
                         max_keys: Some(1_000),
@@ -1068,34 +1387,73 @@ async fn build_remote_candidates(
                 )
                 .await?;
             for object in result.items.into_iter().filter(|object| !object.is_dir) {
-                let relative = safe_download_relative_path(&object.key, &source.key)
-                    .map_err(Error::InvalidPath)?;
-                let relative_string = relative.to_string_lossy().replace('\\', "/");
-                let target_relative = if source_root.is_empty() {
-                    relative.clone()
-                } else {
-                    PathBuf::from(source_root).join(&relative)
-                };
-                let destination = safe_download_destination(target_root, &target_relative)
-                    .await
-                    .map_err(Error::InvalidPath)?;
-                let object_source = RemotePath::new(&source.alias, &source.bucket, &object.key);
-                candidates.push(TransferCandidate {
-                    payload: CpOperation::RemoteToLocal {
-                        source: object_source.clone(),
-                        target: destination.clone(),
-                    },
-                    source: object_source.to_string(),
-                    target: destination.display().to_string(),
-                    relative_path: relative_string,
-                    modified: object.last_modified,
-                    size_bytes: object.size_bytes.and_then(|size| u64::try_from(size).ok()),
-                });
+                let object_source =
+                    RemotePath::new(&listing_source.alias, &listing_source.bucket, &object.key);
+                match target {
+                    ParsedPath::Local(target_root) => {
+                        let relative =
+                            safe_download_relative_path(&object.key, &listing_source.key)
+                                .map_err(Error::InvalidPath)?;
+                        let relative_string = relative.to_string_lossy().replace('\\', "/");
+                        let target_relative = if source_root.is_empty() {
+                            relative.clone()
+                        } else {
+                            PathBuf::from(&source_root).join(&relative)
+                        };
+                        let destination = safe_download_destination(target_root, &target_relative)
+                            .await
+                            .map_err(Error::InvalidPath)?;
+                        candidates.push(TransferCandidate {
+                            payload: CpOperation::RemoteToLocal {
+                                source: object_source.clone(),
+                                target: destination.clone(),
+                            },
+                            source: object_source.to_string(),
+                            target: destination.display().to_string(),
+                            relative_path: relative_string,
+                            modified: object.last_modified,
+                            size_bytes: object.size_bytes.and_then(|size| u64::try_from(size).ok()),
+                        });
+                    }
+                    ParsedPath::Remote(target) => {
+                        let (destination, relative) = recursive_remote_target(
+                            &listing_source,
+                            target,
+                            &object.key,
+                            multiple_sources,
+                        )?;
+                        let size_bytes =
+                            object.size_bytes.and_then(|size| u64::try_from(size).ok());
+                        candidates.push(TransferCandidate {
+                            payload: CpOperation::RemoteToRemote {
+                                source: object_source.clone(),
+                                target: destination.clone(),
+                                source_info: Box::new(object.clone()),
+                                encryption: encryption.clone(),
+                            },
+                            source: object_source.to_string(),
+                            target: destination.to_string(),
+                            relative_path: relative,
+                            modified: object.last_modified,
+                            size_bytes,
+                        });
+                    }
+                }
             }
             if !result.truncated {
                 break;
             }
-            continuation_token = result.continuation_token;
+            let next_token = result.continuation_token.ok_or_else(|| {
+                Error::InvalidPath(
+                    "Truncated object listing did not include a continuation token".to_string(),
+                )
+            })?;
+            if !seen_tokens.insert(next_token.clone()) {
+                return Err(Error::Conflict(
+                    "Object listing repeated a continuation token".to_string(),
+                ));
+            }
+            continuation_token = Some(next_token);
         }
         return Ok(());
     }
@@ -1147,6 +1505,7 @@ async fn build_remote_candidates(
                 payload: CpOperation::RemoteToRemote {
                     source: source.clone(),
                     target: destination.clone(),
+                    source_info: Box::new(object),
                     encryption,
                 },
                 source: source.to_string(),
@@ -1185,6 +1544,69 @@ fn remote_child(parent: &RemotePath, relative: &str) -> RemotePath {
         format!("{}/{}", parent.key, relative)
     };
     RemotePath::new(&parent.alias, &parent.bucket, key)
+}
+
+fn recursive_listing_source(source: &RemotePath) -> RemotePath {
+    let key = if source.key.is_empty() || source.key.ends_with('/') {
+        source.key.clone()
+    } else {
+        format!("{}/", source.key)
+    };
+    RemotePath::new(&source.alias, &source.bucket, key)
+}
+
+fn recursive_source_root(source: &RemotePath, multiple_sources: bool) -> String {
+    if !multiple_sources {
+        return String::new();
+    }
+    source
+        .key
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(&source.bucket)
+        .to_string()
+}
+
+fn recursive_remote_target(
+    source: &RemotePath,
+    target: &RemotePath,
+    object_key: &str,
+    multiple_sources: bool,
+) -> rc_core::Result<(RemotePath, String)> {
+    let relative = object_key.strip_prefix(&source.key).ok_or_else(|| {
+        Error::InvalidPath(format!(
+            "Listed object key '{object_key}' is outside source prefix '{}'",
+            source.key
+        ))
+    })?;
+    if relative.is_empty() {
+        return Err(Error::InvalidPath(format!(
+            "Listed object key '{object_key}' does not identify a child of source prefix '{}'",
+            source.key
+        )));
+    }
+    let destination_relative = match recursive_source_root(source, multiple_sources) {
+        root if root.is_empty() => relative.to_string(),
+        root => format!("{root}/{relative}"),
+    };
+    Ok((
+        remote_child(target, &destination_relative),
+        relative.to_string(),
+    ))
+}
+
+fn remote_copy_scopes_overlap(source: &RemotePath, target: &RemotePath) -> bool {
+    if source.alias != target.alias || source.bucket != target.bucket {
+        return false;
+    }
+    let source_prefix = recursive_listing_source(source).key;
+    let target_prefix = recursive_listing_source(target).key;
+    source_prefix.is_empty()
+        || target_prefix.is_empty()
+        || source_prefix.starts_with(&target_prefix)
+        || target_prefix.starts_with(&source_prefix)
 }
 
 fn parse_cp_path(path: &str, alias_manager: Option<&AliasManager>) -> rc_core::Result<ParsedPath> {
@@ -1874,19 +2296,9 @@ async fn copy_s3_to_s3_prepared(
         return ExitCode::Success;
     }
 
-    match client.head_object(src).await {
-        Ok(info)
-            if info
-                .size_bytes
-                .is_some_and(|size| size > 5 * 1024 * 1024 * 1024) =>
-        {
-            return formatter.fail(
-                ExitCode::UnsupportedFeature,
-                "Objects larger than 5 GiB require multipart copy, which is not implemented",
-            );
-        }
-        Ok(_) => {}
-        Err(rc_core::Error::NotFound(_)) => {
+    let source_info = match client.head_object(src).await {
+        Ok(info) => info,
+        Err(Error::NotFound(_)) => {
             return formatter.fail_with_suggestion(
                 ExitCode::NotFound,
                 &format!("Source not found: {src_display}"),
@@ -1895,34 +2307,87 @@ async fn copy_s3_to_s3_prepared(
         }
         Err(error) => {
             return formatter.fail(
-                ExitCode::NetworkError,
+                exit_code_for_core_error(&error),
                 &format!("Failed to inspect source object: {error}"),
             );
         }
-    }
+    };
 
-    match client.copy_object(src, dst, encryption).await {
-        Ok(info) => {
+    let cancellation = MultipartCopyCancellation::new();
+    let transfer_cancellation = TransferCancellation::new();
+    let signal_task = tokio::spawn({
+        let cancellation = cancellation.clone();
+        let transfer_cancellation = transfer_cancellation.clone();
+        async move {
+            if tokio::signal::ctrl_c().await.is_ok() {
+                cancellation.cancel();
+                transfer_cancellation.cancel();
+            }
+        }
+    });
+    let ignore_progress = |_: u64| {};
+    let copy = perform_planned_remote_copy(
+        &client,
+        src,
+        dst,
+        &source_info,
+        encryption,
+        &cancellation,
+        &ignore_progress,
+    );
+    tokio::pin!(copy);
+    let result = tokio::select! {
+        biased;
+        _ = transfer_cancellation.cancelled() => {
+            // Do not drop an in-flight request. Multipart copy observes its own token and performs
+            // cleanup; CopyObject is allowed to settle before the command reports interruption.
+            let _ = copy.await;
+            Err(Error::Interrupted("Copy interrupted".to_string()))
+        }
+        result = &mut copy => {
+            if transfer_cancellation.is_cancelled() {
+                Err(Error::Interrupted("Copy interrupted".to_string()))
+            } else {
+                result
+            }
+        }
+    };
+    signal_task.abort();
+    let _ = signal_task.await;
+
+    match result {
+        Ok(result) => {
             if formatter.is_json() {
-                print_copy_json(formatter, &info, &src_display, &dst_display);
+                print_copy_json(formatter, &result.object, &src_display, &dst_display);
             } else {
                 let styled_src = formatter.style_file(&src_display);
                 let styled_dst = formatter.style_file(&dst_display);
-                let styled_size = formatter.style_size(&info.size_human.unwrap_or_default());
-                formatter.println(&format!("{styled_src} -> {styled_dst} ({styled_size})"));
+                let styled_size =
+                    formatter.style_size(&result.object.size_human.unwrap_or_else(|| {
+                        humansize::format_size(result.bytes_copied, humansize::BINARY)
+                    }));
+                let upload = result
+                    .upload_id
+                    .map(|upload_id| format!(" upload-id={upload_id}"))
+                    .unwrap_or_default();
+                formatter.println(&format!(
+                    "{styled_src} -> {styled_dst} ({styled_size}){upload}"
+                ));
             }
             ExitCode::Success
         }
-        Err(e) => {
-            let err_str = e.to_string();
-            if err_str.contains("NotFound") || err_str.contains("NoSuchKey") {
+        Err(error) => {
+            if matches!(error, Error::NotFound(_) | Error::VersionNotFound { .. }) {
                 formatter.fail_with_suggestion(
                     ExitCode::NotFound,
                     &format!("Source not found: {src_display}"),
                     "Check the source bucket and object key, then retry the copy command.",
                 )
             } else {
-                formatter.fail(ExitCode::NetworkError, &format!("Failed to copy: {e}"))
+                formatter.fail(
+                    exit_code_for_core_error(&error),
+                    &format!("Failed to copy: {error}"),
+                )
             }
         }
     }
@@ -2395,6 +2860,10 @@ mod tests {
             payload: CpOperation::RemoteToRemote {
                 source: RemotePath::new("shared", "source", "large.bin"),
                 target: RemotePath::new("shared", "target", "large.bin"),
+                source_info: Box::new(ObjectInfo::file(
+                    "large.bin",
+                    (MAX_SINGLE_COPY_SIZE + 1) as i64,
+                )),
                 encryption: None,
             },
             source: "shared/source/large.bin".to_string(),
@@ -2405,6 +2874,106 @@ mod tests {
         };
 
         assert!(requires_multipart_copy(candidate.size_bytes));
+    }
+
+    #[test]
+    fn planned_remote_copy_uses_exact_five_gib_boundary() {
+        assert!(!requires_multipart_copy(Some(MAX_SINGLE_COPY_SIZE)));
+        assert!(requires_multipart_copy(Some(MAX_SINGLE_COPY_SIZE + 1)));
+    }
+
+    #[test]
+    fn planned_progress_replaces_attempt_bytes_instead_of_double_counting() {
+        let progress = PlannedCopyProgress::new(
+            OutputConfig {
+                no_progress: true,
+                ..OutputConfig::default()
+            },
+            20,
+        );
+        let first = ("source/a".to_string(), "target/a".to_string());
+        let second = ("source/b".to_string(), "target/b".to_string());
+
+        progress.set(&first, 7);
+        progress.set(&second, 5);
+        progress.reset(&first);
+        progress.set(&first, 15);
+
+        let positions = progress
+            .positions
+            .lock()
+            .expect("planned copy progress lock");
+        assert_eq!(positions.get(&first), Some(&15));
+        assert_eq!(positions.get(&second), Some(&5));
+        assert_eq!(
+            positions.values().copied().fold(0_u64, u64::saturating_add),
+            20
+        );
+    }
+
+    #[test]
+    fn recursive_remote_mapping_preserves_source_relative_keys() {
+        let source = RemotePath::new("shared", "source", "src/");
+        let target = RemotePath::new("shared", "destination", "archive/");
+
+        let (destination, relative) =
+            recursive_remote_target(&source, &target, "src/nested/report.csv", false)
+                .expect("map recursive object");
+
+        assert_eq!(relative, "nested/report.csv");
+        assert_eq!(destination.key, "archive/nested/report.csv");
+    }
+
+    #[test]
+    fn recursive_bucket_root_mapping_keeps_the_full_object_key() {
+        let source = RemotePath::new("shared", "source", "");
+        let target = RemotePath::new("shared", "destination", "archive/");
+
+        let (destination, relative) =
+            recursive_remote_target(&source, &target, "nested/report.csv", false)
+                .expect("map bucket object");
+
+        assert_eq!(relative, "nested/report.csv");
+        assert_eq!(destination.key, "archive/nested/report.csv");
+    }
+
+    #[test]
+    fn recursive_remote_overlap_is_boundary_aware_and_symmetric() {
+        let source = RemotePath::new("shared", "bucket", "src/");
+        let child = RemotePath::new("shared", "bucket", "src/archive/");
+        let sibling = RemotePath::new("shared", "bucket", "src-old/");
+        let other_bucket = RemotePath::new("shared", "other", "src/archive/");
+
+        assert!(remote_copy_scopes_overlap(&source, &child));
+        assert!(remote_copy_scopes_overlap(&child, &source));
+        assert!(!remote_copy_scopes_overlap(&source, &sibling));
+        assert!(!remote_copy_scopes_overlap(&source, &other_bucket));
+    }
+
+    #[test]
+    fn multipart_options_require_and_preserve_planned_source_identity() {
+        let mut source = rc_core::ObjectInfo::file("large.bin", (MAX_SINGLE_COPY_SIZE + 1) as i64);
+        source.etag = Some("planned-etag".to_string());
+        source.version_id = Some("source-version".to_string());
+        source.content_type = Some("application/octet-stream".to_string());
+        source.metadata = Some(HashMap::from([(
+            "project".to_string(),
+            "archive".to_string(),
+        )]));
+
+        let options = multipart_options_from_source(&source).expect("multipart options");
+
+        assert_eq!(options.source_size, MAX_SINGLE_COPY_SIZE + 1);
+        assert_eq!(options.source_etag, "planned-etag");
+        assert_eq!(options.source_version_id.as_deref(), Some("source-version"));
+        assert_eq!(
+            options.content_type.as_deref(),
+            Some("application/octet-stream")
+        );
+        assert_eq!(
+            options.metadata.get("project").map(String::as_str),
+            Some("archive")
+        );
     }
 
     #[test]

--- a/crates/cli/src/commands/mirror.rs
+++ b/crates/cli/src/commands/mirror.rs
@@ -1169,6 +1169,7 @@ fn report_without_execution<T>(plan: TransferPlan<T>) -> TransferReport<T> {
     TransferReport {
         summary: plan.summary,
         outcomes: Vec::new(),
+        was_cancelled: false,
     }
 }
 
@@ -1302,10 +1303,19 @@ fn output_outcomes<T>(formatter: &Formatter, marker: &str, report: &TransferRepo
                     formatter.sanitize_text(&outcome.item.relative_path)
                 ),
             ),
-            TransferOutcomeState::Cancelled => formatter.warning(&format!(
-                "Cancelled before mirror operation: {}",
-                formatter.sanitize_text(&outcome.item.relative_path)
-            )),
+            TransferOutcomeState::Cancelled { error } => {
+                if let Some(error) = error {
+                    formatter.warning(&format!(
+                        "Cancelled mirror operation: {} ({error})",
+                        formatter.sanitize_text(&outcome.item.relative_path)
+                    ));
+                } else {
+                    formatter.warning(&format!(
+                        "Cancelled before mirror operation: {}",
+                        formatter.sanitize_text(&outcome.item.relative_path)
+                    ));
+                }
+            }
         }
     }
 }

--- a/crates/cli/tests/integration.rs
+++ b/crates/cli/tests/integration.rs
@@ -1527,27 +1527,21 @@ mod recursive_operations {
             assert!(output.status.success(), "Failed to upload {}", file);
         }
 
-        // Copy src/ to dst/ - Note: recursive S3-to-S3 copy may not be fully implemented
+        // Copy src/ to dst/ through the recursive same-endpoint planner.
         let output = run_rc(
             &[
                 "cp",
                 "--recursive",
                 &format!("test/{}/src/", bucket_name),
                 &format!("test/{}/dst/", bucket_name),
-                "--json",
             ],
             config_dir.path(),
         );
-
-        // If recursive copy is not supported, skip the rest of the test
-        if !output.status.success() {
-            eprintln!(
-                "Recursive S3-to-S3 copy not fully implemented, skipping: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-            cleanup_bucket(config_dir.path(), &bucket_name);
-            return;
-        }
+        assert!(
+            output.status.success(),
+            "Failed to recursively copy remote prefix: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
 
         // Verify both src and dst exist
         let output = run_rc(

--- a/crates/cli/tests/recursive_remote_copy.rs
+++ b/crates/cli/tests/recursive_remote_copy.rs
@@ -1,0 +1,971 @@
+#![cfg(not(windows))]
+
+use std::collections::BTreeMap;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Command, Output, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Debug)]
+struct Request {
+    method: String,
+    target: String,
+    headers: BTreeMap<String, String>,
+}
+
+#[derive(Debug)]
+struct Response {
+    status: &'static str,
+    headers: Vec<(&'static str, String)>,
+    body: String,
+}
+
+impl Response {
+    fn xml(body: String) -> Self {
+        Self {
+            status: "200 OK",
+            headers: Vec::new(),
+            body,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            status: "200 OK",
+            headers: Vec::new(),
+            body: String::new(),
+        }
+    }
+
+    fn head(size: usize) -> Self {
+        Self::head_with_etag(size, "destination-etag")
+    }
+
+    fn head_with_etag(size: usize, etag: &str) -> Self {
+        Self {
+            status: "200 OK",
+            headers: vec![
+                ("content-length", size.to_string()),
+                ("etag", format!("\"{etag}\"")),
+            ],
+            body: String::new(),
+        }
+    }
+
+    fn access_denied() -> Self {
+        Self {
+            status: "403 Forbidden",
+            headers: Vec::new(),
+            body: "<Error><Code>AccessDenied</Code><Message>denied</Message></Error>".to_string(),
+        }
+    }
+}
+
+type Handler = dyn Fn(&Request) -> Response + Send + Sync + 'static;
+
+struct S3Mock {
+    endpoint: String,
+    requests: Arc<Mutex<Vec<Request>>>,
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl S3Mock {
+    fn start(handler: impl Fn(&Request) -> Response + Send + Sync + 'static) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind S3 mock");
+        listener
+            .set_nonblocking(true)
+            .expect("set S3 mock nonblocking");
+        let address = listener.local_addr().expect("S3 mock address");
+        let endpoint = format!("http://{address}");
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let requests_for_thread = Arc::clone(&requests);
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_for_thread = Arc::clone(&shutdown);
+        let handler: Arc<Handler> = Arc::new(handler);
+
+        let handle = thread::spawn(move || {
+            while !shutdown_for_thread.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        stream
+                            .set_nonblocking(false)
+                            .expect("set accepted S3 connection blocking");
+                        let requests = Arc::clone(&requests_for_thread);
+                        let handler = Arc::clone(&handler);
+                        thread::spawn(move || {
+                            let mut pending = Vec::new();
+                            while let Some(request) = read_request(&mut stream, &mut pending) {
+                                requests
+                                    .lock()
+                                    .expect("record S3 request")
+                                    .push(request.clone());
+                                write_response(&mut stream, handler(&request));
+                            }
+                        });
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(1));
+                    }
+                    Err(error) => panic!("accept S3 request: {error}"),
+                }
+            }
+        });
+
+        Self {
+            endpoint,
+            requests,
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    fn requests(&self) -> Vec<Request> {
+        self.requests.lock().expect("read S3 requests").clone()
+    }
+}
+
+impl Drop for S3Mock {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        if let Some(handle) = self.handle.take() {
+            handle.join().expect("S3 mock thread should finish");
+        }
+    }
+}
+
+fn read_request(stream: &mut TcpStream, pending: &mut Vec<u8>) -> Option<Request> {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(30)))
+        .expect("set S3 request timeout");
+    let mut buffer = [0_u8; 8192];
+    let header_end = loop {
+        if let Some(position) = pending.windows(4).position(|part| part == b"\r\n\r\n") {
+            break position + 4;
+        }
+        let read = match stream.read(&mut buffer) {
+            Ok(0) => return None,
+            Ok(read) => read,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted
+                ) =>
+            {
+                return None;
+            }
+            Err(error) => panic!("read S3 request: {error}"),
+        };
+        pending.extend_from_slice(&buffer[..read]);
+    };
+    let header_text =
+        String::from_utf8(pending[..header_end].to_vec()).expect("S3 headers should be UTF-8");
+    let mut lines = header_text.lines();
+    let request_line = lines.next()?;
+    let mut request_parts = request_line.split_whitespace();
+    let method = request_parts.next()?.to_string();
+    let target = request_parts.next()?.to_string();
+    let headers = lines
+        .filter_map(|line| line.split_once(':'))
+        .map(|(name, value)| (name.to_ascii_lowercase(), value.trim().to_string()))
+        .collect::<BTreeMap<_, _>>();
+    let content_length = headers
+        .get("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    while pending.len().saturating_sub(header_end) < content_length {
+        let read = stream.read(&mut buffer).ok()?;
+        if read == 0 {
+            return None;
+        }
+        pending.extend_from_slice(&buffer[..read]);
+    }
+    pending.drain(..header_end + content_length);
+
+    Some(Request {
+        method,
+        target,
+        headers,
+    })
+}
+
+fn write_response(stream: &mut TcpStream, response: Response) {
+    let has_content_length = response
+        .headers
+        .iter()
+        .any(|(name, _)| name.eq_ignore_ascii_case("content-length"));
+    let mut head = format!(
+        "HTTP/1.1 {}\r\ncontent-type: application/xml\r\nconnection: keep-alive\r\n",
+        response.status
+    );
+    if !has_content_length {
+        head.push_str(&format!("content-length: {}\r\n", response.body.len()));
+    }
+    for (name, value) in response.headers {
+        head.push_str(&format!("{name}: {value}\r\n"));
+    }
+    head.push_str("\r\n");
+    stream
+        .write_all(head.as_bytes())
+        .expect("write S3 response headers");
+    stream
+        .write_all(response.body.as_bytes())
+        .expect("write S3 response body");
+    stream.flush().expect("flush S3 response");
+}
+
+fn rc_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rc") {
+        return PathBuf::from(path);
+    }
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate parent")
+        .parent()
+        .expect("workspace root")
+        .to_path_buf();
+    workspace_root.join("target/debug/rc")
+}
+
+fn run_rc(mock: &S3Mock, args: &[&str]) -> Output {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    let authority = mock
+        .endpoint
+        .strip_prefix("http://")
+        .expect("mock endpoint has scheme");
+    let alias = format!("http://ACCESS_KEY:SECRET_KEY@{authority}");
+    let mut command = Command::new(rc_binary());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+    command
+        .args(args)
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_test", alias)
+        .env("AWS_EC2_METADATA_DISABLED", "true")
+        .output()
+        .expect("run rc command")
+}
+
+fn list_result(keys: &[String], truncated: bool, next_token: Option<&str>) -> Response {
+    let contents = keys
+        .iter()
+        .map(|key| {
+            format!(
+                "<Contents><Key>{key}</Key><Size>1</Size><ETag>\"source-etag\"</ETag></Contents>"
+            )
+        })
+        .collect::<String>();
+    let next_token = next_token
+        .map(|token| format!("<NextContinuationToken>{token}</NextContinuationToken>"))
+        .unwrap_or_default();
+    Response::xml(format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+         <Name>source</Name><Prefix>src/</Prefix>{contents}\
+         <IsTruncated>{truncated}</IsTruncated>{next_token}</ListBucketResult>"
+    ))
+}
+
+fn one_object_list() -> Response {
+    list_result(&["src/a.txt".to_string()], false, None)
+}
+
+fn large_object_list(size: u64) -> Response {
+    Response::xml(format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+         <ListBucketResult xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">\
+         <Name>source</Name><Prefix>src/</Prefix>\
+         <Contents><Key>src/large.bin</Key><Size>{size}</Size><ETag>\"source-etag\"</ETag></Contents>\
+         <IsTruncated>false</IsTruncated></ListBucketResult>"
+    ))
+}
+
+fn copy_result() -> Response {
+    Response::xml(
+        "<CopyObjectResult><ETag>\"destination-etag\"</ETag>\
+         <LastModified>2026-07-23T00:00:00Z</LastModified></CopyObjectResult>"
+            .to_string(),
+    )
+}
+
+fn is_list_request(request: &Request) -> bool {
+    request.method == "GET"
+        && (request.target.starts_with("/source?") || request.target.starts_with("/source/?"))
+        && request.target.contains("list-type=2")
+}
+
+fn is_copy_request(request: &Request) -> bool {
+    request.method == "PUT" && request.headers.contains_key("x-amz-copy-source")
+}
+
+#[test]
+fn recursive_same_alias_copy_paginates_and_emits_deterministic_plan() {
+    let first_page = (0..1_000)
+        .rev()
+        .map(|index| format!("src/item-{index:04}.txt"))
+        .collect::<Vec<_>>();
+    let mock = S3Mock::start(move |request| {
+        if is_list_request(request) {
+            if request.target.contains("continuation-token=page-2") {
+                return list_result(&["src/item-1000.txt".to_string()], false, None);
+            }
+            return list_result(&first_page, true, Some("page-2"));
+        }
+        if is_copy_request(request) {
+            return copy_result();
+        }
+        if request.method == "HEAD" && request.target.starts_with("/destination/dst/") {
+            return Response::head(1);
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "--dry-run",
+            "--concurrency",
+            "1",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    let requests = mock.requests();
+    let list_requests = requests
+        .iter()
+        .filter(|request| is_list_request(request))
+        .collect::<Vec<_>>();
+    assert_eq!(list_requests.len(), 2);
+    assert!(
+        list_requests[1]
+            .target
+            .contains("continuation-token=page-2")
+    );
+
+    let copies = requests
+        .iter()
+        .filter(|request| is_copy_request(request))
+        .collect::<Vec<_>>();
+    assert!(copies.is_empty(), "dry-run pagination must not mutate");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let planned = stdout
+        .lines()
+        .filter(|line| line.starts_with("Would copy:"))
+        .collect::<Vec<_>>();
+    assert_eq!(planned.len(), 1_001);
+    for (index, line) in planned.iter().enumerate() {
+        assert_eq!(
+            *line,
+            format!(
+                "Would copy: test/source/src/item-{index:04}.txt -> test/destination/dst/item-{index:04}.txt"
+            )
+        );
+    }
+}
+
+#[test]
+fn overlapping_same_bucket_prefix_is_conflict_before_any_copy() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return one_object_list();
+        }
+        Response::empty()
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "test/archive/src/",
+            "test/archive/src/backup/",
+        ],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(6),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !mock.requests().iter().any(is_copy_request),
+        "overlap validation must happen before mutation"
+    );
+}
+
+#[test]
+fn overwrite_false_reports_existing_destination_as_skipped() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return one_object_list();
+        }
+        if request.method == "HEAD" && request.target == "/destination/dst/a.txt" {
+            return Response::head(1);
+        }
+        if is_copy_request(request) {
+            return copy_result();
+        }
+        Response::empty()
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "--overwrite=false",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    assert!(
+        !mock.requests().iter().any(is_copy_request),
+        "an existing destination must not be overwritten"
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout)
+            .to_ascii_lowercase()
+            .contains("skipped"),
+        "skip-existing must be explicit in output"
+    );
+}
+
+#[test]
+fn recursive_copy_access_denial_uses_auth_exit_code_without_mutation() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return Response::access_denied();
+        }
+        Response::empty()
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!mock.requests().iter().any(is_copy_request));
+}
+
+#[test]
+fn recursive_copy_empty_prefix_is_explicit_and_deterministic() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return list_result(&[], false, None);
+        }
+        Response::empty()
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "Summary: 0 planned, 0 skipped, 0 succeeded, 0 failed, 0 cancelled, 0 B transferred"
+    );
+    assert!(!mock.requests().iter().any(is_copy_request));
+}
+
+#[test]
+fn recursive_copy_dry_run_maps_objects_without_mutation() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return list_result(
+                &["src/b.txt".to_string(), "src/sub/a.txt".to_string()],
+                false,
+                None,
+            );
+        }
+        Response::empty()
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "--dry-run",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test/source/src/b.txt -> test/destination/dst/b.txt"));
+    assert!(stdout.contains("test/source/src/sub/a.txt -> test/destination/dst/sub/a.txt"));
+    assert!(
+        mock.requests()
+            .iter()
+            .all(|request| !is_copy_request(request) && request.method != "DELETE"),
+        "dry run must not mutate the destination"
+    );
+}
+
+#[test]
+fn recursive_copy_executes_the_planned_server_side_copy() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return one_object_list();
+        }
+        if is_copy_request(request) {
+            return copy_result();
+        }
+        if request.method == "HEAD" && request.target == "/destination/dst/a.txt" {
+            return Response::head(1);
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "--concurrency",
+            "1",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    let requests = mock.requests();
+    let copies = requests
+        .iter()
+        .filter(|request| is_copy_request(request))
+        .collect::<Vec<_>>();
+    assert_eq!(copies.len(), 1);
+    assert_eq!(copies[0].target, "/destination/dst/a.txt?x-id=CopyObject");
+    assert_eq!(
+        copies[0].headers.get("x-amz-copy-source"),
+        Some(&"source/src/a.txt".to_string())
+    );
+}
+
+#[test]
+fn recursive_copy_continue_on_error_retains_successful_results() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return list_result(
+                &["src/a.txt".to_string(), "src/b.txt".to_string()],
+                false,
+                None,
+            );
+        }
+        if is_copy_request(request) && request.target.contains("/a.txt") {
+            return Response::access_denied();
+        }
+        if is_copy_request(request) {
+            return copy_result();
+        }
+        if request.method == "HEAD" && request.target == "/destination/dst/b.txt" {
+            return Response::head(1);
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "--continue-on-error",
+            "--retry-attempts",
+            "1",
+            "--concurrency",
+            "1",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test/source/src/b.txt -> test/destination/dst/b.txt"));
+    assert!(stdout.contains("1 succeeded"));
+    assert!(stdout.contains("1 failed"));
+    assert_eq!(
+        mock.requests()
+            .iter()
+            .filter(|request| is_copy_request(request))
+            .count(),
+        2
+    );
+}
+
+#[test]
+fn recursive_copy_sigint_drains_started_copy_and_returns_130() {
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return list_result(
+                &["src/a.txt".to_string(), "src/b.txt".to_string()],
+                false,
+                None,
+            );
+        }
+        if is_copy_request(request) {
+            thread::sleep(Duration::from_millis(250));
+            return copy_result();
+        }
+        if request.method == "HEAD" && request.target == "/destination/dst/a.txt" {
+            return Response::head(1);
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    let authority = mock
+        .endpoint
+        .strip_prefix("http://")
+        .expect("mock endpoint has scheme");
+    let alias = format!("http://ACCESS_KEY:SECRET_KEY@{authority}");
+    let mut command = Command::new(rc_binary());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+    let child = command
+        .args([
+            "cp",
+            "--recursive",
+            "--concurrency",
+            "1",
+            "test/source/src/",
+            "test/destination/dst/",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_test", alias)
+        .env("AWS_EC2_METADATA_DISABLED", "true")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rc command");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !mock.requests().iter().any(is_copy_request) {
+        assert!(
+            Instant::now() < deadline,
+            "copy request did not start: {:#?}",
+            mock.requests()
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
+    let signal_status = Command::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status()
+        .expect("send SIGINT");
+    assert!(signal_status.success());
+
+    let output = child
+        .wait_with_output()
+        .expect("wait for interrupted command");
+    assert_eq!(
+        output.status.code(),
+        Some(130),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test/source/src/a.txt -> test/destination/dst/a.txt"));
+    assert!(stdout.contains("1 succeeded"));
+    assert!(stdout.contains("1 cancelled"));
+    let copies = mock
+        .requests()
+        .into_iter()
+        .filter(is_copy_request)
+        .collect::<Vec<_>>();
+    assert_eq!(copies.len(), 1, "SIGINT must stop scheduling new copies");
+    assert!(copies[0].target.contains("/a.txt"));
+}
+
+#[test]
+fn recursive_large_copy_uses_multipart_and_reports_abort_cleanup() {
+    const LARGE_SIZE: u64 = 5 * 1024 * 1024 * 1024 + 1;
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return large_object_list(LARGE_SIZE);
+        }
+        if request.method == "HEAD" && request.target == "/source/src/large.bin" {
+            return Response::head_with_etag(LARGE_SIZE as usize, "source-etag");
+        }
+        if request.method == "POST"
+            && request.target.starts_with("/destination/dst/large.bin?")
+            && request.target.contains("uploads")
+        {
+            return Response::xml(
+                "<InitiateMultipartUploadResult>\
+                 <Bucket>destination</Bucket><Key>dst/large.bin</Key>\
+                 <UploadId>cleanup-upload-id</UploadId>\
+                 </InitiateMultipartUploadResult>"
+                    .to_string(),
+            );
+        }
+        if request.method == "PUT"
+            && request.target.contains("partNumber=1")
+            && request.target.contains("uploadId=cleanup-upload-id")
+        {
+            return Response::access_denied();
+        }
+        if request.method == "DELETE" && request.target.contains("uploadId=cleanup-upload-id") {
+            return Response::empty();
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "--recursive",
+            "--retry-attempts",
+            "1",
+            "test/source/src/",
+            "test/destination/dst/",
+        ],
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cleanup-upload-id"), "{stderr}");
+    assert!(stderr.contains("abort: succeeded"), "{stderr}");
+    let requests = mock.requests();
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == "POST")
+            .count(),
+        1
+    );
+    assert_eq!(
+        requests
+            .iter()
+            .filter(|request| request.method == "DELETE")
+            .count(),
+        1
+    );
+    assert!(
+        requests.iter().all(|request| {
+            request.method != "GET"
+                || is_list_request(request)
+                || request.target.contains("list-type=2")
+        }),
+        "multipart server-side copy must not download the source: {requests:#?}"
+    );
+}
+
+#[test]
+fn recursive_multipart_sigint_aborts_once_and_reports_cancelled_cleanup() {
+    const LARGE_SIZE: u64 = 5 * 1024 * 1024 * 1024 + 1;
+    let mock = S3Mock::start(|request| {
+        if is_list_request(request) {
+            return large_object_list(LARGE_SIZE);
+        }
+        if request.method == "HEAD" && request.target == "/source/src/large.bin" {
+            return Response::head_with_etag(LARGE_SIZE as usize, "source-etag");
+        }
+        if request.method == "POST"
+            && request.target.starts_with("/destination/dst/large.bin?")
+            && request.target.contains("uploads")
+        {
+            return Response::xml(
+                "<InitiateMultipartUploadResult>\
+                 <Bucket>destination</Bucket><Key>dst/large.bin</Key>\
+                 <UploadId>cancel-upload-id</UploadId>\
+                 </InitiateMultipartUploadResult>"
+                    .to_string(),
+            );
+        }
+        if request.method == "PUT"
+            && request.target.contains("partNumber=1")
+            && request.target.contains("uploadId=cancel-upload-id")
+        {
+            thread::sleep(Duration::from_millis(500));
+            return Response::xml(
+                "<CopyPartResult><ETag>\"part-etag\"</ETag></CopyPartResult>".to_string(),
+            );
+        }
+        if request.method == "DELETE" && request.target.contains("uploadId=cancel-upload-id") {
+            return Response::empty();
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    let authority = mock
+        .endpoint
+        .strip_prefix("http://")
+        .expect("mock endpoint has scheme");
+    let alias = format!("http://ACCESS_KEY:SECRET_KEY@{authority}");
+    let mut command = Command::new(rc_binary());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+    let child = command
+        .args([
+            "cp",
+            "--recursive",
+            "--concurrency",
+            "1",
+            "test/source/src/",
+            "test/destination/dst/",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_test", alias)
+        .env("AWS_EC2_METADATA_DISABLED", "true")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rc command");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while !mock.requests().iter().any(|request| {
+        request.method == "PUT"
+            && request.target.contains("partNumber=1")
+            && request.target.contains("uploadId=cancel-upload-id")
+    }) {
+        assert!(
+            Instant::now() < deadline,
+            "multipart part request did not start: {:#?}",
+            mock.requests()
+        );
+        thread::sleep(Duration::from_millis(5));
+    }
+    let signal_status = Command::new("kill")
+        .args(["-INT", &child.id().to_string()])
+        .status()
+        .expect("send SIGINT");
+    assert!(signal_status.success());
+
+    let output = child
+        .wait_with_output()
+        .expect("wait for interrupted command");
+    assert_eq!(
+        output.status.code(),
+        Some(130),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+        mock.requests()
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("0 failed"), "{stdout}");
+    assert!(stdout.contains("1 cancelled"), "{stdout}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("cancel-upload-id"), "{stderr}");
+    assert!(stderr.contains("abort: succeeded"), "{stderr}");
+    assert_eq!(
+        mock.requests()
+            .iter()
+            .filter(|request| {
+                request.method == "DELETE" && request.target.contains("cancel-upload-id")
+            })
+            .count(),
+        1
+    );
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -74,8 +74,8 @@ pub use traits::{
     ObjectVersion, ObjectVersionIdentifier, ObjectVersionListResult,
 };
 pub use transfer::{
-    TransferCandidate, TransferControls, TransferExecutor, TransferOutcome, TransferOutcomeState,
-    TransferPlan, TransferReport, TransferSelection, TransferSummary,
+    TransferCancellation, TransferCandidate, TransferControls, TransferExecutor, TransferOutcome,
+    TransferOutcomeState, TransferPlan, TransferReport, TransferSelection, TransferSummary,
 };
 pub use undo::{
     UndoAction, UndoObjectResult, UndoOutcome, UndoPlan, UndoPlanItem, plan_object_undo,

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -59,7 +59,7 @@ where
 }
 
 /// Calculate backoff duration with jitter
-fn calculate_backoff(config: &RetryConfig, attempt: u32) -> Duration {
+pub(crate) fn calculate_backoff(config: &RetryConfig, attempt: u32) -> Duration {
     // Exponential backoff: initial * 2^(attempt-1)
     let base_ms = config.initial_backoff_ms * (1u64 << (attempt - 1).min(10));
     let capped_ms = base_ms.min(config.max_backoff_ms);

--- a/crates/core/src/transfer.rs
+++ b/crates/core/src/transfer.rs
@@ -7,18 +7,19 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use futures::stream::{FuturesUnordered, StreamExt as _};
 use glob::Pattern;
 use jiff::Timestamp;
 use serde::Serialize;
-use tokio::sync::Mutex;
-use tokio::time::{Instant, sleep_until};
+use tokio::sync::{Mutex, Notify};
+use tokio::time::{Instant, sleep, sleep_until};
 
 use crate::alias::RetryConfig;
 use crate::error::{Error, Result};
-use crate::retry::{is_retryable_error, retry_with_backoff};
+use crate::retry::{calculate_backoff, is_retryable_error};
 
 /// A storage-independent item that can be selected and executed as part of a transfer.
 #[derive(Debug, Clone)]
@@ -202,12 +203,50 @@ impl Default for TransferControls {
     }
 }
 
+/// Cooperative cancellation shared by a transfer command and its executor.
+#[derive(Debug, Clone, Default)]
+pub struct TransferCancellation {
+    inner: Arc<TransferCancellationInner>,
+}
+
+#[derive(Debug, Default)]
+struct TransferCancellationInner {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
+impl TransferCancellation {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        if !self.inner.cancelled.swap(true, Ordering::AcqRel) {
+            self.inner.notify.notify_waiters();
+        }
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.inner.cancelled.load(Ordering::Acquire)
+    }
+
+    pub async fn cancelled(&self) {
+        let notified = self.inner.notify.notified();
+        tokio::pin!(notified);
+        notified.as_mut().enable();
+        if self.is_cancelled() {
+            return;
+        }
+        notified.await;
+    }
+}
+
 /// Result state for one candidate.
 #[derive(Debug)]
 pub enum TransferOutcomeState {
     Success { bytes_transferred: u64 },
     Failed { error: Error },
-    Cancelled,
+    Cancelled { error: Option<Error> },
 }
 
 /// Deterministically ordered result for one candidate.
@@ -222,6 +261,7 @@ pub struct TransferOutcome<T> {
 pub struct TransferReport<T> {
     pub summary: TransferSummary,
     pub outcomes: Vec<TransferOutcome<T>>,
+    pub was_cancelled: bool,
 }
 
 impl<T> TransferReport<T> {
@@ -231,7 +271,8 @@ impl<T> TransferReport<T> {
             .iter()
             .find_map(|outcome| match &outcome.state {
                 TransferOutcomeState::Failed { error } => Some(error),
-                TransferOutcomeState::Success { .. } | TransferOutcomeState::Cancelled => None,
+                TransferOutcomeState::Success { .. }
+                | TransferOutcomeState::Cancelled { error: _ } => None,
             })
     }
 }
@@ -255,6 +296,24 @@ impl TransferExecutor {
         F: Fn(TransferCandidate<T>) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = Result<u64>> + Send + 'static,
     {
+        self.execute_with_cancellation(plan, TransferCancellation::new(), operation)
+            .await
+    }
+
+    /// Execute candidates until completion, failure policy, or cooperative cancellation.
+    ///
+    /// Work already in flight is allowed to settle so callers can await backend cleanup.
+    pub async fn execute_with_cancellation<T, F, Fut>(
+        &self,
+        plan: TransferPlan<T>,
+        cancellation: TransferCancellation,
+        operation: F,
+    ) -> TransferReport<T>
+    where
+        T: Clone + Send + Sync + 'static,
+        F: Fn(TransferCandidate<T>) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = Result<u64>> + Send + 'static,
+    {
         let mut summary = plan.summary;
         let items = plan.items;
         let operation = Arc::new(operation);
@@ -262,26 +321,52 @@ impl TransferExecutor {
         let mut in_flight = FuturesUnordered::new();
         let mut completed = BTreeMap::new();
         let mut next_index = 0usize;
-        let mut stop_scheduling = false;
+        let mut was_cancelled = cancellation.is_cancelled();
+        let mut stop_scheduling = was_cancelled;
 
-        while next_index < items.len() && in_flight.len() < self.controls.concurrency {
+        while !stop_scheduling
+            && next_index < items.len()
+            && in_flight.len() < self.controls.concurrency
+        {
             in_flight.push(execute_candidate(
                 next_index,
                 items[next_index].clone(),
                 Arc::clone(&operation),
                 Arc::clone(&rate_gate),
                 self.controls.retry.clone(),
+                cancellation.clone(),
             ));
             next_index += 1;
         }
 
-        while let Some((index, result)) = in_flight.next().await {
+        while !in_flight.is_empty() {
+            let next = if stop_scheduling {
+                in_flight.next().await
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => {
+                        was_cancelled = true;
+                        stop_scheduling = true;
+                        continue;
+                    }
+                    next = in_flight.next() => next,
+                }
+            };
+            let Some((index, result)) = next else {
+                break;
+            };
             let failed = result.is_err();
             completed.insert(index, result);
 
             if failed && !self.controls.continue_on_error {
                 // Work that has already started is allowed to settle so the report never marks a
                 // completed side effect as cancelled. No additional candidates are scheduled.
+                stop_scheduling = true;
+            }
+
+            if cancellation.is_cancelled() {
+                was_cancelled = true;
                 stop_scheduling = true;
             }
 
@@ -292,11 +377,15 @@ impl TransferExecutor {
                     Arc::clone(&operation),
                     Arc::clone(&rate_gate),
                     self.controls.retry.clone(),
+                    cancellation.clone(),
                 ));
                 next_index += 1;
             }
         }
         drop(in_flight);
+        if cancellation.is_cancelled() {
+            was_cancelled = true;
+        }
 
         let mut outcomes = Vec::with_capacity(items.len());
         for (index, item) in items.into_iter().enumerate() {
@@ -307,19 +396,27 @@ impl TransferExecutor {
                         summary.transferred_bytes.saturating_add(bytes_transferred);
                     TransferOutcomeState::Success { bytes_transferred }
                 }
+                Some(Err(error @ Error::Interrupted(_))) => {
+                    summary.cancelled += 1;
+                    TransferOutcomeState::Cancelled { error: Some(error) }
+                }
                 Some(Err(error)) => {
                     summary.failed += 1;
                     TransferOutcomeState::Failed { error }
                 }
                 None => {
                     summary.cancelled += 1;
-                    TransferOutcomeState::Cancelled
+                    TransferOutcomeState::Cancelled { error: None }
                 }
             };
             outcomes.push(TransferOutcome { item, state });
         }
 
-        TransferReport { summary, outcomes }
+        TransferReport {
+            summary,
+            outcomes,
+            was_cancelled,
+        }
     }
 }
 
@@ -329,26 +426,56 @@ async fn execute_candidate<T, F, Fut>(
     operation: Arc<F>,
     rate_gate: Arc<RateGate>,
     retry: RetryConfig,
+    cancellation: TransferCancellation,
 ) -> (usize, Result<u64>)
 where
     T: Clone + Send + Sync + 'static,
     F: Fn(TransferCandidate<T>) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<u64>> + Send + 'static,
 {
-    let result = retry_with_backoff(
-        &retry,
-        || {
-            let item = item.clone();
-            let operation = Arc::clone(&operation);
-            let rate_gate = Arc::clone(&rate_gate);
-            async move {
-                rate_gate.wait(item.size_bytes.unwrap_or_default()).await;
-                operation(item).await
+    let mut attempt = 0;
+    let result = loop {
+        if cancellation.is_cancelled() {
+            break Err(Error::Interrupted("Transfer cancelled".to_string()));
+        }
+
+        attempt += 1;
+        let rate_wait = rate_gate.wait(item.size_bytes.unwrap_or_default());
+        tokio::pin!(rate_wait);
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => {
+                break Err(Error::Interrupted("Transfer cancelled".to_string()));
             }
-        },
-        is_retryable_error,
-    )
-    .await;
+            _ = &mut rate_wait => {}
+        }
+
+        // Once an operation starts it is allowed to settle so callers can complete backend
+        // cleanup. Cancellation is checked again before any retry is attempted.
+        match operation(item.clone()).await {
+            Ok(bytes) => break Ok(bytes),
+            Err(error) => {
+                if attempt >= retry.max_attempts || !is_retryable_error(&error) {
+                    break Err(error);
+                }
+
+                let backoff = calculate_backoff(&retry, attempt);
+                tracing::debug!(
+                    attempt,
+                    backoff_ms = backoff.as_millis(),
+                    error = %error,
+                    "Retrying transfer after transient error"
+                );
+                tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => {
+                        break Err(Error::Interrupted("Transfer cancelled".to_string()));
+                    }
+                    _ = sleep(backoff) => {}
+                }
+            }
+        }
+    };
     (index, result)
 }
 
@@ -680,5 +807,170 @@ mod tests {
         assert_eq!(report.summary.successful, 1);
         assert_eq!(report.summary.failed, 1);
         assert_eq!(report.summary.cancelled, 1);
+    }
+
+    #[tokio::test]
+    async fn cooperative_cancellation_stops_scheduling_and_drains_started_work() {
+        let controls = TransferControls {
+            concurrency: 2,
+            retry: RetryConfig {
+                max_attempts: 1,
+                ..RetryConfig::default()
+            },
+            continue_on_error: true,
+            ..TransferControls::default()
+        };
+        let executor = TransferExecutor::new(controls).expect("valid controls");
+        let cancellation = TransferCancellation::new();
+        let plan = TransferPlan::build(
+            vec![
+                candidate("a", None, 1),
+                candidate("b", None, 1),
+                candidate("c", None, 1),
+            ],
+            &TransferSelection::default(),
+        );
+        let started = Arc::new(AtomicUsize::new(0));
+        let release = Arc::new(tokio::sync::Semaphore::new(0));
+
+        let task = tokio::spawn({
+            let cancellation = cancellation.clone();
+            let started = Arc::clone(&started);
+            let release = Arc::clone(&release);
+            async move {
+                executor
+                    .execute_with_cancellation(plan, cancellation, move |_| {
+                        let started = Arc::clone(&started);
+                        let release = Arc::clone(&release);
+                        async move {
+                            started.fetch_add(1, Ordering::SeqCst);
+                            release.acquire().await.expect("release semaphore").forget();
+                            Ok(1)
+                        }
+                    })
+                    .await
+            }
+        });
+
+        while started.load(Ordering::SeqCst) < 2 {
+            tokio::task::yield_now().await;
+        }
+        cancellation.cancel();
+        release.add_permits(2);
+        let report = task.await.expect("executor task");
+
+        assert!(report.was_cancelled);
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        assert_eq!(report.summary.successful, 2);
+        assert_eq!(report.summary.cancelled, 1);
+    }
+
+    #[tokio::test]
+    async fn cancellation_during_retry_backoff_does_not_start_another_attempt() {
+        let controls = TransferControls {
+            concurrency: 1,
+            retry: RetryConfig {
+                max_attempts: 3,
+                initial_backoff_ms: 10_000,
+                max_backoff_ms: 10_000,
+            },
+            continue_on_error: true,
+            ..TransferControls::default()
+        };
+        let executor = TransferExecutor::new(controls).expect("valid controls");
+        let cancellation = TransferCancellation::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let first_attempt = Arc::new(tokio::sync::Semaphore::new(0));
+        let plan = TransferPlan::build(
+            vec![candidate("retry", None, 1)],
+            &TransferSelection::default(),
+        );
+
+        let task = tokio::spawn({
+            let cancellation = cancellation.clone();
+            let calls = Arc::clone(&calls);
+            let first_attempt = Arc::clone(&first_attempt);
+            async move {
+                executor
+                    .execute_with_cancellation(plan, cancellation, move |_| {
+                        let calls = Arc::clone(&calls);
+                        let first_attempt = Arc::clone(&first_attempt);
+                        async move {
+                            calls.fetch_add(1, Ordering::SeqCst);
+                            first_attempt.add_permits(1);
+                            Err(Error::Network("503 Service Unavailable".to_string()))
+                        }
+                    })
+                    .await
+            }
+        });
+
+        first_attempt
+            .acquire()
+            .await
+            .expect("first attempt semaphore")
+            .forget();
+        cancellation.cancel();
+        let report = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("cancellation should interrupt retry backoff")
+            .expect("executor task");
+
+        assert!(report.was_cancelled);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(report.summary.failed, 0);
+        assert_eq!(report.summary.cancelled, 1);
+    }
+
+    #[tokio::test]
+    async fn simultaneous_completion_and_cancellation_never_schedules_more_work() {
+        for _ in 0..100 {
+            let controls = TransferControls {
+                concurrency: 1,
+                retry: RetryConfig {
+                    max_attempts: 1,
+                    ..RetryConfig::default()
+                },
+                continue_on_error: true,
+                ..TransferControls::default()
+            };
+            let executor = TransferExecutor::new(controls).expect("valid controls");
+            let cancellation = TransferCancellation::new();
+            let started = Arc::new(AtomicUsize::new(0));
+            let release = Arc::new(tokio::sync::Semaphore::new(0));
+            let plan = TransferPlan::build(
+                vec![candidate("a", None, 1), candidate("b", None, 1)],
+                &TransferSelection::default(),
+            );
+
+            let task = tokio::spawn({
+                let cancellation = cancellation.clone();
+                let started = Arc::clone(&started);
+                let release = Arc::clone(&release);
+                async move {
+                    executor
+                        .execute_with_cancellation(plan, cancellation, move |_| {
+                            let started = Arc::clone(&started);
+                            let release = Arc::clone(&release);
+                            async move {
+                                started.fetch_add(1, Ordering::SeqCst);
+                                release.acquire().await.expect("release semaphore").forget();
+                                Ok(1)
+                            }
+                        })
+                        .await
+                }
+            });
+
+            while started.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+            cancellation.cancel();
+            release.add_permits(1);
+            let report = task.await.expect("executor task");
+
+            assert!(report.was_cancelled);
+            assert_eq!(started.load(Ordering::SeqCst), 1);
+        }
     }
 }

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -3701,6 +3701,12 @@ impl ObjectStore for S3Client {
     ) -> Result<MultipartCopyResult> {
         use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 
+        if cancellation.is_cancelled() {
+            return Err(self.redact_sensitive_error(Error::Interrupted(
+                "Multipart copy cancelled before upload creation".to_string(),
+            )));
+        }
+
         let plan = options
             .plan()
             .map_err(|error| self.redact_sensitive_error(error))?;
@@ -7876,6 +7882,24 @@ mod tests {
             .metadata
             .insert("owner".to_string(), "copy-test".to_string());
         options
+    }
+
+    #[tokio::test]
+    async fn multipart_copy_cancelled_before_start_sends_no_requests() {
+        let (client, replay) = test_s3_client_with_response_sequence(vec![]);
+        let src = RemotePath::new("test", "source-bucket", "src.bin");
+        let dst = RemotePath::new("test", "destination-bucket", "dst.bin");
+        let options = multipart_copy_options(S3_MULTIPART_COPY_MIN_PART_SIZE);
+        let cancellation = MultipartCopyCancellation::new();
+        cancellation.cancel();
+
+        let error = client
+            .multipart_copy(&src, &dst, &options, &cancellation, None, &|_| {})
+            .await
+            .expect_err("pre-cancelled copy should be interrupted");
+
+        assert!(matches!(error, Error::Interrupted(_)));
+        assert!(replay.actual_requests().next().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related issue

Closes rustfs/backlog#1439
Parent roadmap: rustfs/backlog#1370
Depends on merged multipart copy primitive PR #301.

## Background and user impact

Recursive remote-to-remote copy previously stopped at the CLI boundary even though RustFS now exposes the required same-endpoint server-side copy primitives. Users could not safely copy complete prefixes without scripting individual object operations.

## Solution

- Traverse and paginate the complete source prefix before any mutation, then produce deterministic source-to-destination mappings.
- Reject overlapping prefixes, self copies, duplicate destinations, missing pagination tokens, and repeated pagination tokens during preflight.
- Reuse one S3 client pool per alias and the shared transfer executor for bounded concurrency, rate limiting, retry policy, and deterministic outcomes.
- Route objects at or below 5 GiB through CopyObject and larger objects through multipart server-side copy with source identity checks.
- Support dry run, continue-on-error, fail-empty, explicit skip-existing behavior, logical-byte progress, and deterministic summaries.
- Preserve source/destination versions and multipart upload IDs in human results, and retain abort cleanup details after failures or cancellation.
- Make cancellation race-safe across scheduling, rate waits, retry backoff, small CopyObject, and multipart cleanup; interrupted work is counted as cancelled and exits 130.
- Add the RustFS beta.10 recursive-copy integration smoke test.

## Compatibility

- Cross-alias and cross-endpoint streaming copy remain out of scope.
- Planned/bulk JSON output remains explicitly unsupported until a versioned output contract is introduced.
- No protected CLI, JSON, exit-code, or configuration contract files are changed.

## Validation

- cargo fmt --all --check
- cargo clippy --workspace --all-targets -- -D warnings
- CARGO_BUILD_JOBS=2 cargo test --workspace
- Recursive remote-copy black-box suite: 11 tests, including 1001-object pagination, mapping, overlap, empty prefix, skip-existing, partial failure, 5 GiB multipart routing, abort cleanup, and SIGINT exit 130.
- Flake check: recursive suite passed five consecutive full runs before final additions; final full workspace run passed with all 11 cases.
