### PR TITLE
feat(core): add transfer fidelity option models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2647,10 +2647,12 @@ version = "0.1.24"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "dirs",
  "futures",
  "getrandom 0.4.3",
  "glob",
+ "http 1.4.2",
  "humansize",
  "jiff",
  "mockall",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ http-body = "1.0"
 http-body-util = "0.1"
 sha2 = "0.10"
 hex = "0.4"
+base64 = "0.22"
 urlencoding = "2.1"
 
 # Testing

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -40,6 +40,8 @@ rustls-pki-types.workspace = true
 x509-parser.workspace = true
 zeroize.workspace = true
 getrandom.workspace = true
+base64.workspace = true
+http.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,6 +25,7 @@ pub mod retry;
 pub mod select;
 pub mod traits;
 pub mod transfer;
+pub mod transfer_options;
 pub mod undo;
 pub mod watch;
 
@@ -76,6 +77,11 @@ pub use traits::{
 pub use transfer::{
     TransferCancellation, TransferCandidate, TransferControls, TransferExecutor, TransferOutcome,
     TransferOutcomeState, TransferPlan, TransferReport, TransferSelection, TransferSummary,
+};
+pub use transfer_options::{
+    ChecksumAlgorithm, ChecksumRequest, MetadataDirective, ObjectAttributes, ObjectChecksum,
+    ObjectTransferMetadata, ObjectWriteEncryption, ObjectWriteOptions, SseCustomerKey,
+    TaggingDirective, TransferCopyOptions, TransferReadOptions,
 };
 pub use undo::{
     UndoAction, UndoObjectResult, UndoOutcome, UndoPlan, UndoPlanItem, plan_object_undo,

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -26,6 +26,9 @@ use crate::replication::{
     ReplicationResyncStatus,
 };
 use crate::select::SelectOptions;
+use crate::transfer_options::{
+    ObjectTransferMetadata, ObjectWriteOptions, TransferCopyOptions, TransferReadOptions,
+};
 
 /// Requested behavior for bucket creation.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -460,6 +463,30 @@ pub trait ObjectStore: Send + Sync {
         self.head_object(path).await
     }
 
+    /// Get metadata with checksum-mode and SSE-C support when implemented by the backend.
+    ///
+    /// The default preserves legacy version selection and rejects advanced options explicitly.
+    async fn head_object_with_transfer_options(
+        &self,
+        path: &RemotePath,
+        options: &TransferReadOptions,
+    ) -> Result<ObjectInfo> {
+        let legacy = options.legacy_read_options()?;
+        self.head_object_with_options(path, &legacy).await
+    }
+
+    /// Read complete transfer metadata without changing ObjectInfo's stable output contract.
+    async fn head_object_transfer_metadata(
+        &self,
+        _path: &RemotePath,
+        options: &TransferReadOptions,
+    ) -> Result<ObjectTransferMetadata> {
+        options.validate()?;
+        Err(Error::UnsupportedFeature(
+            "Complete transfer metadata is not implemented by this object store".to_string(),
+        ))
+    }
+
     /// Check if a bucket exists
     async fn bucket_exists(&self, bucket: &str) -> Result<bool>;
 
@@ -516,6 +543,18 @@ pub trait ObjectStore: Send + Sync {
         self.get_object(path).await
     }
 
+    /// Read an object with checksum-mode and SSE-C support when implemented by the backend.
+    ///
+    /// The default preserves legacy version selection and rejects advanced options explicitly.
+    async fn get_object_with_transfer_options(
+        &self,
+        path: &RemotePath,
+        options: &TransferReadOptions,
+    ) -> Result<Vec<u8>> {
+        let legacy = options.legacy_read_options()?;
+        self.get_object_with_options(path, &legacy).await
+    }
+
     /// Stream current object content or an exact historical version to a writer.
     async fn write_object_to_with_options(
         &self,
@@ -534,6 +573,21 @@ pub trait ObjectStore: Send + Sync {
         Ok(write_len as u64)
     }
 
+    /// Stream an object with checksum-mode and SSE-C support when implemented by the backend.
+    ///
+    /// The default preserves legacy version selection and rejects advanced options explicitly.
+    async fn write_object_to_with_transfer_options(
+        &self,
+        path: &RemotePath,
+        options: &TransferReadOptions,
+        writer: &mut (dyn AsyncWrite + Send + Unpin),
+        max_bytes: Option<u64>,
+    ) -> Result<u64> {
+        let legacy = options.legacy_read_options()?;
+        self.write_object_to_with_options(path, &legacy, writer, max_bytes)
+            .await
+    }
+
     /// Upload object from bytes
     async fn put_object(
         &self,
@@ -542,6 +596,20 @@ pub trait ObjectStore: Send + Sync {
         content_type: Option<&str>,
         encryption: Option<&ObjectEncryptionRequest>,
     ) -> Result<ObjectInfo>;
+
+    /// Upload an object with complete transfer-fidelity options.
+    ///
+    /// The default delegates Content-Type and managed encryption to the legacy API and rejects
+    /// every option that cannot be represented there.
+    async fn put_object_with_options(
+        &self,
+        path: &RemotePath,
+        data: Vec<u8>,
+        options: &ObjectWriteOptions,
+    ) -> Result<ObjectInfo> {
+        let (content_type, encryption) = options.legacy_put_arguments()?;
+        self.put_object(path, data, content_type, encryption).await
+    }
 
     /// Delete an object
     async fn delete_object(&self, path: &RemotePath) -> Result<()>;
@@ -606,6 +674,21 @@ pub trait ObjectStore: Send + Sync {
         self.copy_object(src, dst, encryption).await
     }
 
+    /// Copy an object with explicit metadata, tags, checksum, SSE-C, and lock intent.
+    ///
+    /// The default preserves legacy source-version and managed-encryption behavior while
+    /// rejecting every advanced option that the original API cannot represent.
+    async fn copy_object_with_transfer_options(
+        &self,
+        src: &RemotePath,
+        dst: &RemotePath,
+        options: &TransferCopyOptions,
+    ) -> Result<ObjectInfo> {
+        let (legacy, encryption) = options.legacy_copy_arguments()?;
+        self.copy_object_with_options(src, dst, &legacy, encryption)
+            .await
+    }
+
     /// Copy an object with S3's multipart server-side copy lifecycle.
     ///
     /// Backends that do not implement multipart copy fail explicitly. The
@@ -622,6 +705,25 @@ pub trait ObjectStore: Send + Sync {
         Err(Error::UnsupportedFeature(
             "Multipart server-side copy is not implemented by this object store".to_string(),
         ))
+    }
+
+    /// Copy an object through the multipart lifecycle with transfer-fidelity options.
+    ///
+    /// The default delegates only when all requested fidelity can be represented by the legacy
+    /// multipart API. Implementations must override this method before accepting advanced fields.
+    async fn multipart_copy_with_transfer_options(
+        &self,
+        src: &RemotePath,
+        dst: &RemotePath,
+        multipart: &MultipartCopyOptions,
+        transfer: &TransferCopyOptions,
+        cancellation: &MultipartCopyCancellation,
+        on_progress: &MultipartCopyProgress<'_>,
+    ) -> Result<MultipartCopyResult> {
+        transfer.validate_multipart_source_version(multipart.source_version_id.as_deref())?;
+        let (_, encryption) = transfer.legacy_copy_arguments()?;
+        self.multipart_copy(src, dst, multipart, cancellation, encryption, on_progress)
+            .await
     }
 
     /// Generate a presigned URL for an object

--- a/crates/core/src/transfer_options.rs
+++ b/crates/core/src/transfer_options.rs
@@ -1,0 +1,559 @@
+//! Backend-neutral options for faithful object reads, writes, and copies.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use http::header::{HeaderName, HeaderValue};
+use jiff::Timestamp;
+use zeroize::Zeroizing;
+
+use crate::encryption::ObjectEncryptionRequest;
+use crate::object_lock::{LegalHoldStatus, ObjectRetention};
+use crate::traits::{CopyObjectOptions, ObjectReadOptions};
+use crate::{Error, Result};
+
+/// Standard HTTP object attributes and user-defined metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObjectAttributes {
+    /// Media type stored with the object.
+    pub content_type: Option<String>,
+    /// Cache policy stored with the object.
+    pub cache_control: Option<String>,
+    /// Content disposition stored with the object.
+    pub content_disposition: Option<String>,
+    /// Content encoding stored with the object.
+    pub content_encoding: Option<String>,
+    /// Content language stored with the object.
+    pub content_language: Option<String>,
+    /// Optional expiry timestamp stored with the object.
+    pub expires: Option<Timestamp>,
+    /// User-defined metadata without the protocol header prefix.
+    pub user_metadata: HashMap<String, String>,
+}
+
+impl ObjectAttributes {
+    /// Validate values that would otherwise be ambiguous at the S3 boundary.
+    pub fn validate(&self) -> Result<()> {
+        for (name, value) in [
+            ("Content-Type", self.content_type.as_deref()),
+            ("Cache-Control", self.cache_control.as_deref()),
+            ("Content-Disposition", self.content_disposition.as_deref()),
+            ("Content-Encoding", self.content_encoding.as_deref()),
+            ("Content-Language", self.content_language.as_deref()),
+        ] {
+            if let Some(value) = value {
+                if value.trim().is_empty() {
+                    return Err(Error::InvalidPath(format!("{name} cannot be empty")));
+                }
+                HeaderValue::from_str(value).map_err(|_| {
+                    Error::InvalidPath(format!("{name} contains invalid HTTP header characters"))
+                })?;
+            }
+        }
+        for (key, value) in &self.user_metadata {
+            if key.trim().is_empty() {
+                return Err(Error::InvalidPath(
+                    "User metadata keys cannot be empty".to_string(),
+                ));
+            }
+            let header_name = format!("x-amz-meta-{key}");
+            HeaderName::from_bytes(header_name.as_bytes()).map_err(|_| {
+                Error::InvalidPath(format!(
+                    "User metadata key '{key}' cannot be represented as an HTTP header"
+                ))
+            })?;
+            HeaderValue::from_str(value).map_err(|_| {
+                Error::InvalidPath(format!(
+                    "User metadata value for '{key}' contains invalid HTTP header characters"
+                ))
+            })?;
+        }
+        Ok(())
+    }
+
+    fn contains_only_content_type(&self) -> bool {
+        self.cache_control.is_none()
+            && self.content_disposition.is_none()
+            && self.content_encoding.is_none()
+            && self.content_language.is_none()
+            && self.expires.is_none()
+            && self.user_metadata.is_empty()
+    }
+}
+
+/// How CopyObject handles source metadata.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetadataDirective {
+    /// Copy metadata from the selected source object.
+    Copy,
+    /// Replace source metadata with the provided destination attributes.
+    Replace,
+}
+
+/// How CopyObject handles source tags.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TaggingDirective {
+    /// Copy tags from the selected source object.
+    Copy,
+    /// Replace source tags with the provided destination tags.
+    Replace,
+}
+
+/// Checksum algorithms understood by S3-compatible object APIs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChecksumAlgorithm {
+    /// CRC-32.
+    Crc32,
+    /// CRC-32C.
+    Crc32c,
+    /// CRC-64/NVME.
+    Crc64Nvme,
+    /// SHA-1.
+    Sha1,
+    /// SHA-256.
+    Sha256,
+}
+
+/// An encoded checksum paired with its algorithm.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectChecksum {
+    /// Algorithm used to calculate the checksum.
+    pub algorithm: ChecksumAlgorithm,
+    /// Protocol-encoded checksum value.
+    pub value: String,
+}
+
+/// How a destination checksum should be supplied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChecksumRequest {
+    /// Ask the adapter and service to calculate the selected algorithm.
+    Calculate(ChecksumAlgorithm),
+    /// Send a checksum that the caller already calculated.
+    Precomputed(ObjectChecksum),
+}
+
+impl ChecksumRequest {
+    fn validate(&self) -> Result<()> {
+        match self {
+            Self::Calculate(_) => Ok(()),
+            Self::Precomputed(checksum) => checksum.validate(),
+        }
+    }
+}
+
+/// Fidelity metadata returned independently of the stable ObjectInfo output contract.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObjectTransferMetadata {
+    /// Standard HTTP attributes and user-defined metadata.
+    pub attributes: ObjectAttributes,
+    /// Storage class reported by the service.
+    pub storage_class: Option<String>,
+    /// Persisted checksums reported by checksum-mode metadata reads.
+    pub checksums: Vec<ObjectChecksum>,
+}
+
+impl ObjectChecksum {
+    /// Build a checksum while rejecting an ambiguous empty value.
+    pub fn new(algorithm: ChecksumAlgorithm, value: impl Into<String>) -> Result<Self> {
+        let checksum = Self {
+            algorithm,
+            value: value.into(),
+        };
+        checksum.validate()?;
+        Ok(checksum)
+    }
+
+    /// Validate the checksum value before a request is attempted.
+    pub fn validate(&self) -> Result<()> {
+        if self.value.trim().is_empty() {
+            return Err(Error::InvalidPath(
+                "Object checksum value cannot be empty".to_string(),
+            ));
+        }
+        let decoded = BASE64_STANDARD
+            .decode(&self.value)
+            .map_err(|_| Error::InvalidPath("Object checksum must be valid Base64".to_string()))?;
+        let expected_length = match self.algorithm {
+            ChecksumAlgorithm::Crc32 | ChecksumAlgorithm::Crc32c => 4,
+            ChecksumAlgorithm::Crc64Nvme => 8,
+            ChecksumAlgorithm::Sha1 => 20,
+            ChecksumAlgorithm::Sha256 => 32,
+        };
+        if decoded.len() != expected_length {
+            return Err(Error::InvalidPath(format!(
+                "Object checksum for {:?} must decode to {expected_length} bytes",
+                self.algorithm
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// A 256-bit SSE-C key whose formatting never reveals key material.
+#[derive(Clone, PartialEq, Eq)]
+pub struct SseCustomerKey(Zeroizing<Vec<u8>>);
+
+impl SseCustomerKey {
+    /// Store an exact 256-bit key in zeroizing memory.
+    pub fn new(key: Vec<u8>) -> Result<Self> {
+        let key = Zeroizing::new(key);
+        if key.len() != 32 {
+            return Err(Error::InvalidPath(
+                "SSE-C keys must contain exactly 32 bytes".to_string(),
+            ));
+        }
+        Ok(Self(key))
+    }
+
+    /// Borrow key bytes for protocol adapters.
+    ///
+    /// Callers must not log, serialize, or include this value in errors.
+    pub fn expose_secret(&self) -> &[u8] {
+        self.0.as_slice()
+    }
+}
+
+impl fmt::Debug for SseCustomerKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str("SseCustomerKey([REDACTED])")
+    }
+}
+
+/// Encryption requested for a destination object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ObjectWriteEncryption {
+    /// Existing S3-managed or KMS-managed encryption request.
+    Managed(ObjectEncryptionRequest),
+    /// Customer-provided key used only for this transfer.
+    SseCustomer {
+        /// Redacted, zeroizing customer key.
+        key: SseCustomerKey,
+    },
+}
+
+impl From<ObjectEncryptionRequest> for ObjectWriteEncryption {
+    fn from(value: ObjectEncryptionRequest) -> Self {
+        Self::Managed(value)
+    }
+}
+
+/// Complete destination options for an object write or copy.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ObjectWriteOptions {
+    /// Attributes to store. `Some(Default::default())` represents an explicit empty replacement.
+    pub attributes: Option<ObjectAttributes>,
+    /// Tags to store. `Some(HashMap::new())` represents an explicit empty replacement.
+    pub tags: Option<HashMap<String, String>>,
+    /// Requested destination storage class.
+    pub storage_class: Option<String>,
+    /// Checksum supplied or selected for the write.
+    pub checksum: Option<ChecksumRequest>,
+    /// Destination encryption policy.
+    pub encryption: Option<ObjectWriteEncryption>,
+    /// Retention applied atomically with object creation.
+    pub retention: Option<ObjectRetention>,
+    /// Legal-hold state applied atomically with object creation.
+    pub legal_hold: Option<LegalHoldStatus>,
+}
+
+impl ObjectWriteOptions {
+    /// Validate fields before any backend mutation.
+    pub fn validate(&self) -> Result<()> {
+        if let Some(attributes) = &self.attributes {
+            attributes.validate()?;
+        }
+        if let Some(tags) = &self.tags {
+            if tags.len() > 10 {
+                return Err(Error::InvalidPath(
+                    "Objects can have at most 10 tags".to_string(),
+                ));
+            }
+            for (key, value) in tags {
+                let key_length = key.chars().count();
+                if !(1..=128).contains(&key_length) {
+                    return Err(Error::InvalidPath(
+                        "Object tag keys must contain between 1 and 128 characters".to_string(),
+                    ));
+                }
+                if value.chars().count() > 256 {
+                    return Err(Error::InvalidPath(
+                        "Object tag values cannot exceed 256 characters".to_string(),
+                    ));
+                }
+            }
+        }
+        if self
+            .storage_class
+            .as_deref()
+            .is_some_and(|value| value.trim().is_empty())
+        {
+            return Err(Error::InvalidPath(
+                "Storage class cannot be empty".to_string(),
+            ));
+        }
+        if let Some(checksum) = &self.checksum {
+            checksum.validate()?;
+        }
+        if matches!(
+            self.encryption.as_ref(),
+            Some(ObjectWriteEncryption::Managed(
+                ObjectEncryptionRequest::SseKms { key_id }
+            )) if key_id.trim().is_empty()
+        ) {
+            return Err(Error::InvalidPath("KMS key ID cannot be empty".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Translate the subset supported by the original ObjectStore put API.
+    ///
+    /// Backends use this to preserve compatibility without silently dropping advanced fields.
+    pub fn legacy_put_arguments(&self) -> Result<(Option<&str>, Option<&ObjectEncryptionRequest>)> {
+        self.validate()?;
+        let content_type = match &self.attributes {
+            Some(attributes) if attributes.contains_only_content_type() => {
+                attributes.content_type.as_deref()
+            }
+            Some(_) => {
+                return Err(Error::UnsupportedFeature(
+                    "Object attributes other than Content-Type require advanced write support"
+                        .to_string(),
+                ));
+            }
+            None => None,
+        };
+        if self.tags.is_some()
+            || self.storage_class.is_some()
+            || self.checksum.is_some()
+            || self.retention.is_some()
+            || self.legal_hold.is_some()
+        {
+            return Err(Error::UnsupportedFeature(
+                "Transfer fidelity options are not implemented by this object store".to_string(),
+            ));
+        }
+        let encryption = match self.encryption.as_ref() {
+            Some(ObjectWriteEncryption::Managed(request)) => Some(request),
+            Some(ObjectWriteEncryption::SseCustomer { .. }) => {
+                return Err(Error::UnsupportedFeature(
+                    "SSE-C writes are not implemented by this object store".to_string(),
+                ));
+            }
+            None => None,
+        };
+        Ok((content_type, encryption))
+    }
+
+    fn legacy_copy_encryption(&self) -> Result<Option<&ObjectEncryptionRequest>> {
+        self.validate()?;
+        if self.attributes.is_some()
+            || self.tags.is_some()
+            || self.storage_class.is_some()
+            || self.checksum.is_some()
+            || self.retention.is_some()
+            || self.legal_hold.is_some()
+        {
+            return Err(Error::UnsupportedFeature(
+                "Advanced copy destination options are not implemented by this object store"
+                    .to_string(),
+            ));
+        }
+        match self.encryption.as_ref() {
+            Some(ObjectWriteEncryption::Managed(request)) => Ok(Some(request)),
+            Some(ObjectWriteEncryption::SseCustomer { .. }) => Err(Error::UnsupportedFeature(
+                "Destination SSE-C is not implemented by this object store".to_string(),
+            )),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Advanced read options that do not change the legacy ObjectReadOptions contract.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TransferReadOptions {
+    /// Exact object version to select.
+    pub version_id: Option<String>,
+    /// Request persisted checksum fields from the backend.
+    pub checksum_mode: bool,
+    /// Customer key needed to read an SSE-C source object.
+    pub customer_key: Option<SseCustomerKey>,
+}
+
+impl TransferReadOptions {
+    /// Validate read selection before issuing a request.
+    pub fn validate(&self) -> Result<()> {
+        if self.version_id.as_deref().is_some_and(str::is_empty) {
+            return Err(Error::InvalidPath("Version ID cannot be empty".to_string()));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn legacy_read_options(&self) -> Result<ObjectReadOptions> {
+        self.validate()?;
+        if self.checksum_mode || self.customer_key.is_some() {
+            return Err(Error::UnsupportedFeature(
+                "Checksum-mode or SSE-C reads are not implemented by this object store".to_string(),
+            ));
+        }
+        ObjectReadOptions::for_version(self.version_id.clone())
+    }
+}
+
+impl From<ObjectReadOptions> for TransferReadOptions {
+    fn from(value: ObjectReadOptions) -> Self {
+        Self {
+            version_id: value.version_id,
+            ..Self::default()
+        }
+    }
+}
+
+/// Complete options for a faithful server-side object copy.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TransferCopyOptions {
+    /// Source version, checksum, and SSE-C selection.
+    pub source: TransferReadOptions,
+    /// Source metadata handling requested for the destination.
+    pub metadata_directive: Option<MetadataDirective>,
+    /// Source tag handling requested for the destination.
+    pub tagging_directive: Option<TaggingDirective>,
+    /// Destination attributes, tags, checksum, encryption, and lock state.
+    pub destination: ObjectWriteOptions,
+}
+
+impl TransferCopyOptions {
+    /// Validate directives and their replacement payloads before mutation.
+    pub fn validate(&self) -> Result<()> {
+        self.source.validate()?;
+        self.destination.validate()?;
+        match self.metadata_directive {
+            None | Some(MetadataDirective::Copy) if self.destination.attributes.is_some() => {
+                return Err(Error::InvalidPath(
+                    "Destination attributes require an explicit metadata REPLACE directive"
+                        .to_string(),
+                ));
+            }
+            Some(MetadataDirective::Replace) if self.destination.attributes.is_none() => {
+                return Err(Error::InvalidPath(
+                    "Metadata REPLACE requires an explicit attributes value".to_string(),
+                ));
+            }
+            _ => {}
+        }
+        match self.tagging_directive {
+            None | Some(TaggingDirective::Copy) if self.destination.tags.is_some() => {
+                return Err(Error::InvalidPath(
+                    "Destination tags require an explicit tagging REPLACE directive".to_string(),
+                ));
+            }
+            Some(TaggingDirective::Replace) if self.destination.tags.is_none() => {
+                return Err(Error::InvalidPath(
+                    "Tagging REPLACE requires an explicit tags value".to_string(),
+                ));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    pub(crate) fn legacy_copy_arguments(
+        &self,
+    ) -> Result<(CopyObjectOptions, Option<&ObjectEncryptionRequest>)> {
+        self.validate()?;
+        if self.metadata_directive.is_some() || self.tagging_directive.is_some() {
+            return Err(Error::UnsupportedFeature(
+                "Metadata or tagging directives are not implemented by this object store"
+                    .to_string(),
+            ));
+        }
+        let source = self.source.legacy_read_options()?;
+        let encryption = self.destination.legacy_copy_encryption()?;
+        let copy = CopyObjectOptions::for_source_version(source.version_id)?;
+        Ok((copy, encryption))
+    }
+
+    pub(crate) fn validate_multipart_source_version(
+        &self,
+        multipart_source_version_id: Option<&str>,
+    ) -> Result<()> {
+        if self.source.version_id.is_some()
+            && self.source.version_id.as_deref() != multipart_source_version_id
+        {
+            return Err(Error::InvalidPath(
+                "Transfer and multipart source version IDs must match".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn advanced_reads_cannot_fall_through_to_legacy_backends() {
+        let checksum_read = TransferReadOptions {
+            checksum_mode: true,
+            ..TransferReadOptions::default()
+        };
+        assert!(matches!(
+            checksum_read.legacy_read_options(),
+            Err(Error::UnsupportedFeature(_))
+        ));
+
+        let customer_key = SseCustomerKey::new(vec![3; 32]).expect("valid customer key");
+        let encrypted_read = TransferReadOptions {
+            customer_key: Some(customer_key),
+            ..TransferReadOptions::default()
+        };
+        assert!(matches!(
+            encrypted_read.legacy_read_options(),
+            Err(Error::UnsupportedFeature(_))
+        ));
+    }
+
+    #[test]
+    fn explicit_copy_directives_cannot_fall_through_to_legacy_backends() {
+        for options in [
+            TransferCopyOptions {
+                metadata_directive: Some(MetadataDirective::Copy),
+                ..TransferCopyOptions::default()
+            },
+            TransferCopyOptions {
+                tagging_directive: Some(TaggingDirective::Copy),
+                ..TransferCopyOptions::default()
+            },
+        ] {
+            assert!(matches!(
+                options.legacy_copy_arguments(),
+                Err(Error::UnsupportedFeature(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn multipart_source_versions_must_match_when_transfer_selects_one() {
+        let options = TransferCopyOptions {
+            source: TransferReadOptions {
+                version_id: Some("source-v1".to_string()),
+                ..TransferReadOptions::default()
+            },
+            ..TransferCopyOptions::default()
+        };
+
+        options
+            .validate_multipart_source_version(Some("source-v1"))
+            .expect("matching source versions should be accepted");
+        assert!(matches!(
+            options.validate_multipart_source_version(Some("source-v2")),
+            Err(Error::InvalidPath(_))
+        ));
+        assert!(matches!(
+            options.validate_multipart_source_version(None),
+            Err(Error::InvalidPath(_))
+        ));
+    }
+}

--- a/crates/core/tests/transfer_options.rs
+++ b/crates/core/tests/transfer_options.rs
@@ -1,0 +1,333 @@
+use std::collections::HashMap;
+
+use rc_core::{
+    ChecksumAlgorithm, ChecksumRequest, Error, LegalHoldStatus, MetadataDirective,
+    ObjectAttributes, ObjectChecksum, ObjectEncryptionRequest, ObjectTransferMetadata,
+    ObjectWriteEncryption, ObjectWriteOptions, SseCustomerKey, TaggingDirective,
+    TransferCopyOptions, TransferReadOptions,
+};
+
+#[test]
+fn customer_key_requires_exactly_32_bytes_and_redacts_debug_output() {
+    let raw_key = b"0123456789abcdef0123456789abcdef".to_vec();
+    let key = SseCustomerKey::new(raw_key.clone()).expect("32-byte key should be accepted");
+
+    assert_eq!(key.expose_secret(), raw_key.as_slice());
+    let debug = format!("{key:?}");
+    assert!(debug.contains("REDACTED"));
+    assert!(!debug.contains("0123456789abcdef"));
+
+    assert!(matches!(
+        SseCustomerKey::new(vec![0; 31]),
+        Err(Error::InvalidPath(_))
+    ));
+    assert!(matches!(
+        SseCustomerKey::new(vec![0; 33]),
+        Err(Error::InvalidPath(_))
+    ));
+}
+
+#[test]
+fn write_options_reject_ambiguous_or_empty_values() {
+    let empty_storage_class = ObjectWriteOptions {
+        storage_class: Some("  ".to_string()),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(
+        empty_storage_class.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let mut metadata = HashMap::new();
+    metadata.insert(String::new(), "value".to_string());
+    let empty_metadata_key = ObjectWriteOptions {
+        attributes: Some(ObjectAttributes {
+            user_metadata: metadata,
+            ..ObjectAttributes::default()
+        }),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(
+        empty_metadata_key.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let empty_checksum = ObjectWriteOptions {
+        checksum: Some(ChecksumRequest::Precomputed(ObjectChecksum {
+            algorithm: ChecksumAlgorithm::Sha256,
+            value: String::new(),
+        })),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(
+        empty_checksum.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let empty_kms_key = ObjectWriteOptions {
+        encryption: Some(ObjectWriteEncryption::Managed(
+            ObjectEncryptionRequest::SseKms {
+                key_id: " ".to_string(),
+            },
+        )),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(
+        empty_kms_key.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+}
+
+#[test]
+fn attributes_reject_invalid_http_header_names_and_values() {
+    for attributes in [
+        ObjectAttributes {
+            cache_control: Some("max-age=60\r\nx-injected: true".to_string()),
+            ..ObjectAttributes::default()
+        },
+        ObjectAttributes {
+            user_metadata: HashMap::from([("bad key".to_string(), "value".to_string())]),
+            ..ObjectAttributes::default()
+        },
+        ObjectAttributes {
+            user_metadata: HashMap::from([(
+                "safe-key".to_string(),
+                "value\nx-injected: true".to_string(),
+            )]),
+            ..ObjectAttributes::default()
+        },
+    ] {
+        assert!(matches!(attributes.validate(), Err(Error::InvalidPath(_))));
+    }
+}
+
+#[test]
+fn object_tags_enforce_s3_count_and_character_limits() {
+    let eleven_tags = (0..11)
+        .map(|index| (format!("key-{index}"), String::new()))
+        .collect();
+    let too_many = ObjectWriteOptions {
+        tags: Some(eleven_tags),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(too_many.validate(), Err(Error::InvalidPath(_))));
+
+    for tags in [
+        HashMap::from([("k".repeat(129), String::new())]),
+        HashMap::from([("key".to_string(), "v".repeat(257))]),
+    ] {
+        let options = ObjectWriteOptions {
+            tags: Some(tags),
+            ..ObjectWriteOptions::default()
+        };
+        assert!(matches!(options.validate(), Err(Error::InvalidPath(_))));
+    }
+
+    let boundary = ObjectWriteOptions {
+        tags: Some(HashMap::from([("k".repeat(128), "v".repeat(256))])),
+        ..ObjectWriteOptions::default()
+    };
+    boundary
+        .validate()
+        .expect("maximum tag key and value lengths should be accepted");
+}
+
+#[test]
+fn copy_options_require_explicit_replace_payloads() {
+    let missing_metadata = TransferCopyOptions {
+        metadata_directive: Some(MetadataDirective::Replace),
+        ..TransferCopyOptions::default()
+    };
+    assert!(matches!(
+        missing_metadata.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let missing_tags = TransferCopyOptions {
+        tagging_directive: Some(TaggingDirective::Replace),
+        ..TransferCopyOptions::default()
+    };
+    assert!(matches!(
+        missing_tags.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let explicit_empty_replacements = TransferCopyOptions {
+        metadata_directive: Some(MetadataDirective::Replace),
+        tagging_directive: Some(TaggingDirective::Replace),
+        destination: ObjectWriteOptions {
+            attributes: Some(ObjectAttributes::default()),
+            tags: Some(HashMap::new()),
+            ..ObjectWriteOptions::default()
+        },
+        ..TransferCopyOptions::default()
+    };
+    explicit_empty_replacements
+        .validate()
+        .expect("explicit empty replacement payloads should be valid");
+}
+
+#[test]
+fn copy_options_reject_values_that_conflict_with_copy_directives() {
+    let metadata_conflict = TransferCopyOptions {
+        metadata_directive: Some(MetadataDirective::Copy),
+        destination: ObjectWriteOptions {
+            attributes: Some(ObjectAttributes::default()),
+            ..ObjectWriteOptions::default()
+        },
+        ..TransferCopyOptions::default()
+    };
+    assert!(matches!(
+        metadata_conflict.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let tag_conflict = TransferCopyOptions {
+        tagging_directive: Some(TaggingDirective::Copy),
+        destination: ObjectWriteOptions {
+            tags: Some(HashMap::new()),
+            ..ObjectWriteOptions::default()
+        },
+        ..TransferCopyOptions::default()
+    };
+    assert!(matches!(
+        tag_conflict.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let implicit_metadata_replace = TransferCopyOptions {
+        destination: ObjectWriteOptions {
+            attributes: Some(ObjectAttributes::default()),
+            ..ObjectWriteOptions::default()
+        },
+        ..TransferCopyOptions::default()
+    };
+    assert!(matches!(
+        implicit_metadata_replace.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+
+    let implicit_tag_replace = TransferCopyOptions {
+        destination: ObjectWriteOptions {
+            tags: Some(HashMap::new()),
+            ..ObjectWriteOptions::default()
+        },
+        ..TransferCopyOptions::default()
+    };
+    assert!(matches!(
+        implicit_tag_replace.validate(),
+        Err(Error::InvalidPath(_))
+    ));
+}
+
+#[test]
+fn read_options_reject_an_empty_version() {
+    let options = TransferReadOptions {
+        version_id: Some(String::new()),
+        ..TransferReadOptions::default()
+    };
+
+    assert!(matches!(options.validate(), Err(Error::InvalidPath(_))));
+}
+
+#[test]
+fn advanced_write_options_are_not_legacy_compatible() {
+    let basic = ObjectWriteOptions {
+        attributes: Some(ObjectAttributes {
+            content_type: Some("text/plain".to_string()),
+            ..ObjectAttributes::default()
+        }),
+        ..ObjectWriteOptions::default()
+    };
+    basic
+        .legacy_put_arguments()
+        .expect("content type should map to the legacy put API");
+
+    let advanced = ObjectWriteOptions {
+        legal_hold: Some(LegalHoldStatus::On),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(
+        advanced.legacy_put_arguments(),
+        Err(Error::UnsupportedFeature(_))
+    ));
+}
+
+#[test]
+fn customer_encryption_is_never_legacy_compatible() {
+    let key = SseCustomerKey::new(vec![7; 32]).expect("valid key");
+    let options = ObjectWriteOptions {
+        encryption: Some(ObjectWriteEncryption::SseCustomer { key }),
+        ..ObjectWriteOptions::default()
+    };
+
+    assert!(matches!(
+        options.legacy_put_arguments(),
+        Err(Error::UnsupportedFeature(_))
+    ));
+}
+
+#[test]
+fn nested_transfer_options_never_expose_customer_keys() {
+    let raw_key = b"0123456789abcdef0123456789abcdef";
+    let key = SseCustomerKey::new(raw_key.to_vec()).expect("valid key");
+    let write = ObjectWriteOptions {
+        encryption: Some(ObjectWriteEncryption::SseCustomer { key: key.clone() }),
+        ..ObjectWriteOptions::default()
+    };
+    let copy = TransferCopyOptions {
+        source: TransferReadOptions {
+            customer_key: Some(key),
+            ..TransferReadOptions::default()
+        },
+        destination: write.clone(),
+        ..TransferCopyOptions::default()
+    };
+
+    for debug in [format!("{write:?}"), format!("{copy:?}")] {
+        assert!(debug.contains("REDACTED"));
+        assert!(!debug.contains("0123456789abcdef"));
+    }
+}
+
+#[test]
+fn checksum_requests_distinguish_calculation_from_precomputed_values() {
+    let calculate = ObjectWriteOptions {
+        checksum: Some(ChecksumRequest::Calculate(ChecksumAlgorithm::Sha256)),
+        ..ObjectWriteOptions::default()
+    };
+    calculate
+        .validate()
+        .expect("calculated checksum request should not require a value");
+
+    let precomputed = ObjectWriteOptions {
+        checksum: Some(ChecksumRequest::Precomputed(ObjectChecksum {
+            algorithm: ChecksumAlgorithm::Sha256,
+            value: "  ".to_string(),
+        })),
+        ..ObjectWriteOptions::default()
+    };
+    assert!(matches!(precomputed.validate(), Err(Error::InvalidPath(_))));
+
+    for value in ["not-base64", "AA=="] {
+        assert!(matches!(
+            ObjectChecksum::new(ChecksumAlgorithm::Crc32, value),
+            Err(Error::InvalidPath(_))
+        ));
+    }
+    assert_eq!(
+        ObjectChecksum::new(ChecksumAlgorithm::Crc32, "AAAAAA==")
+            .expect("four encoded checksum bytes")
+            .value,
+        "AAAAAA=="
+    );
+}
+
+#[test]
+fn transfer_metadata_default_is_explicitly_empty() {
+    let metadata = ObjectTransferMetadata::default();
+
+    assert_eq!(metadata.attributes, ObjectAttributes::default());
+    assert!(metadata.storage_class.is_none());
+    assert!(metadata.checksums.is_empty());
+}

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -5109,7 +5109,11 @@ mod tests {
     use aws_smithy_http_client::test_util::{
         CaptureRequestReceiver, ReplayEvent, StaticReplayClient, capture_request,
     };
-    use rc_core::S3_MULTIPART_COPY_MIN_PART_SIZE;
+    use rc_core::{
+        ChecksumAlgorithm, ChecksumRequest, MetadataDirective, ObjectAttributes,
+        ObjectWriteEncryption, ObjectWriteOptions, S3_MULTIPART_COPY_MIN_PART_SIZE, SseCustomerKey,
+        TransferCopyOptions, TransferReadOptions,
+    };
     use std::collections::HashMap;
     use std::collections::VecDeque;
     use std::io::{Read, Write};
@@ -6933,6 +6937,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transfer_read_default_delegates_version_through_trait_object() {
+        let response = http::Response::builder()
+            .status(200)
+            .header("content-length", "3")
+            .header("x-amz-version-id", "v1")
+            .body(SdkBody::from(""))
+            .expect("build versioned head response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "bucket", "key.txt");
+        let store: &dyn ObjectStore = &client;
+        let options = TransferReadOptions {
+            version_id: Some("v1".to_string()),
+            ..TransferReadOptions::default()
+        };
+
+        let info = store
+            .head_object_with_transfer_options(&path, &options)
+            .await
+            .expect("legacy-compatible transfer metadata read");
+
+        let request = request_receiver.expect_request();
+        assert!(request.uri().to_string().contains("versionId=v1"));
+        assert_eq!(info.version_id.as_deref(), Some("v1"));
+    }
+
+    #[tokio::test]
     async fn exact_version_errors_distinguish_missing_versions_and_delete_markers() {
         let missing_response = http::Response::builder()
             .status(404)
@@ -7578,6 +7608,93 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transfer_put_default_delegates_through_object_store_trait_object() {
+        let response = http::Response::builder()
+            .status(200)
+            .body(SdkBody::from(""))
+            .expect("build put response");
+        let (client, request_receiver) = test_s3_client(Some(response));
+        let path = RemotePath::new("test", "bucket", "file.txt");
+        let store: &dyn ObjectStore = &client;
+        let options = ObjectWriteOptions {
+            attributes: Some(ObjectAttributes {
+                content_type: Some("text/plain".to_string()),
+                ..ObjectAttributes::default()
+            }),
+            ..ObjectWriteOptions::default()
+        };
+
+        store
+            .put_object_with_options(&path, b"payload".to_vec(), &options)
+            .await
+            .expect("legacy-compatible transfer put");
+
+        let request = request_receiver.expect_request();
+        assert_eq!(request.headers().get("content-type"), Some("text/plain"));
+    }
+
+    #[tokio::test]
+    async fn advanced_transfer_defaults_reject_before_backend_requests() {
+        let path = RemotePath::new("test", "bucket", "file.txt");
+
+        let (put_client, put_requests) = test_s3_client(None);
+        let put_store: &dyn ObjectStore = &put_client;
+        let put_error = put_store
+            .put_object_with_options(
+                &path,
+                b"payload".to_vec(),
+                &ObjectWriteOptions {
+                    checksum: Some(ChecksumRequest::Calculate(ChecksumAlgorithm::Sha256)),
+                    ..ObjectWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("advanced put must not silently degrade");
+        assert!(matches!(put_error, Error::UnsupportedFeature(_)));
+        put_requests.expect_no_request();
+
+        let (read_client, read_requests) = test_s3_client(None);
+        let read_store: &dyn ObjectStore = &read_client;
+        let read_options = TransferReadOptions {
+            customer_key: Some(SseCustomerKey::new(vec![9; 32]).expect("valid customer key")),
+            ..TransferReadOptions::default()
+        };
+        let read_error = read_store
+            .get_object_with_transfer_options(&path, &read_options)
+            .await
+            .expect_err("advanced read must not silently degrade");
+        assert!(matches!(read_error, Error::UnsupportedFeature(_)));
+        let mut sink = tokio::io::sink();
+        let stream_error = read_store
+            .write_object_to_with_transfer_options(&path, &read_options, &mut sink, None)
+            .await
+            .expect_err("advanced streaming read must not silently degrade");
+        assert!(matches!(stream_error, Error::UnsupportedFeature(_)));
+        let metadata_error = read_store
+            .head_object_transfer_metadata(&path, &TransferReadOptions::default())
+            .await
+            .expect_err("complete transfer metadata needs an explicit backend implementation");
+        assert!(matches!(metadata_error, Error::UnsupportedFeature(_)));
+        read_requests.expect_no_request();
+
+        let (copy_client, copy_requests) = test_s3_client(None);
+        let copy_store: &dyn ObjectStore = &copy_client;
+        let copy_error = copy_store
+            .copy_object_with_transfer_options(
+                &path,
+                &RemotePath::new("test", "bucket", "copy.txt"),
+                &TransferCopyOptions {
+                    metadata_directive: Some(MetadataDirective::Copy),
+                    ..TransferCopyOptions::default()
+                },
+            )
+            .await
+            .expect_err("explicit copy directive must not silently degrade");
+        assert!(matches!(copy_error, Error::UnsupportedFeature(_)));
+        copy_requests.expect_no_request();
+    }
+
+    #[tokio::test]
     async fn kms_diagnostic_put_uses_sse_kms_and_sensitive_body() {
         let response = http::Response::builder()
             .status(200)
@@ -7900,6 +8017,76 @@ mod tests {
 
         assert!(matches!(error, Error::Interrupted(_)));
         assert!(replay.actual_requests().next().is_none());
+    }
+
+    #[tokio::test]
+    async fn multipart_transfer_default_validates_versions_and_delegates() {
+        let src = RemotePath::new("test", "source-bucket", "src.bin");
+        let dst = RemotePath::new("test", "destination-bucket", "dst.bin");
+        let multipart = multipart_copy_options(S3_MULTIPART_COPY_MIN_PART_SIZE);
+        let mismatched = TransferCopyOptions {
+            source: TransferReadOptions {
+                version_id: Some("different-version".to_string()),
+                ..TransferReadOptions::default()
+            },
+            ..TransferCopyOptions::default()
+        };
+        let (mismatch_client, mismatch_replay) = test_s3_client_with_response_sequence(vec![]);
+        let mismatch_store: &dyn ObjectStore = &mismatch_client;
+
+        let mismatch_error = mismatch_store
+            .multipart_copy_with_transfer_options(
+                &src,
+                &dst,
+                &multipart,
+                &mismatched,
+                &MultipartCopyCancellation::new(),
+                &|_| {},
+            )
+            .await
+            .expect_err("mismatched versions must fail before multipart create");
+        assert!(matches!(mismatch_error, Error::InvalidPath(_)));
+        assert!(mismatch_replay.actual_requests().next().is_none());
+
+        let (client, replay) = test_s3_client_with_response_sequence(vec![
+            multipart_copy_create_response("transfer-upload-id"),
+            multipart_copy_part_response("part-1", Some("source v1+/?")),
+            multipart_copy_complete_response(),
+        ]);
+        let store: &dyn ObjectStore = &client;
+        let transfer = TransferCopyOptions {
+            source: TransferReadOptions {
+                version_id: multipart.source_version_id.clone(),
+                ..TransferReadOptions::default()
+            },
+            destination: ObjectWriteOptions {
+                encryption: Some(ObjectWriteEncryption::Managed(
+                    ObjectEncryptionRequest::SseS3,
+                )),
+                ..ObjectWriteOptions::default()
+            },
+            ..TransferCopyOptions::default()
+        };
+
+        let result = store
+            .multipart_copy_with_transfer_options(
+                &src,
+                &dst,
+                &multipart,
+                &transfer,
+                &MultipartCopyCancellation::new(),
+                &|_| {},
+            )
+            .await
+            .expect("legacy-compatible multipart transfer");
+
+        assert_eq!(result.upload_id, "transfer-upload-id");
+        let requests = replay.actual_requests().collect::<Vec<_>>();
+        assert_eq!(requests.len(), 3);
+        assert_eq!(
+            requests[0].headers().get("x-amz-server-side-encryption"),
+            Some("AES256")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related issue

Closes rustfs/backlog#1455
Parent: rustfs/backlog#1371
Roadmap: rustfs/backlog#1361

## Background and impact

The existing ObjectStore write/copy APIs can express only Content-Type and SSE-S3/SSE-KMS. Adding metadata, tags, storage class, checksums, SSE-C, retention, or legal hold directly to those public structs would break downstream struct literals, while adding SSE-C to the serializable encryption enum could expose customer key material. Backends also need an explicit way to reject advanced fields instead of silently discarding them.

## Solution

- Add backend-neutral transfer fidelity models for standard object attributes, metadata/tag directives, checksum calculation or precomputed values, storage class, encryption, retention, and legal hold.
- Store SSE-C keys in zeroizing memory with redacted Debug output and exact 32-byte validation.
- Validate HTTP metadata names/values, S3 tag limits, checksum Base64/digest length, empty storage class/KMS identifiers, and copy directive consistency before mutation.
- Add additive ObjectStore transfer methods with compatibility defaults. Legacy-compatible fields delegate to existing methods; unsupported advanced behavior returns UnsupportedFeature before backend requests.
- Add a separate transfer metadata result so ObjectInfo and output schema v1 remain unchanged.
- Cover single and multipart copy compatibility, source-version consistency, trait-object dispatch, argument preservation, zero-request rejection, and encryption propagation.

## Compatibility

- No protected files changed.
- No direct AWS SDK dependency was added to rc-core.
- Existing ObjectReadOptions, CopyObjectOptions, ObjectEncryptionRequest, ObjectInfo, and output schemas are unchanged.
- Existing ObjectStore implementations keep compiling because all new trait methods have defaults.

## Review follow-up addressed

- Reject metadata header injection and invalid metadata header names.
- Validate checksum Base64 and algorithm-specific digest lengths.
- Enforce S3 object-tag count/key/value limits.
- Exercise inherited default methods through `&dyn ObjectStore`, including zero-request rejection and multipart version behavior.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `CARGO_BUILD_JOBS=2 cargo test --workspace`
- Independent final re-review: no remaining actionable findings