### PR TITLE
feat(ilm): pass manual transition duration budget

### DIFF
--- a/crates/cli/src/commands/admin/ilm.rs
+++ b/crates/cli/src/commands/admin/ilm.rs
@@ -9,6 +9,7 @@ use crate::exit_code::ExitCode;
 use crate::output::Formatter;
 
 const MAX_MANUAL_TRANSITION_OBJECTS: u64 = 100_000;
+const MAX_MANUAL_TRANSITION_DURATION_SECONDS: u64 = 3600;
 
 #[derive(Subcommand, Debug)]
 pub enum IlmCommands {
@@ -46,6 +47,10 @@ pub struct ManualTransitionRunArgs {
     /// Maximum number of object versions to scan
     #[arg(long, default_value_t = 10_000, value_parser = clap::value_parser!(u64).range(1..=MAX_MANUAL_TRANSITION_OBJECTS))]
     pub max_objects: u64,
+
+    /// Best-effort seconds budget checked between listed object versions
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=MAX_MANUAL_TRANSITION_DURATION_SECONDS))]
+    pub max_duration_seconds: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -80,6 +85,7 @@ async fn execute_manual_transition_run(
         tier: args.tier,
         dry_run: args.dry_run,
         max_objects: args.max_objects,
+        max_duration_seconds: args.max_duration_seconds,
     };
 
     match client.run_manual_transition(request).await {
@@ -147,7 +153,8 @@ fn print_manual_transition_run(response: &ManualTransitionRunResponse, formatter
         "Queue pressure: {}",
         report.skipped_queue_full + report.skipped_queue_closed + report.skipped_queue_timeout
     ));
-    formatter.println(&format!("Truncated:      {}", report.truncated_by_limit));
+    formatter.println(&format!("Limit reached:  {}", report.truncated_by_limit));
+    formatter.println(&format!("Duration hit:   {}", report.truncated_by_duration));
 }
 
 fn value_or_all(value: &str) -> &str {

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -325,6 +325,8 @@ mod tests {
             "--dry-run",
             "--max-objects",
             "25",
+            "--max-duration-seconds",
+            "30",
         ]);
 
         match cli.command {
@@ -337,6 +339,7 @@ mod tests {
                 assert_eq!(args.tier.as_deref(), Some("COLDTIER"));
                 assert!(args.dry_run);
                 assert_eq!(args.max_objects, 25);
+                assert_eq!(args.max_duration_seconds, Some(30));
             }
             _ => panic!("Unexpected ILM transition run command"),
         }

--- a/crates/cli/tests/admin_ilm.rs
+++ b/crates/cli/tests/admin_ilm.rs
@@ -32,7 +32,8 @@ const MANUAL_TRANSITION_RESPONSE: &str = r#"{
     "skipped_queue_full":0,
     "skipped_queue_closed":0,
     "skipped_queue_timeout":0,
-    "truncated_by_limit":false
+    "truncated_by_limit":false,
+    "truncated_by_duration":true
   }
 }"#;
 
@@ -45,6 +46,35 @@ const MANUAL_TRANSITION_CONTROL_RESPONSE: &str = r#"{
     "bucket":"photos",
     "prefix":"logs/\nnext",
     "tier":"COLD\tTIER",
+    "dry_run":true,
+    "lifecycle_config_found":true,
+    "scanned":1,
+    "eligible":1,
+    "enqueued":0,
+    "dry_run_eligible":1,
+    "skipped_not_transition":0,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "truncated_by_limit":false,
+    "truncated_by_duration":false
+  }
+}"#;
+
+const MANUAL_TRANSITION_LEGACY_RESPONSE: &str = r#"{
+  "state":"completed",
+  "mode":"enqueue_only",
+  "job_id":null,
+  "status_endpoint":null,
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/",
+    "tier":"COLDTIER",
     "dry_run":true,
     "lifecycle_config_found":true,
     "scanned":1,
@@ -89,6 +119,8 @@ fn ilm_transition_run_json_calls_manual_transition_endpoint() {
             "--dry-run",
             "--max-objects",
             "25",
+            "--max-duration-seconds",
+            "30",
         ])
         .env("RC_CONFIG_DIR", config_dir.path())
         .env("RC_HOST_myalias", rc_host_alias(&endpoint))
@@ -112,7 +144,7 @@ fn ilm_transition_run_json_calls_manual_transition_endpoint() {
     assert_eq!(request.method, "POST");
     assert_eq!(
         request.target,
-        "/rustfs/admin/v3/ilm/transition/run?bucket=photos&prefix=logs%2F&dryRun=true&maxObjects=25&tier=COLDTIER"
+        "/rustfs/admin/v3/ilm/transition/run?bucket=photos&prefix=logs%2F&dryRun=true&maxObjects=25&maxDurationSeconds=30&tier=COLDTIER"
     );
     assert!(request.body.is_empty());
     handle.join().expect("admin test server finished");
@@ -160,6 +192,7 @@ fn ilm_transition_run_human_output_exposes_counts_without_keys() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     assert!(stdout.contains("Manual Transition Run"), "stdout: {stdout}");
     assert!(stdout.contains("Eligible:       2"), "stdout: {stdout}");
+    assert!(stdout.contains("Duration hit:   true"), "stdout: {stdout}");
     assert!(!stdout.contains("next_marker"), "stdout: {stdout}");
     assert!(!stdout.contains("\x1b["), "stdout: {stdout}");
     assert!(stdout.contains("\\u{1b}"), "stdout: {stdout}");
@@ -208,5 +241,39 @@ fn ilm_transition_run_human_output_sanitizes_server_text() {
         stdout.contains("Tier:           COLD\\tTIER"),
         "stdout: {stdout}"
     );
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_run_accepts_legacy_response_without_duration_flag() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_response_test_server(
+        "200 OK",
+        "application/json",
+        MANUAL_TRANSITION_LEGACY_RESPONSE.to_string(),
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "ilm",
+            "transition",
+            "run",
+            "myalias",
+            "photos",
+            "--dry-run",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("Duration hit:   false"), "stdout: {stdout}");
     handle.join().expect("admin test server finished");
 }

--- a/crates/core/src/admin/tier.rs
+++ b/crates/core/src/admin/tier.rs
@@ -295,6 +295,7 @@ pub struct ManualTransitionRunRequest {
     pub tier: Option<String>,
     pub dry_run: bool,
     pub max_objects: u64,
+    pub max_duration_seconds: Option<u64>,
 }
 
 /// Response returned by the manual lifecycle transition endpoint.
@@ -329,6 +330,8 @@ pub struct ManualTransitionRunReport {
     pub skipped_queue_closed: u64,
     pub skipped_queue_timeout: u64,
     pub truncated_by_limit: bool,
+    #[serde(default)]
+    pub truncated_by_duration: bool,
 }
 
 // ==================== Per-type sub-configs ====================

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -3467,6 +3467,12 @@ impl AdminApi for AdminClient {
             ("dryRun", dry_run),
             ("maxObjects", max_objects.as_str()),
         ];
+        let max_duration_seconds = request
+            .max_duration_seconds
+            .map(|duration| duration.to_string());
+        if let Some(max_duration_seconds) = max_duration_seconds.as_deref() {
+            query.push(("maxDurationSeconds", max_duration_seconds));
+        }
         if let Some(tier) = request.tier.as_deref() {
             query.push(("tier", tier));
         }


### PR DESCRIPTION
## Related Issues
Relates to rustfs/backlog#1476, rustfs/backlog#1478, rustfs/backlog#1480.

## Summary of Changes
- Add `--max-duration-seconds` to `rc admin ilm transition run`.
- Pass the optional `maxDurationSeconds` query parameter through the admin client.
- Print the server's `truncated_by_duration` flag as `Duration hit` in human output.
- Keep older server responses compatible by defaulting a missing `truncated_by_duration` field to `false`.

## Verification
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p rustfs-cli --test admin_ilm -- --nocapture`
- `cargo test -p rustfs-cli test_parse_admin_ilm_transition_run -- --nocapture`
- `cargo clippy -p rustfs-cli --all-targets -- -D warnings`

## Impact
The CLI remains compatible with older servers because the new flag is optional and the new response field is tolerated when absent. Status, wait, and cancel commands are intentionally not added here because the backend durable job API is not implemented yet.

## Additional Notes
This is the CLI companion for the RustFS manual transition duration-budget follow-up.
