### PR TITLE
feat(transfer): support truthful destination storage classes

### DIFF
--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -7,9 +7,10 @@ use jiff::Timestamp;
 use rc_core::alias::RetryConfig;
 use rc_core::{
     AliasManager, CopyObjectOptions, Error, MultipartCopyCancellation, MultipartCopyOptions,
-    ObjectEncryptionRequest, ObjectInfo, ObjectStore as _, ParsedPath, RemotePath,
-    TransferCancellation, TransferCandidate, TransferControls, TransferExecutor,
-    TransferOutcomeState, TransferPlan, TransferSelection, parse_path,
+    ObjectAttributes, ObjectEncryptionRequest, ObjectInfo, ObjectStore as _, ObjectWriteEncryption,
+    ObjectWriteOptions, ParsedPath, RemotePath, TransferCancellation, TransferCandidate,
+    TransferControls, TransferCopyOptions, TransferExecutor, TransferOutcomeState, TransferPlan,
+    TransferReadOptions, TransferSelection, parse_path,
 };
 use rc_s3::S3Client;
 use serde::Serialize;
@@ -209,11 +210,8 @@ pub async fn execute(args: CpArgs, output_config: OutputConfig) -> ExitCode {
             "--preserve is not implemented; refusing to continue with a silently ignored option",
         );
     }
-    if args.storage_class.is_some() {
-        return formatter.fail(
-            ExitCode::UnsupportedFeature,
-            "--storage-class is not implemented; refusing to continue with a silently ignored option",
-        );
+    if let Err(error) = validate_destination_storage_class(args.storage_class.as_deref()) {
+        return formatter.fail(exit_code_for_core_error(&error), &error.to_string());
     }
 
     if formatter.is_json() && uses_transfer_planner(&args) {
@@ -259,6 +257,12 @@ pub async fn execute(args: CpArgs, output_config: OutputConfig) -> ExitCode {
             );
         }
     };
+    if args.storage_class.is_some() && matches!(target, ParsedPath::Local(_)) {
+        return formatter.fail(
+            ExitCode::UsageError,
+            "--storage-class requires a remote destination",
+        );
+    }
 
     let target_is_container = is_container_target(&args.target, &target);
     if args.sources.len() > 1 && !target_is_container {
@@ -333,6 +337,47 @@ fn uses_transfer_planner(args: &CpArgs) -> bool {
         || args.retry_max_backoff_ms.is_some()
         || args.fail_empty
         || args.summary
+}
+
+pub(super) fn validate_destination_storage_class(value: Option<&str>) -> rc_core::Result<()> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    match value {
+        "STANDARD" | "REDUCED_REDUNDANCY" => Ok(()),
+        "DEEP_ARCHIVE"
+        | "EXPRESS_ONEZONE"
+        | "FSX_ONTAP"
+        | "FSX_OPENZFS"
+        | "GLACIER"
+        | "GLACIER_IR"
+        | "INTELLIGENT_TIERING"
+        | "ONEZONE_IA"
+        | "OUTPOSTS"
+        | "SNOW"
+        | "STANDARD_IA" => Err(Error::UnsupportedFeature(format!(
+            "RustFS beta.10 does not provide meaningful storage policy '{value}'"
+        ))),
+        value => Err(Error::InvalidPath(format!(
+            "Unknown destination storage class '{value}'"
+        ))),
+    }
+}
+
+fn object_write_options(
+    content_type: Option<&str>,
+    encryption: Option<&ObjectEncryptionRequest>,
+    storage_class: Option<String>,
+) -> ObjectWriteOptions {
+    ObjectWriteOptions {
+        attributes: content_type.map(|content_type| ObjectAttributes {
+            content_type: Some(content_type.to_string()),
+            ..ObjectAttributes::default()
+        }),
+        storage_class,
+        encryption: encryption.cloned().map(ObjectWriteEncryption::Managed),
+        ..ObjectWriteOptions::default()
+    }
 }
 
 async fn execute_single_copy(
@@ -466,6 +511,9 @@ async fn execute_transfer_plan(
     };
 
     let mut plan = TransferPlan::build(candidates, &selection);
+    if let Err(error) = validate_storage_class_plan(&plan, args.storage_class.as_deref()) {
+        return formatter.fail(exit_code_for_core_error(&error), &error.to_string());
+    }
     if let Err(error) = validate_plan_targets(&plan) {
         return formatter.fail(ExitCode::UsageError, &error.to_string());
     }
@@ -508,9 +556,10 @@ async fn execute_transfer_plan(
     if args.dry_run {
         for item in &plan.items {
             formatter.println(&format!(
-                "Would copy: {} -> {}",
+                "Would copy: {} -> {}{}",
                 formatter.style_file(&item.source),
-                formatter.style_file(&item.target)
+                formatter.style_file(&item.target),
+                storage_class_suffix(args.storage_class.as_deref())
             ));
         }
         for item in &skipped_existing {
@@ -642,6 +691,41 @@ async fn execute_transfer_plan(
     }
 }
 
+fn storage_class_suffix(storage_class: Option<&str>) -> String {
+    storage_class
+        .map(|value| format!(" [storage-class={value}]"))
+        .unwrap_or_default()
+}
+
+fn validate_storage_class_plan(
+    plan: &TransferPlan<CpOperation>,
+    storage_class: Option<&str>,
+) -> rc_core::Result<()> {
+    if storage_class.is_none() {
+        return Ok(());
+    }
+    for item in &plan.items {
+        let size = item.size_bytes.ok_or_else(|| {
+            Error::UnsupportedFeature(format!(
+                "Cannot guarantee storage class for a transfer with unknown size: {}",
+                item.source
+            ))
+        })?;
+        let multipart = match &item.payload {
+            CpOperation::LocalToRemote { .. } => size > MULTIPART_THRESHOLD,
+            CpOperation::RemoteToRemote { .. } => rc_core::requires_multipart_copy(size),
+            CpOperation::RemoteToLocal { .. } => false,
+        };
+        if multipart {
+            return Err(Error::UnsupportedFeature(format!(
+                "RustFS beta.10 does not persist storage class for multipart transfer: {}",
+                item.source
+            )));
+        }
+    }
+    Ok(())
+}
+
 async fn execute_planned_operation(
     item: TransferCandidate<CpOperation>,
     args: &CpArgs,
@@ -674,6 +758,7 @@ async fn execute_planned_operation(
                 target,
                 source_info,
                 encryption.as_ref(),
+                args.storage_class.as_deref(),
                 multipart_cancellation,
                 &|bytes| copy_progress.set(&progress_key, bytes),
             )
@@ -709,9 +794,23 @@ async fn perform_planned_upload(
         guessed_type.as_deref(),
         file_size,
     );
-    let info = client
-        .put_object_from_path(target, source, content_type, encryption, |_| {})
-        .await?;
+    let info = if let Some(storage_class) = args.storage_class.as_deref() {
+        if file_size > MULTIPART_THRESHOLD {
+            return Err(Error::UnsupportedFeature(
+                "RustFS beta.10 does not persist storage class for multipart uploads".to_string(),
+            ));
+        }
+        let data = tokio::fs::read(source).await?;
+        let options =
+            object_write_options(content_type, encryption, Some(storage_class.to_string()));
+        client
+            .put_object_with_options(target, data, &options)
+            .await?
+    } else {
+        client
+            .put_object_from_path(target, source, content_type, encryption, |_| {})
+            .await?
+    };
     Ok(info
         .size_bytes
         .and_then(|size| u64::try_from(size).ok())
@@ -746,12 +845,14 @@ struct PlannedRemoteCopyResult {
     object: ObjectInfo,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn perform_planned_remote_copy(
     client: &S3Client,
     source: &RemotePath,
     target: &RemotePath,
     source_info: &ObjectInfo,
     encryption: Option<&ObjectEncryptionRequest>,
+    storage_class: Option<&str>,
     cancellation: &MultipartCopyCancellation,
     on_progress: &(dyn Fn(u64) + Send + Sync),
 ) -> rc_core::Result<PlannedRemoteCopyResult> {
@@ -765,6 +866,11 @@ async fn perform_planned_remote_copy(
         .and_then(|size| u64::try_from(size).ok())
         .ok_or_else(|| Error::InvalidPath(format!("Source size is unavailable: {source}")))?;
     if rc_core::requires_multipart_copy(planned_size) {
+        if storage_class.is_some() {
+            return Err(Error::UnsupportedFeature(
+                "RustFS beta.10 does not persist storage class for multipart copies".to_string(),
+            ));
+        }
         let current = client.head_object(source).await?;
         if current.size_bytes != source_info.size_bytes
             || source_info
@@ -796,10 +902,31 @@ async fn perform_planned_remote_copy(
             object: copied.object,
         });
     }
-    let options = CopyObjectOptions::for_source_version(source_info.version_id.clone())?;
-    let copied = client
-        .copy_object_with_options(source, target, &options, encryption)
-        .await?;
+    let copied = if let Some(storage_class) = storage_class {
+        client
+            .copy_object_with_transfer_options(
+                source,
+                target,
+                &TransferCopyOptions {
+                    source: TransferReadOptions {
+                        version_id: source_info.version_id.clone(),
+                        ..TransferReadOptions::default()
+                    },
+                    destination: object_write_options(
+                        None,
+                        encryption,
+                        Some(storage_class.to_string()),
+                    ),
+                    ..TransferCopyOptions::default()
+                },
+            )
+            .await?
+    } else {
+        let options = CopyObjectOptions::for_source_version(source_info.version_id.clone())?;
+        client
+            .copy_object_with_options(source, target, &options, encryption)
+            .await?
+    };
     let bytes_copied = copied
         .size_bytes
         .and_then(|size| u64::try_from(size).ok())
@@ -970,7 +1097,7 @@ fn print_transfer_summary(formatter: &Formatter, summary: &rc_core::TransferSumm
     ));
 }
 
-fn exit_code_for_core_error(error: &Error) -> ExitCode {
+pub(super) fn exit_code_for_core_error(error: &Error) -> ExitCode {
     ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError)
 }
 
@@ -1753,13 +1880,6 @@ async fn upload_file(
     let src_display = src.display().to_string();
     let dst_display = format!("{}/{}/{}", dst.alias, dst.bucket, dst_key);
 
-    if args.dry_run {
-        let styled_src = formatter.style_file(&src_display);
-        let styled_dst = formatter.style_file(&dst_display);
-        formatter.println(&format!("Would copy: {styled_src} -> {styled_dst}"));
-        return ExitCode::Success;
-    }
-
     // Get file size for progress bar decision
     let file_size = match std::fs::metadata(src) {
         Ok(m) => m.len(),
@@ -1770,6 +1890,21 @@ async fn upload_file(
             );
         }
     };
+    if args.storage_class.is_some() && file_size > MULTIPART_THRESHOLD {
+        return formatter.fail(
+            ExitCode::UnsupportedFeature,
+            "RustFS beta.10 does not persist storage class for multipart uploads",
+        );
+    }
+    if args.dry_run {
+        let styled_src = formatter.style_file(&src_display);
+        let styled_dst = formatter.style_file(&dst_display);
+        formatter.println(&format!(
+            "Would copy: {styled_src} -> {styled_dst}{}",
+            storage_class_suffix(args.storage_class.as_deref())
+        ));
+        return ExitCode::Success;
+    }
 
     // Determine content type
     let guessed_type: Option<String> = mime_guess::from_path(src)
@@ -1795,14 +1930,27 @@ async fn upload_file(
     };
 
     // Upload
-    match client
-        .put_object_from_path(&target, src, content_type, encryption, |bytes_sent| {
-            if let Some(ref pb) = progress {
-                pb.set_position(bytes_sent);
+    let upload_result = if let Some(storage_class) = args.storage_class.as_deref() {
+        match tokio::fs::read(src).await {
+            Ok(data) => {
+                let options =
+                    object_write_options(content_type, encryption, Some(storage_class.to_string()));
+                client
+                    .put_object_with_options(&target, data, &options)
+                    .await
             }
-        })
-        .await
-    {
+            Err(error) => Err(Error::Io(error)),
+        }
+    } else {
+        client
+            .put_object_from_path(&target, src, content_type, encryption, |bytes_sent| {
+                if let Some(ref pb) = progress {
+                    pb.set_position(bytes_sent);
+                }
+            })
+            .await
+    };
+    match upload_result {
         Ok(info) => {
             if let Some(ref pb) = progress {
                 pb.finish_and_clear();
@@ -1815,7 +1963,7 @@ async fn upload_file(
                 pb.finish_and_clear();
             }
             formatter.fail(
-                ExitCode::NetworkError,
+                exit_code_for_core_error(&e),
                 &format!("Failed to upload {src_display}: {e}"),
             )
         }
@@ -2289,7 +2437,7 @@ async fn copy_s3_to_s3_prepared(
     let src_display = format!("{}/{}/{}", src.alias, src.bucket, src.key);
     let dst_display = format!("{}/{}/{}", dst.alias, dst.bucket, dst.key);
 
-    if args.dry_run {
+    if args.dry_run && args.storage_class.is_none() {
         let styled_src = formatter.style_file(&src_display);
         let styled_dst = formatter.style_file(&dst_display);
         formatter.println(&format!("Would copy: {styled_src} -> {styled_dst}"));
@@ -2312,6 +2460,24 @@ async fn copy_s3_to_s3_prepared(
             );
         }
     };
+    let source_size = source_info
+        .size_bytes
+        .and_then(|size| u64::try_from(size).ok());
+    if args.storage_class.is_some() && source_size.is_none_or(rc_core::requires_multipart_copy) {
+        return formatter.fail(
+            ExitCode::UnsupportedFeature,
+            "RustFS beta.10 does not persist storage class for multipart or unknown-size copies",
+        );
+    }
+    if args.dry_run {
+        let styled_src = formatter.style_file(&src_display);
+        let styled_dst = formatter.style_file(&dst_display);
+        formatter.println(&format!(
+            "Would copy: {styled_src} -> {styled_dst}{}",
+            storage_class_suffix(args.storage_class.as_deref())
+        ));
+        return ExitCode::Success;
+    }
 
     let cancellation = MultipartCopyCancellation::new();
     let transfer_cancellation = TransferCancellation::new();
@@ -2332,6 +2498,7 @@ async fn copy_s3_to_s3_prepared(
         dst,
         &source_info,
         encryption,
+        args.storage_class.as_deref(),
         &cancellation,
         &ignore_progress,
     );
@@ -3135,5 +3302,46 @@ mod tests {
         assert_eq!(json["data"]["operation"], "copy");
         assert_eq!(json["data"]["source_version_id"], "source-v1");
         assert_eq!(json["data"]["version_id"], "destination-v2");
+    }
+
+    #[tokio::test]
+    async fn storage_class_validation_has_usage_and_unsupported_exit_codes() {
+        for (storage_class, expected) in [
+            ("not-a-class", ExitCode::UsageError),
+            ("STANDARD_IA", ExitCode::UnsupportedFeature),
+        ] {
+            let mut args = CpArgs::single("source.txt", "local/bucket/target.txt");
+            args.storage_class = Some(storage_class.to_string());
+
+            assert_eq!(execute(args, OutputConfig::default()).await, expected);
+        }
+    }
+
+    #[test]
+    fn storage_class_plan_rejects_multipart_without_mutation() {
+        let plan = TransferPlan::build(
+            vec![TransferCandidate {
+                payload: CpOperation::RemoteToRemote {
+                    source: RemotePath::new("local", "source", "large.bin"),
+                    target: RemotePath::new("local", "target", "large.bin"),
+                    source_info: Box::new(ObjectInfo::file(
+                        "large.bin",
+                        (MAX_SINGLE_COPY_SIZE + 1) as i64,
+                    )),
+                    encryption: None,
+                },
+                source: "local/source/large.bin".to_string(),
+                target: "local/target/large.bin".to_string(),
+                relative_path: "large.bin".to_string(),
+                modified: None,
+                size_bytes: Some(MAX_SINGLE_COPY_SIZE + 1),
+            }],
+            &TransferSelection::default(),
+        );
+
+        assert!(matches!(
+            validate_storage_class_plan(&plan, Some("STANDARD")),
+            Err(Error::UnsupportedFeature(_))
+        ));
     }
 }

--- a/crates/cli/src/commands/pipe.rs
+++ b/crates/cli/src/commands/pipe.rs
@@ -3,13 +3,18 @@
 //! Reads from stdin and uploads to S3. Useful for piping output from other commands.
 
 use clap::Args;
-use rc_core::{AliasManager, ObjectEncryptionRequest, ObjectStore as _, RemotePath};
+use rc_core::{
+    AliasManager, ObjectAttributes, ObjectEncryptionRequest, ObjectStore as _,
+    ObjectWriteEncryption, ObjectWriteOptions, RemotePath,
+};
 use rc_s3::S3Client;
 use serde::Serialize;
 use std::io::Read;
 
 use crate::exit_code::ExitCode;
 use crate::output::{Formatter, OutputConfig};
+
+use super::cp::{exit_code_for_core_error, validate_destination_storage_class};
 
 /// Stream stdin to an object
 #[derive(Args, Debug)]
@@ -47,11 +52,8 @@ struct PipeOutput {
 /// Execute the pipe command
 pub async fn execute(args: PipeArgs, output_config: OutputConfig) -> ExitCode {
     let formatter = Formatter::new(output_config);
-    if args.storage_class.is_some() {
-        return formatter.fail(
-            ExitCode::UnsupportedFeature,
-            "--storage-class is not implemented for pipe",
-        );
+    if let Err(error) = validate_destination_storage_class(args.storage_class.as_deref()) {
+        return formatter.fail(exit_code_for_core_error(&error), &error.to_string());
     }
     let encryption = match (args.enc_s3, args.enc_kms.as_deref()) {
         (true, None) => Some(ObjectEncryptionRequest::SseS3),
@@ -119,13 +121,17 @@ pub async fn execute(args: PipeArgs, output_config: OutputConfig) -> ExitCode {
     let target_display = format!("{alias_name}/{bucket}/{key}");
 
     // Upload
+    let options = ObjectWriteOptions {
+        attributes: Some(ObjectAttributes {
+            content_type: Some(args.content_type.clone()),
+            ..ObjectAttributes::default()
+        }),
+        storage_class: args.storage_class.clone(),
+        encryption: encryption.map(ObjectWriteEncryption::Managed),
+        ..ObjectWriteOptions::default()
+    };
     match client
-        .put_object(
-            &target,
-            buffer,
-            Some(&args.content_type),
-            encryption.as_ref(),
-        )
+        .put_object_with_options(&target, buffer, &options)
         .await
     {
         Ok(info) => {
@@ -148,7 +154,7 @@ pub async fn execute(args: PipeArgs, output_config: OutputConfig) -> ExitCode {
         }
         Err(e) => {
             formatter.error(&format!("Failed to upload: {e}"));
-            ExitCode::NetworkError
+            exit_code_for_core_error(&e)
         }
     }
 }
@@ -224,5 +230,23 @@ mod tests {
 
         let code = execute(args, OutputConfig::default()).await;
         assert_eq!(code, ExitCode::UsageError);
+    }
+
+    #[tokio::test]
+    async fn pipe_storage_class_errors_have_distinct_exit_codes_before_io() {
+        for (storage_class, expected) in [
+            ("NOT_A_CLASS", ExitCode::UsageError),
+            ("STANDARD_IA", ExitCode::UnsupportedFeature),
+        ] {
+            let args = PipeArgs {
+                target: "local/bucket/file.txt".to_string(),
+                content_type: "application/octet-stream".to_string(),
+                storage_class: Some(storage_class.to_string()),
+                enc_s3: false,
+                enc_kms: None,
+            };
+
+            assert_eq!(execute(args, OutputConfig::default()).await, expected);
+        }
     }
 }

--- a/crates/cli/tests/recursive_remote_copy.rs
+++ b/crates/cli/tests/recursive_remote_copy.rs
@@ -253,6 +253,38 @@ fn run_rc(mock: &S3Mock, args: &[&str]) -> Output {
         .expect("run rc command")
 }
 
+fn run_rc_with_stdin(mock: &S3Mock, args: &[&str], input: &[u8]) -> Output {
+    let config_dir = tempfile::tempdir().expect("create config directory");
+    let authority = mock
+        .endpoint
+        .strip_prefix("http://")
+        .expect("mock endpoint has scheme");
+    let alias = format!("http://ACCESS_KEY:SECRET_KEY@{authority}");
+    let mut command = Command::new(rc_binary());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+    let mut child = command
+        .args(args)
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_test", alias)
+        .env("AWS_EC2_METADATA_DISABLED", "true")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rc command");
+    child
+        .stdin
+        .take()
+        .expect("pipe command stdin")
+        .write_all(input)
+        .expect("write pipe input");
+    child.wait_with_output().expect("wait for rc command")
+}
+
 fn list_result(keys: &[String], truncated: bool, next_token: Option<&str>) -> Response {
     let contents = keys
         .iter()
@@ -303,6 +335,165 @@ fn is_list_request(request: &Request) -> bool {
 
 fn is_copy_request(request: &Request) -> bool {
     request.method == "PUT" && request.headers.contains_key("x-amz-copy-source")
+}
+
+#[test]
+fn single_copy_and_pipe_send_supported_storage_classes() {
+    let mock = S3Mock::start(|request| {
+        if request.method == "HEAD" && request.target == "/source/a.txt" {
+            return Response::head_with_etag(7, "source-etag");
+        }
+        if is_copy_request(request) {
+            return copy_result();
+        }
+        if request.method == "HEAD" && request.target == "/destination/b.txt" {
+            return Response {
+                status: "200 OK",
+                headers: vec![
+                    ("content-length", "7".to_string()),
+                    ("etag", "\"destination-etag\"".to_string()),
+                    ("x-amz-storage-class", "REDUCED_REDUNDANCY".to_string()),
+                ],
+                body: String::new(),
+            };
+        }
+        if request.method == "PUT" && request.target.starts_with("/destination/pipe.txt") {
+            return Response::empty();
+        }
+        if request.method == "PUT" && request.target.starts_with("/destination/upload.txt") {
+            return Response::empty();
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+
+    let copy = run_rc(
+        &mock,
+        &[
+            "cp",
+            "test/source/a.txt",
+            "test/destination/b.txt",
+            "--storage-class",
+            "REDUCED_REDUNDANCY",
+        ],
+    );
+    assert!(
+        copy.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&copy.stdout),
+        String::from_utf8_lossy(&copy.stderr)
+    );
+
+    let pipe = run_rc_with_stdin(
+        &mock,
+        &[
+            "pipe",
+            "test/destination/pipe.txt",
+            "--storage-class",
+            "STANDARD",
+        ],
+        b"payload",
+    );
+    assert!(
+        pipe.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&pipe.stdout),
+        String::from_utf8_lossy(&pipe.stderr),
+        mock.requests()
+    );
+
+    let source_dir = tempfile::tempdir().expect("create upload source directory");
+    let source = source_dir.path().join("upload.txt");
+    std::fs::write(&source, b"payload").expect("write upload source");
+    let upload = run_rc(
+        &mock,
+        &[
+            "cp",
+            source.to_str().expect("source path is valid UTF-8"),
+            "test/destination/upload.txt",
+            "--storage-class",
+            "STANDARD",
+        ],
+    );
+    assert!(
+        upload.status.success(),
+        "stdout: {}\nstderr: {}\nrequests: {:#?}",
+        String::from_utf8_lossy(&upload.stdout),
+        String::from_utf8_lossy(&upload.stderr),
+        mock.requests()
+    );
+
+    let requests = mock.requests();
+    let copy_request = requests
+        .iter()
+        .find(|request| is_copy_request(request))
+        .expect("copy request");
+    assert_eq!(
+        copy_request.headers.get("x-amz-storage-class"),
+        Some(&"REDUCED_REDUNDANCY".to_string())
+    );
+    let pipe_request = requests
+        .iter()
+        .find(|request| {
+            request.method == "PUT" && request.target.starts_with("/destination/pipe.txt")
+        })
+        .expect("pipe put request");
+    assert_eq!(
+        pipe_request.headers.get("x-amz-storage-class"),
+        Some(&"STANDARD".to_string())
+    );
+    let upload_request = requests
+        .iter()
+        .find(|request| {
+            request.method == "PUT" && request.target.starts_with("/destination/upload.txt")
+        })
+        .expect("local upload put request");
+    assert_eq!(
+        upload_request.headers.get("x-amz-storage-class"),
+        Some(&"STANDARD".to_string())
+    );
+}
+
+#[test]
+fn storage_class_dry_run_reports_policy_without_copy_mutation() {
+    let mock = S3Mock::start(|request| {
+        if request.method == "HEAD" && request.target == "/source/a.txt" {
+            return Response::head_with_etag(7, "source-etag");
+        }
+        Response {
+            status: "500 Internal Server Error",
+            headers: Vec::new(),
+            body: "<Error><Code>UnexpectedRequest</Code></Error>".to_string(),
+        }
+    });
+
+    let output = run_rc(
+        &mock,
+        &[
+            "cp",
+            "test/source/a.txt",
+            "test/destination/b.txt",
+            "--storage-class",
+            "STANDARD",
+            "--dry-run",
+        ],
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("[storage-class=STANDARD]"));
+    assert!(
+        mock.requests()
+            .iter()
+            .all(|request| !is_copy_request(request))
+    );
 }
 
 #[test]

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -672,13 +672,27 @@ fn managed_object_encryption(
     }
 }
 
+fn rustfs_storage_class(value: Option<&str>) -> Result<Option<aws_sdk_s3::types::StorageClass>> {
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    match value {
+        "STANDARD" => Ok(Some(aws_sdk_s3::types::StorageClass::Standard)),
+        "REDUCED_REDUNDANCY" => Ok(Some(aws_sdk_s3::types::StorageClass::ReducedRedundancy)),
+        value if aws_sdk_s3::types::StorageClass::try_parse(value).is_ok() => {
+            Err(Error::UnsupportedFeature(format!(
+                "RustFS beta.10 does not provide meaningful storage policy '{value}'; tracked by rustfs/backlog#1465"
+            )))
+        }
+        value => Err(Error::InvalidPath(format!(
+            "Unknown destination storage class '{value}'"
+        ))),
+    }
+}
+
 fn validate_attribute_tag_write_options(options: &ObjectWriteOptions) -> Result<()> {
     options.validate()?;
-    if options.storage_class.is_some() {
-        return Err(Error::UnsupportedFeature(
-            "Storage-class writes are tracked by rustfs/backlog#1457".to_string(),
-        ));
-    }
+    rustfs_storage_class(options.storage_class.as_deref())?;
     if options.checksum.is_some() {
         return Err(Error::UnsupportedFeature(
             "Checksum writes are tracked by rustfs/backlog#1458".to_string(),
@@ -1987,6 +2001,11 @@ impl S3Client {
                     .and_then(|value| std::str::from_utf8(value.as_bytes()).ok())
             });
             let status = raw.status().as_u16();
+            if matches!(code, Some("InvalidStorageClass")) {
+                return Error::UnsupportedFeature(
+                    "The S3 endpoint rejected the requested storage class".to_string(),
+                );
+            }
             if matches!(status, 409 | 412)
                 || matches!(
                     code,
@@ -3943,6 +3962,7 @@ impl ObjectStore for S3Client {
         let size = data.len() as i64;
         let body = aws_sdk_s3::primitives::ByteStream::from(data);
         let encryption = managed_object_encryption(options)?;
+        let storage_class = rustfs_storage_class(options.storage_class.as_deref())?;
         let request = apply_object_encryption_to_put_request(
             self.inner
                 .put_object()
@@ -3950,7 +3970,8 @@ impl ObjectStore for S3Client {
                 .key(&path.key)
                 .body(body),
             encryption,
-        );
+        )
+        .set_storage_class(storage_class);
         let mut request =
             apply_object_attributes_to_put_request(request, options.attributes.as_ref())?;
         if let Some(tags) = &options.tags {
@@ -3966,6 +3987,7 @@ impl ObjectStore for S3Client {
             info.metadata =
                 (!attributes.user_metadata.is_empty()).then(|| attributes.user_metadata.clone());
         }
+        info.storage_class = options.storage_class.clone();
         info.etag = response
             .e_tag()
             .map(|etag| etag.trim_matches('"').to_string());
@@ -4060,6 +4082,7 @@ impl ObjectStore for S3Client {
         validate_beta10_copy_options(options)?;
         let copy_source = encoded_copy_source(src, options.source.version_id.as_deref());
         let encryption = managed_object_encryption(&options.destination)?;
+        let storage_class = rustfs_storage_class(options.destination.storage_class.as_deref())?;
         let mut request = apply_object_encryption_to_copy_request(
             self.inner
                 .copy_object()
@@ -4067,7 +4090,8 @@ impl ObjectStore for S3Client {
                 .bucket(&dst.bucket)
                 .key(&dst.key),
             encryption,
-        );
+        )
+        .set_storage_class(storage_class);
         if matches!(options.metadata_directive, Some(MetadataDirective::Copy)) {
             request = request.metadata_directive(aws_sdk_s3::types::MetadataDirective::Copy);
         }
@@ -4167,6 +4191,12 @@ impl ObjectStore for S3Client {
             )));
         }
         validate_beta10_copy_options(transfer)?;
+        if transfer.destination.storage_class.is_some() {
+            return Err(Error::UnsupportedFeature(
+                "RustFS beta.10 does not persist storage class for multipart uploads; tracked by rustfs/backlog#1464"
+                    .to_string(),
+            ));
+        }
         if transfer.source.version_id.is_some()
             && transfer.source.version_id.as_deref() != multipart.source_version_id.as_deref()
         {
@@ -8076,13 +8106,15 @@ mod tests {
                 ("team name".to_string(), "storage/core".to_string()),
                 ("owner".to_string(), "alice smith".to_string()),
             ])),
+            storage_class: Some("REDUCED_REDUNDANCY".to_string()),
             ..ObjectWriteOptions::default()
         };
 
-        client
+        let info = client
             .put_object_with_options(&path, b"payload".to_vec(), &options)
             .await
             .expect("put object with attributes and tags");
+        assert_eq!(info.storage_class.as_deref(), Some("REDUCED_REDUNDANCY"));
 
         let request = request_receiver.expect_request();
         assert_eq!(request.headers().get("content-type"), Some("text/plain"));
@@ -8098,6 +8130,10 @@ mod tests {
         assert_eq!(
             request.headers().get("x-amz-tagging"),
             Some("owner=alice+smith&team+name=storage%2Fcore")
+        );
+        assert_eq!(
+            request.headers().get("x-amz-storage-class"),
+            Some("REDUCED_REDUNDANCY")
         );
     }
 
@@ -8147,6 +8183,62 @@ mod tests {
             .expect_err("access denied must remain typed");
         assert!(matches!(error, Error::Auth(_)));
         denied_requests.expect_request();
+    }
+
+    #[tokio::test]
+    async fn transfer_put_rejects_unsupported_and_maps_invalid_storage_classes() {
+        let path = RemotePath::new("test", "bucket", "file.txt");
+        let (unsupported_client, unsupported_requests) = test_s3_client(None);
+        let unsupported = unsupported_client
+            .put_object_with_options(
+                &path,
+                b"payload".to_vec(),
+                &ObjectWriteOptions {
+                    storage_class: Some("STANDARD_IA".to_string()),
+                    ..ObjectWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("label-only RustFS storage classes must fail locally");
+        assert!(matches!(unsupported, Error::UnsupportedFeature(_)));
+        unsupported_requests.expect_no_request();
+
+        let (unknown_client, unknown_requests) = test_s3_client(None);
+        let unknown = unknown_client
+            .put_object_with_options(
+                &path,
+                b"payload".to_vec(),
+                &ObjectWriteOptions {
+                    storage_class: Some("NOT_A_CLASS".to_string()),
+                    ..ObjectWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("unknown storage classes must fail locally");
+        assert!(matches!(unknown, Error::InvalidPath(_)));
+        unknown_requests.expect_no_request();
+
+        let invalid_response = http::Response::builder()
+            .status(400)
+            .header("x-amz-error-code", "InvalidStorageClass")
+            .body(SdkBody::from(
+                "<Error><Code>InvalidStorageClass</Code><Message>invalid</Message></Error>",
+            ))
+            .expect("build invalid storage class response");
+        let (invalid_client, invalid_requests) = test_s3_client(Some(invalid_response));
+        let invalid = invalid_client
+            .put_object_with_options(
+                &path,
+                b"payload".to_vec(),
+                &ObjectWriteOptions {
+                    storage_class: Some("STANDARD".to_string()),
+                    ..ObjectWriteOptions::default()
+                },
+            )
+            .await
+            .expect_err("service storage-class rejection must remain typed");
+        assert!(matches!(invalid, Error::UnsupportedFeature(_)));
+        invalid_requests.expect_request();
     }
 
     #[tokio::test]
@@ -8416,6 +8508,10 @@ mod tests {
                 &dst,
                 &TransferCopyOptions {
                     metadata_directive: Some(MetadataDirective::Copy),
+                    destination: ObjectWriteOptions {
+                        storage_class: Some("STANDARD".to_string()),
+                        ..ObjectWriteOptions::default()
+                    },
                     ..TransferCopyOptions::default()
                 },
             )
@@ -8425,6 +8521,10 @@ mod tests {
         assert_eq!(
             request.headers().get("x-amz-metadata-directive"),
             Some("COPY")
+        );
+        assert_eq!(
+            request.headers().get("x-amz-storage-class"),
+            Some("STANDARD")
         );
     }
 
@@ -8779,6 +8879,29 @@ mod tests {
             .expect_err("unsupported multipart tags must fail before preflight");
         assert!(matches!(error, Error::UnsupportedFeature(_)));
         assert!(replay.actual_requests().next().is_none());
+
+        let (storage_client, storage_replay) = test_s3_client_with_response_sequence(vec![]);
+        let storage_transfer = TransferCopyOptions {
+            metadata_directive: Some(MetadataDirective::Copy),
+            destination: ObjectWriteOptions {
+                storage_class: Some("STANDARD".to_string()),
+                ..ObjectWriteOptions::default()
+            },
+            ..TransferCopyOptions::default()
+        };
+        let storage_error = storage_client
+            .multipart_copy_with_transfer_options(
+                &src,
+                &dst,
+                &multipart,
+                &storage_transfer,
+                &MultipartCopyCancellation::new(),
+                &|_| {},
+            )
+            .await
+            .expect_err("multipart storage class must fail before metadata preflight");
+        assert!(matches!(storage_error, Error::UnsupportedFeature(_)));
+        assert!(storage_replay.actual_requests().next().is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes rustfs/backlog#1457

## Background

`cp --storage-class` and `pipe --storage-class` were parsed but rejected unconditionally. The S3 transfer model can now carry destination storage class, while RustFS beta.10 has meaningful single-request behavior only for STANDARD and REDUCED_REDUNDANCY.

## Root cause

The S3 adapter did not map storage class onto PutObject or CopyObject, command paths still used legacy methods, and multipart paths could not truthfully guarantee persistence. InvalidStorageClass also fell through to a generic network error.

## Solution

- accept only STANDARD and REDUCED_REDUNDANCY as meaningful RustFS beta.10 policies
- send storage class on advanced PutObject and CopyObject requests
- wire `cp` single/planned upload and server-side copy paths plus `pipe` to advanced options
- reject label-only classes, unknown values, unknown sizes, and multipart transfers before mutation
- report selected class in human dry-run output without changing JSON contracts
- map service InvalidStorageClass to a stable UnsupportedFeature error
- preserve HEAD-observed storage class for copy results

Multipart persistence remains tracked by rustfs/backlog#1464; broader capability truthfulness remains tracked by rustfs/backlog#1465.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- process-level mock S3 coverage for cp upload, remote copy, pipe, and dry-run
- independent review completed with no actionable findings