### PR TITLE
feat(ilm): show already transitioned count

### DIFF
--- a/crates/cli/src/commands/admin/ilm.rs
+++ b/crates/cli/src/commands/admin/ilm.rs
@@ -150,6 +150,10 @@ fn print_manual_transition_run(response: &ManualTransitionRunResponse, formatter
         report.skipped_not_transition
     ));
     formatter.println(&format!(
+        "Already moved:  {}",
+        report.skipped_already_transitioned
+    ));
+    formatter.println(&format!(
         "Queue pressure: {}",
         report.skipped_queue_full + report.skipped_queue_closed + report.skipped_queue_timeout
     ));

--- a/crates/cli/tests/admin_ilm.rs
+++ b/crates/cli/tests/admin_ilm.rs
@@ -28,6 +28,7 @@ const MANUAL_TRANSITION_RESPONSE: &str = r#"{
     "skipped_delete_marker":0,
     "skipped_directory":0,
     "skipped_replication":0,
+    "skipped_already_transitioned":1,
     "skipped_already_in_flight":0,
     "skipped_queue_full":0,
     "skipped_queue_closed":0,
@@ -57,6 +58,7 @@ const MANUAL_TRANSITION_CONTROL_RESPONSE: &str = r#"{
     "skipped_delete_marker":0,
     "skipped_directory":0,
     "skipped_replication":0,
+    "skipped_already_transitioned":0,
     "skipped_already_in_flight":0,
     "skipped_queue_full":0,
     "skipped_queue_closed":0,
@@ -137,6 +139,7 @@ fn ilm_transition_run_json_calls_manual_transition_endpoint() {
     assert_eq!(value["type"], "manual_transition_run");
     assert_eq!(value["data"]["state"], "completed");
     assert_eq!(value["data"]["report"]["dry_run_eligible"], 2);
+    assert_eq!(value["data"]["report"]["skipped_already_transitioned"], 1);
 
     let request = receiver
         .recv_timeout(Duration::from_secs(5))
@@ -192,6 +195,7 @@ fn ilm_transition_run_human_output_exposes_counts_without_keys() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
     assert!(stdout.contains("Manual Transition Run"), "stdout: {stdout}");
     assert!(stdout.contains("Eligible:       2"), "stdout: {stdout}");
+    assert!(stdout.contains("Already moved:  1"), "stdout: {stdout}");
     assert!(stdout.contains("Duration hit:   true"), "stdout: {stdout}");
     assert!(!stdout.contains("next_marker"), "stdout: {stdout}");
     assert!(!stdout.contains("\x1b["), "stdout: {stdout}");
@@ -274,6 +278,7 @@ fn ilm_transition_run_accepts_legacy_response_without_duration_flag() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(stdout.contains("Already moved:  0"), "stdout: {stdout}");
     assert!(stdout.contains("Duration hit:   false"), "stdout: {stdout}");
     handle.join().expect("admin test server finished");
 }

--- a/crates/core/src/admin/tier.rs
+++ b/crates/core/src/admin/tier.rs
@@ -325,6 +325,8 @@ pub struct ManualTransitionRunReport {
     pub skipped_delete_marker: u64,
     pub skipped_directory: u64,
     pub skipped_replication: u64,
+    #[serde(default)]
+    pub skipped_already_transitioned: u64,
     pub skipped_already_in_flight: u64,
     pub skipped_queue_full: u64,
     pub skipped_queue_closed: u64,


### PR DESCRIPTION
## Related Issues
Relates to rustfs/backlog#1478 and rustfs/backlog#1480.

## Summary of Changes
- Add `skipped_already_transitioned` to the manual transition response model with a default of `0` for older servers.
- Show the aggregate count as `Already moved` in human output.
- Keep marker-like continuation data out of human output.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-cli --test admin_ilm -- --nocapture`
- `cargo test -p rustfs-cli test_parse_admin_ilm_transition_run -- --nocapture`
- `cargo clippy -p rustfs-cli --all-targets -- -D warnings`

## Impact
The CLI remains compatible with older RustFS servers because the new response field defaults to `0` when absent. No status, wait, cancel, or continuation command behavior is added here.

## Additional Notes
This is the CLI companion for the RustFS manual transition already-transitioned counter.
