### PR TITLE
feat(admin): add manual transition run command

### DIFF
--- a/crates/cli/src/commands/admin/ilm.rs
+++ b/crates/cli/src/commands/admin/ilm.rs
@@ -1,0 +1,155 @@
+//! ILM administration commands.
+
+use clap::{Args, Subcommand};
+use rc_core::admin::{AdminApi, ManualTransitionRunRequest, ManualTransitionRunResponse};
+use serde::Serialize;
+
+use super::{emit_observability_error, get_admin_client};
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+const MAX_MANUAL_TRANSITION_OBJECTS: u64 = 100_000;
+
+#[derive(Subcommand, Debug)]
+pub enum IlmCommands {
+    /// Manage lifecycle transition operations
+    #[command(subcommand)]
+    Transition(TransitionCommands),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum TransitionCommands {
+    /// Run bounded lifecycle transition evaluation for existing objects
+    Run(ManualTransitionRunArgs),
+}
+
+#[derive(Args, Debug)]
+pub struct ManualTransitionRunArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Bucket to evaluate
+    pub bucket: String,
+
+    /// Limit evaluation to this object key prefix
+    #[arg(long, default_value = "")]
+    pub prefix: String,
+
+    /// Limit evaluation to lifecycle transitions targeting this storage tier
+    #[arg(long)]
+    pub tier: Option<String>,
+
+    /// Report eligible objects without enqueueing transition tasks
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Maximum number of object versions to scan
+    #[arg(long, default_value_t = 10_000, value_parser = clap::value_parser!(u64).range(1..=MAX_MANUAL_TRANSITION_OBJECTS))]
+    pub max_objects: u64,
+}
+
+#[derive(Debug, Serialize)]
+struct ManualTransitionRunSuccessOutput<'a> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: &'a ManualTransitionRunResponse,
+}
+
+pub async fn execute(command: IlmCommands, formatter: &Formatter) -> ExitCode {
+    match command {
+        IlmCommands::Transition(TransitionCommands::Run(args)) => {
+            execute_manual_transition_run(args, formatter).await
+        }
+    }
+}
+
+async fn execute_manual_transition_run(
+    args: ManualTransitionRunArgs,
+    formatter: &Formatter,
+) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    let request = ManualTransitionRunRequest {
+        bucket: args.bucket,
+        prefix: args.prefix,
+        tier: args.tier,
+        dry_run: args.dry_run,
+        max_objects: args.max_objects,
+    };
+
+    match client.run_manual_transition(request).await {
+        Ok(response) => {
+            if formatter.is_json() {
+                formatter.json(&ManualTransitionRunSuccessOutput {
+                    schema_version: 3,
+                    output_type: "manual_transition_run",
+                    status: "success",
+                    data: &response,
+                });
+            } else {
+                print_manual_transition_run(&response, formatter);
+            }
+            ExitCode::Success
+        }
+        Err(error) => emit_observability_error(
+            "manual_transition_run",
+            "admin.ilm-transition-run",
+            "Failed to run manual transition",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+fn print_manual_transition_run(response: &ManualTransitionRunResponse, formatter: &Formatter) {
+    let report = &response.report;
+    formatter.println(&formatter.style_name("Manual Transition Run"));
+    formatter.println("");
+    formatter.println(&format!(
+        "State:          {}",
+        formatter.sanitize_text(&response.state)
+    ));
+    formatter.println(&format!(
+        "Mode:           {}",
+        formatter.sanitize_text(&response.mode)
+    ));
+    formatter.println(&format!(
+        "Bucket:         {}",
+        formatter.sanitize_text(&report.bucket)
+    ));
+    formatter.println(&format!(
+        "Prefix:         {}",
+        formatter.sanitize_text(value_or_all(&report.prefix))
+    ));
+    formatter.println(&format!(
+        "Tier:           {}",
+        formatter.sanitize_text(report.tier.as_deref().map(value_or_all).unwrap_or("all"))
+    ));
+    formatter.println(&format!("Dry run:        {}", report.dry_run));
+    formatter.println(&format!(
+        "Lifecycle:      {}",
+        report.lifecycle_config_found
+    ));
+    formatter.println(&format!("Scanned:        {}", report.scanned));
+    formatter.println(&format!("Eligible:       {}", report.eligible));
+    formatter.println(&format!("Enqueued:       {}", report.enqueued));
+    formatter.println(&format!("Dry-run count:  {}", report.dry_run_eligible));
+    formatter.println(&format!(
+        "Not due:        {}",
+        report.skipped_not_transition
+    ));
+    formatter.println(&format!(
+        "Queue pressure: {}",
+        report.skipped_queue_full + report.skipped_queue_closed + report.skipped_queue_timeout
+    ));
+    formatter.println(&format!("Truncated:      {}", report.truncated_by_limit));
+}
+
+fn value_or_all(value: &str) -> &str {
+    if value.is_empty() { "all" } else { value }
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -11,6 +11,7 @@ mod diagnostics;
 mod expand;
 mod group;
 mod heal;
+mod ilm;
 mod info;
 mod kms;
 mod metrics;
@@ -56,6 +57,10 @@ pub enum AdminCommands {
     /// Inspect scanner health and freshness
     #[command(subcommand)]
     Scanner(scanner::ScannerCommands),
+
+    /// Manage lifecycle transition operations
+    #[command(subcommand)]
+    Ilm(ilm::IlmCommands),
 
     /// Display cluster information (servers, disks, usage)
     #[command(subcommand)]
@@ -121,6 +126,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
         AdminCommands::Metrics(args) => metrics::execute(args, &formatter).await,
         AdminCommands::Kms(kms_cmd) => kms::execute(kms_cmd, &formatter).await,
         AdminCommands::Scanner(scanner_cmd) => scanner::execute(scanner_cmd, &formatter).await,
+        AdminCommands::Ilm(ilm_cmd) => ilm::execute(ilm_cmd, &formatter).await,
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
         AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,
@@ -300,6 +306,39 @@ mod tests {
                 assert!(args.refresh);
             }
             _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_ilm_transition_run() {
+        let cli = TestCli::parse_from([
+            "rc",
+            "ilm",
+            "transition",
+            "run",
+            "local",
+            "photos",
+            "--prefix",
+            "logs/",
+            "--tier",
+            "COLDTIER",
+            "--dry-run",
+            "--max-objects",
+            "25",
+        ]);
+
+        match cli.command {
+            AdminCommands::Ilm(ilm::IlmCommands::Transition(ilm::TransitionCommands::Run(
+                args,
+            ))) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.bucket, "photos");
+                assert_eq!(args.prefix, "logs/");
+                assert_eq!(args.tier.as_deref(), Some("COLDTIER"));
+                assert!(args.dry_run);
+                assert_eq!(args.max_objects, 25);
+            }
+            _ => panic!("Unexpected ILM transition run command"),
         }
     }
 

--- a/crates/cli/tests/admin_ilm.rs
+++ b/crates/cli/tests/admin_ilm.rs
@@ -1,0 +1,212 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_response_test_server};
+use serde_json::Value;
+
+const MANUAL_TRANSITION_RESPONSE: &str = r#"{
+  "state":"completed",
+  "mode":"enqueue_only",
+  "job_id":null,
+  "status_endpoint":null,
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/",
+    "tier":"COLDTIER",
+    "dry_run":true,
+    "lifecycle_config_found":true,
+    "scanned":3,
+    "eligible":2,
+    "enqueued":0,
+    "dry_run_eligible":2,
+    "skipped_not_transition":1,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "truncated_by_limit":false
+  }
+}"#;
+
+const MANUAL_TRANSITION_CONTROL_RESPONSE: &str = r#"{
+  "state":"completed\nspoofed",
+  "mode":"enqueue_only",
+  "job_id":null,
+  "status_endpoint":null,
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/\nnext",
+    "tier":"COLD\tTIER",
+    "dry_run":true,
+    "lifecycle_config_found":true,
+    "scanned":1,
+    "eligible":1,
+    "enqueued":0,
+    "dry_run_eligible":1,
+    "skipped_not_transition":0,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "truncated_by_limit":false
+  }
+}"#;
+
+#[test]
+fn ilm_transition_run_json_calls_manual_transition_endpoint() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_response_test_server(
+        "200 OK",
+        "application/json",
+        MANUAL_TRANSITION_RESPONSE.to_string(),
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "ilm",
+            "transition",
+            "run",
+            "myalias",
+            "photos",
+            "--prefix",
+            "logs/",
+            "--tier",
+            "COLDTIER",
+            "--dry-run",
+            "--max-objects",
+            "25",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "manual_transition_run");
+    assert_eq!(value["data"]["state"], "completed");
+    assert_eq!(value["data"]["report"]["dry_run_eligible"], 2);
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/ilm/transition/run?bucket=photos&prefix=logs%2F&dryRun=true&maxObjects=25&tier=COLDTIER"
+    );
+    assert!(request.body.is_empty());
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_run_human_output_exposes_counts_without_keys() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let response = MANUAL_TRANSITION_RESPONSE
+        .replace(
+            "\"state\":\"completed\"",
+            "\"state\":\"completed\\u001b[31m\"",
+        )
+        .replace(
+            "\"mode\":\"enqueue_only\"",
+            "\"mode\":\"enqueue_only\\u001b[31m\"",
+        )
+        .replace("\"prefix\":\"logs/\"", "\"prefix\":\"logs/\\u001b[31m\"")
+        .replace("\"tier\":\"COLDTIER\"", "\"tier\":\"COLDTIER\\u001b[31m\"");
+    let (endpoint, _receiver, handle) =
+        start_admin_response_test_server("200 OK", "application/json", response);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "ilm",
+            "transition",
+            "run",
+            "myalias",
+            "photos",
+            "--prefix",
+            "logs/",
+            "--dry-run",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("Manual Transition Run"), "stdout: {stdout}");
+    assert!(stdout.contains("Eligible:       2"), "stdout: {stdout}");
+    assert!(!stdout.contains("next_marker"), "stdout: {stdout}");
+    assert!(!stdout.contains("\x1b["), "stdout: {stdout}");
+    assert!(stdout.contains("\\u{1b}"), "stdout: {stdout}");
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_run_human_output_sanitizes_server_text() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_response_test_server(
+        "200 OK",
+        "application/json",
+        MANUAL_TRANSITION_CONTROL_RESPONSE.to_string(),
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "ilm",
+            "transition",
+            "run",
+            "myalias",
+            "photos",
+            "--dry-run",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(
+        stdout.contains("State:          completed\\nspoofed"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Prefix:         logs/\\nnext"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Tier:           COLD\\tTIER"),
+        "stdout: {stdout}"
+    );
+    handle.join().expect("admin test server finished");
+}

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -74,8 +74,9 @@ pub use site::{
     SiteReplicationResyncStatus, SiteStatusOptions, validate_site_replication_ca_bundle,
 };
 pub use tier::{
-    TierAliyun, TierAzure, TierConfig, TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2,
-    TierRustFS, TierS3, TierTencent, TierType,
+    ManualTransitionRunReport, ManualTransitionRunRequest, ManualTransitionRunResponse, TierAliyun,
+    TierAzure, TierConfig, TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2, TierRustFS,
+    TierS3, TierTencent, TierType,
 };
 pub use types::{
     AccessKeyDetails, AccessKeyInfo, BucketQuota, CreateServiceAccountRequest, Group, GroupStatus,
@@ -266,6 +267,12 @@ pub trait AdminApi: Send + Sync {
 
     /// Remove a storage tier
     async fn remove_tier(&self, name: &str, force: bool) -> Result<()>;
+
+    /// Run bounded manual lifecycle transition evaluation for a bucket scope.
+    async fn run_manual_transition(
+        &self,
+        request: ManualTransitionRunRequest,
+    ) -> Result<ManualTransitionRunResponse>;
 
     // ==================== Replication Target Operations ====================
 

--- a/crates/core/src/admin/tier.rs
+++ b/crates/core/src/admin/tier.rs
@@ -287,6 +287,50 @@ pub struct TierCreds {
     pub secret_key: String,
 }
 
+/// Request for a bounded manual lifecycle transition run.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManualTransitionRunRequest {
+    pub bucket: String,
+    pub prefix: String,
+    pub tier: Option<String>,
+    pub dry_run: bool,
+    pub max_objects: u64,
+}
+
+/// Response returned by the manual lifecycle transition endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManualTransitionRunResponse {
+    pub state: String,
+    pub mode: String,
+    pub job_id: Option<String>,
+    pub status_endpoint: Option<String>,
+    pub report: ManualTransitionRunReport,
+}
+
+/// Aggregate report for a manual lifecycle transition run.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManualTransitionRunReport {
+    pub bucket: String,
+    pub prefix: String,
+    pub tier: Option<String>,
+    pub dry_run: bool,
+    pub lifecycle_config_found: bool,
+    pub scanned: u64,
+    pub eligible: u64,
+    pub enqueued: u64,
+    pub dry_run_eligible: u64,
+    pub skipped_not_transition: u64,
+    pub skipped_tier: u64,
+    pub skipped_delete_marker: u64,
+    pub skipped_directory: u64,
+    pub skipped_replication: u64,
+    pub skipped_already_in_flight: u64,
+    pub skipped_queue_full: u64,
+    pub skipped_queue_closed: u64,
+    pub skipped_queue_timeout: u64,
+    pub truncated_by_limit: bool,
+}
+
 // ==================== Per-type sub-configs ====================
 // These match the RustFS backend JSON format exactly.
 

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -26,9 +26,10 @@ use rc_core::admin::{
     MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
     MAX_METRICS_SAMPLES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REQUEST_BYTES,
-    MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, MetricsBatch, MetricsQuery, ModuleSwitches,
-    ObservabilityApi, PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
-    RealtimeMetrics, RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
+    MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, ManualTransitionRunRequest,
+    ManualTransitionRunResponse, MetricsBatch, MetricsQuery, ModuleSwitches, ObservabilityApi,
+    PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RealtimeMetrics,
+    RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
     ReplicationDiffApi, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
     ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
     SiteReplicationInfo, SiteReplicationPeer, SiteReplicationResyncOperation,
@@ -3452,6 +3453,26 @@ impl AdminApi for AdminClient {
             self.request_no_response(Method::DELETE, &path, None, None)
                 .await
         }
+    }
+
+    async fn run_manual_transition(
+        &self,
+        request: ManualTransitionRunRequest,
+    ) -> Result<ManualTransitionRunResponse> {
+        let dry_run = if request.dry_run { "true" } else { "false" };
+        let max_objects = request.max_objects.to_string();
+        let mut query = vec![
+            ("bucket", request.bucket.as_str()),
+            ("prefix", request.prefix.as_str()),
+            ("dryRun", dry_run),
+            ("maxObjects", max_objects.as_str()),
+        ];
+        if let Some(tier) = request.tier.as_deref() {
+            query.push(("tier", tier));
+        }
+
+        self.request(Method::POST, "/ilm/transition/run", Some(&query), None)
+            .await
     }
 
     // ==================== Replication Target Operations ====================


### PR DESCRIPTION
## Summary
Adds `rc admin ilm transition run` for the backend manual ILM transition API. The command supports `--prefix`, `--tier`, `--dry-run`, and bounded `--max-objects`, emits a typed JSON envelope, and prints only aggregate counts in human mode.

## Compatibility
The change is additive to the admin API trait and S3 admin client. It does not add Console functionality, does not change existing command behavior, and keeps request parameters mapped to the backend `/ilm/transition/run` query contract.

## Verification
- `cargo fmt --all`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-cli --test admin_ilm -- --nocapture`
- `cargo test -p rustfs-cli test_parse_admin_ilm_transition_run -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Notes
Draft PR for the rc side of rustfs/backlog#1480, rustfs/backlog#1476 and https://github.com/rustfs/rustfs/issues/5153#issuecomment-5059464765. 
