### PR TITLE
feat(transfer): add get and put compatibility aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ rc cp -r ./reports/ local/archive/ --include '*.csv' --exclude 'private-*' --new
 rc cp -r ./reports/ local/archive/ --rate-limit 10MiB/s --retry-attempts 5 --continue-on-error
 ```
 
+Direction-safe `mc` compatibility commands reuse the same copy planner:
+
+```bash
+rc get local/reports/report.json ./report.json
+rc put ./report.json local/reports/
+```
+
 When include rules are present, a path must match at least one of them. Exclude rules are applied
 after include rules and always win, regardless of flag order. Age filters compare source metadata in
 UTC: newer/older boundaries are strict, while `--rewind` includes the specified boundary. Rate,

--- a/crates/cli/src/commands/cp.rs
+++ b/crates/cli/src/commands/cp.rs
@@ -32,6 +32,16 @@ Examples:
   rc cp ./report.json local/my-bucket/reports/
   rc object copy local/source-bucket/archive.tar.gz ./downloads/archive.tar.gz";
 
+pub(crate) const GET_AFTER_HELP: &str = "\
+Examples:
+  rc get local/my-bucket/report.json ./report.json
+  rc get local/my-bucket/archive.tar.gz ./downloads/archive.tar.gz";
+
+pub(crate) const PUT_AFTER_HELP: &str = "\
+Examples:
+  rc put ./report.json local/my-bucket/reports/
+  rc put ./january.csv ./february.csv local/my-bucket/reports/";
+
 const REMOTE_PATH_SUGGESTION: &str =
     "Use a local filesystem path or a remote path in the form alias/bucket[/key].";
 const DEFAULT_TRANSFER_CONCURRENCY: usize = 4;
@@ -226,6 +236,32 @@ impl CpArgs {
     }
 }
 
+/// Download one remote object through the canonical copy implementation.
+#[derive(Args, Debug)]
+#[command(
+    override_usage = "rc get [OPTIONS] <SOURCE> <TARGET>",
+    after_help = GET_AFTER_HELP
+)]
+pub struct GetArgs {
+    #[command(flatten)]
+    pub transfer: CpArgs,
+}
+
+/// Upload one or more local paths through the canonical copy implementation.
+#[derive(Args, Debug)]
+#[command(after_help = PUT_AFTER_HELP)]
+pub struct PutArgs {
+    #[command(flatten)]
+    pub transfer: CpArgs,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TransferAlias {
+    Copy,
+    Get,
+    Put,
+}
+
 #[derive(Debug, Serialize)]
 struct CpOutput {
     status: &'static str,
@@ -253,8 +289,33 @@ struct VersionCopyData {
 }
 
 /// Execute the cp command
-pub async fn execute(mut args: CpArgs, output_config: OutputConfig) -> ExitCode {
+pub async fn execute(args: CpArgs, output_config: OutputConfig) -> ExitCode {
+    execute_with_alias(args, output_config, TransferAlias::Copy).await
+}
+
+/// Execute the mc-compatible `get` command through the canonical copy path.
+pub async fn execute_get(args: GetArgs, output_config: OutputConfig) -> ExitCode {
+    execute_with_alias(args.transfer, output_config, TransferAlias::Get).await
+}
+
+/// Execute the mc-compatible `put` command through the canonical copy path.
+pub async fn execute_put(args: PutArgs, output_config: OutputConfig) -> ExitCode {
+    execute_with_alias(args.transfer, output_config, TransferAlias::Put).await
+}
+
+async fn execute_with_alias(
+    mut args: CpArgs,
+    output_config: OutputConfig,
+    alias: TransferAlias,
+) -> ExitCode {
     let formatter = Formatter::new(output_config);
+
+    if alias == TransferAlias::Get && args.sources.len() != 1 {
+        return formatter.fail(
+            ExitCode::UsageError,
+            "get requires exactly one remote source and one local target",
+        );
+    }
 
     if let Err(error) = validate_destination_storage_class(args.storage_class.as_deref()) {
         return formatter.fail(exit_code_for_core_error(&error), &error.to_string());
@@ -290,7 +351,15 @@ pub async fn execute(mut args: CpArgs, output_config: OutputConfig) -> ExitCode 
     // Parse every operand before starting any transfer.
     let mut sources = Vec::with_capacity(args.sources.len());
     for source in &args.sources {
-        match parse_cp_path(source, alias_manager.as_ref().ok()) {
+        let parsed = match alias {
+            // `put` defines every source operand as a local path, including
+            // relative paths containing a slash that do not exist yet.
+            TransferAlias::Put => Ok(ParsedPath::Local(PathBuf::from(source))),
+            TransferAlias::Copy | TransferAlias::Get => {
+                parse_cp_path(source, alias_manager.as_ref().ok())
+            }
+        };
+        match parsed {
             Ok(path) => sources.push(path),
             Err(error) => {
                 return formatter.fail_with_suggestion(
@@ -302,7 +371,15 @@ pub async fn execute(mut args: CpArgs, output_config: OutputConfig) -> ExitCode 
         }
     }
 
-    let target = match parse_cp_path(&args.target, alias_manager.as_ref().ok()) {
+    let parsed_target = match alias {
+        // `get` defines its target operand as a local path. Do not reinterpret
+        // a non-existent `directory/file` path as an alias and bucket.
+        TransferAlias::Get => Ok(ParsedPath::Local(PathBuf::from(&args.target))),
+        TransferAlias::Copy | TransferAlias::Put => {
+            parse_cp_path(&args.target, alias_manager.as_ref().ok())
+        }
+    };
+    let target = match parsed_target {
         Ok(p) => p,
         Err(e) => {
             return formatter.fail_with_suggestion(
@@ -312,6 +389,9 @@ pub async fn execute(mut args: CpArgs, output_config: OutputConfig) -> ExitCode 
             );
         }
     };
+    if let Err(error) = validate_alias_direction(alias, &sources, &target) {
+        return formatter.fail(ExitCode::UsageError, error);
+    }
     if let Err(error) = validate_fidelity_directions(&args, &sources, &target) {
         return formatter.fail(exit_code_for_core_error(&error), &error.to_string());
     }
@@ -442,6 +522,24 @@ pub async fn execute(mut args: CpArgs, output_config: OutputConfig) -> ExitCode 
         target_encryption.as_ref(),
     )
     .await
+}
+
+fn validate_alias_direction(
+    alias: TransferAlias,
+    sources: &[ParsedPath],
+    target: &ParsedPath,
+) -> Result<(), &'static str> {
+    match alias {
+        TransferAlias::Copy => Ok(()),
+        TransferAlias::Get if sources.len() == 1 && sources[0].is_remote() && target.is_local() => {
+            Ok(())
+        }
+        TransferAlias::Get => Err("get requires exactly one remote source and one local target"),
+        TransferAlias::Put if sources.iter().all(ParsedPath::is_local) && target.is_remote() => {
+            Ok(())
+        }
+        TransferAlias::Put => Err("put requires one or more local sources and one remote target"),
+    }
 }
 
 fn uses_transfer_planner(args: &CpArgs) -> bool {
@@ -3709,5 +3807,49 @@ mod tests {
             validate_storage_class_plan(&plan, Some("STANDARD")),
             Err(Error::UnsupportedFeature(_))
         ));
+    }
+
+    #[test]
+    fn get_alias_accepts_only_one_remote_source_and_local_target() {
+        let remote = ParsedPath::Remote(RemotePath::new("local", "reports", "report.json"));
+        let other_remote = ParsedPath::Remote(RemotePath::new("local", "reports", "other.json"));
+        let local = ParsedPath::Local(PathBuf::from("./report.json"));
+
+        assert_eq!(
+            validate_alias_direction(TransferAlias::Get, std::slice::from_ref(&remote), &local),
+            Ok(())
+        );
+        assert_eq!(
+            validate_alias_direction(TransferAlias::Get, &[remote.clone(), other_remote], &local),
+            Err("get requires exactly one remote source and one local target")
+        );
+        assert_eq!(
+            validate_alias_direction(TransferAlias::Get, std::slice::from_ref(&local), &remote),
+            Err("get requires exactly one remote source and one local target")
+        );
+    }
+
+    #[test]
+    fn put_alias_accepts_only_local_sources_and_remote_target() {
+        let first_local = ParsedPath::Local(PathBuf::from("./january.csv"));
+        let second_local = ParsedPath::Local(PathBuf::from("./february.csv"));
+        let remote = ParsedPath::Remote(RemotePath::new("local", "reports", ""));
+
+        assert_eq!(
+            validate_alias_direction(
+                TransferAlias::Put,
+                &[first_local.clone(), second_local],
+                &remote
+            ),
+            Ok(())
+        );
+        assert_eq!(
+            validate_alias_direction(
+                TransferAlias::Put,
+                std::slice::from_ref(&remote),
+                &first_local
+            ),
+            Err("put requires one or more local sources and one remote target")
+        );
     }
 }

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -249,6 +249,12 @@ pub enum Commands {
     /// Deprecated: use `rc object copy`
     Cp(Box<cp::CpArgs>),
 
+    /// Download one remote object to the local filesystem
+    Get(Box<cp::GetArgs>),
+
+    /// Upload one or more local paths to remote object storage
+    Put(Box<cp::PutArgs>),
+
     /// Deprecated: use `rc object move`
     Mv(mv::MvArgs),
 
@@ -415,6 +421,12 @@ pub async fn execute(cli: Cli) -> ExitCode {
         }
         Commands::Cp(args) => {
             cp::execute(*args, output_options.resolve(OutputBehavior::HumanDefault)).await
+        }
+        Commands::Get(args) => {
+            cp::execute_get(*args, output_options.resolve(OutputBehavior::HumanDefault)).await
+        }
+        Commands::Put(args) => {
+            cp::execute_put(*args, output_options.resolve(OutputBehavior::HumanDefault)).await
         }
         Commands::Mv(args) => {
             mv::execute(args, output_options.resolve(OutputBehavior::HumanDefault)).await
@@ -1419,6 +1431,62 @@ mod tests {
                 assert!(args.summary);
             }
             other => panic!("expected cp command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_get_with_copy_options() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "get",
+            "local/reports/report.json",
+            "./report.json",
+            "--enc-c-source-key-env",
+            "RC_SSE_C_KEY",
+            "--retry-attempts",
+            "5",
+        ])
+        .expect("parse get compatibility command");
+
+        match cli.command {
+            Commands::Get(args) => {
+                assert_eq!(args.transfer.sources, ["local/reports/report.json"]);
+                assert_eq!(args.transfer.target, "./report.json");
+                assert_eq!(
+                    args.transfer.enc_c_source_key_env.as_deref(),
+                    Some("RC_SSE_C_KEY")
+                );
+                assert_eq!(args.transfer.retry_attempts, Some(5));
+            }
+            other => panic!("expected get command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cli_accepts_put_with_multiple_sources_and_copy_options() {
+        let cli = Cli::try_parse_from([
+            "rc",
+            "put",
+            "./january.csv",
+            "./february.csv",
+            "local/reports/",
+            "--storage-class",
+            "STANDARD",
+            "--concurrency",
+            "8",
+            "--summary",
+        ])
+        .expect("parse put compatibility command");
+
+        match cli.command {
+            Commands::Put(args) => {
+                assert_eq!(args.transfer.sources, ["./january.csv", "./february.csv"]);
+                assert_eq!(args.transfer.target, "local/reports/");
+                assert_eq!(args.transfer.storage_class.as_deref(), Some("STANDARD"));
+                assert_eq!(args.transfer.concurrency, Some(8));
+                assert!(args.transfer.summary);
+            }
+            other => panic!("expected put command, got {other:?}"),
         }
     }
 

--- a/crates/cli/tests/get_put_aliases.rs
+++ b/crates/cli/tests/get_put_aliases.rs
@@ -1,0 +1,114 @@
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+fn rc_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rc") {
+        return PathBuf::from(path);
+    }
+
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has parent directory")
+        .parent()
+        .expect("workspace root exists")
+        .join("target/debug/rc")
+}
+
+fn run_rc(config_dir: &Path, args: &[&str]) -> Output {
+    Command::new(rc_binary())
+        .env("RC_CONFIG_DIR", config_dir)
+        .current_dir(config_dir)
+        .args(args)
+        .output()
+        .expect("run rc")
+}
+
+#[test]
+fn directional_aliases_treat_slash_paths_on_the_local_side_as_local() {
+    let sandbox = tempfile::tempdir().expect("create sandbox");
+
+    let get = run_rc(
+        sandbox.path(),
+        &[
+            "get",
+            "unconfigured-alias/reports/report.txt",
+            "downloads/report.txt",
+        ],
+    );
+    assert_eq!(get.status.code(), Some(5));
+    assert!(String::from_utf8_lossy(&get.stderr).contains("Alias 'unconfigured-alias' not found"));
+
+    let put = run_rc(
+        sandbox.path(),
+        &[
+            "put",
+            "uploads/report.txt",
+            "unconfigured-alias/reports/report.txt",
+        ],
+    );
+    assert_eq!(put.status.code(), Some(5));
+    assert!(String::from_utf8_lossy(&put.stderr).contains("Source not found: uploads/report.txt"));
+}
+
+#[test]
+fn put_uses_the_same_missing_source_behavior_as_cp() {
+    let sandbox = tempfile::tempdir().expect("create sandbox");
+    let missing = sandbox.path().join("missing-source.txt");
+    let source = missing.to_string_lossy().into_owned();
+    let args = [source.as_str(), "unconfigured-alias/reports/report.txt"];
+
+    let cp = run_rc(sandbox.path(), &["cp", args[0], args[1]]);
+    let put = run_rc(sandbox.path(), &["put", args[0], args[1]]);
+
+    assert_eq!(put.status.code(), cp.status.code());
+    assert_eq!(put.stdout, cp.stdout);
+    assert_eq!(put.stderr, cp.stderr);
+    assert_eq!(put.status.code(), Some(5));
+}
+
+#[test]
+fn get_uses_the_same_missing_alias_behavior_as_cp() {
+    let sandbox = tempfile::tempdir().expect("create sandbox");
+    let target = sandbox.path().join("report.txt");
+    let target = target.to_string_lossy().into_owned();
+    let args = ["unconfigured-alias/reports/report.txt", target.as_str()];
+
+    let cp = run_rc(sandbox.path(), &["cp", args[0], args[1]]);
+    let get = run_rc(sandbox.path(), &["get", args[0], args[1]]);
+
+    assert_eq!(get.status.code(), cp.status.code());
+    assert_eq!(get.stdout, cp.stdout);
+    assert_eq!(get.stderr, cp.stderr);
+    assert_eq!(get.status.code(), Some(5));
+}
+
+#[test]
+fn direction_mismatches_fail_with_usage_before_remote_access() {
+    let sandbox = tempfile::tempdir().expect("create sandbox");
+    let local_source = sandbox.path().join("source.txt");
+    std::fs::write(&local_source, "payload").expect("write local source");
+    let local_target = sandbox.path().join("target.txt");
+    let source = local_source.to_string_lossy().into_owned();
+    let target = local_target.to_string_lossy().into_owned();
+
+    let get = run_rc(sandbox.path(), &["get", source.as_str(), target.as_str()]);
+    assert_eq!(get.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&get.stderr)
+            .contains("get requires exactly one remote source and one local target")
+    );
+
+    let put = run_rc(
+        sandbox.path(),
+        &[
+            "put",
+            "unconfigured-alias/reports/report.txt",
+            target.as_str(),
+        ],
+    );
+    assert_eq!(put.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&put.stderr)
+            .contains("put requires one or more local sources and one remote target")
+    );
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -128,6 +128,8 @@ fn top_level_command_help_contract() {
                 "head",
                 "stat",
                 "cp",
+                "get",
+                "put",
                 "mv",
                 "rm",
                 "pipe",
@@ -533,6 +535,26 @@ fn top_level_command_help_contract() {
                 "--versions",
                 "--incomplete",
                 "client-side S3 scan",
+            ],
+        },
+        HelpCase {
+            args: &["get"],
+            usage: "Usage: rc get [OPTIONS] <SOURCE> <TARGET>",
+            expected_tokens: &[
+                "Download one remote object",
+                "--enc-c-source-key-file",
+                "--retry-attempts",
+                "rc get local/my-bucket/report.json ./report.json",
+            ],
+        },
+        HelpCase {
+            args: &["put"],
+            usage: "Usage: rc put [OPTIONS] <SOURCE>... <TARGET>",
+            expected_tokens: &[
+                "Upload one or more local paths",
+                "--storage-class",
+                "--concurrency",
+                "rc put ./report.json local/my-bucket/reports/",
             ],
         },
     ];

--- a/docs/reference/rc/README.md
+++ b/docs/reference/rc/README.md
@@ -10,7 +10,7 @@ For installation and quick-start usage, see the [project README](../../../README
 | --- | --- | --- |
 | Configure targets | [`rc alias`](alias.md) | none |
 | Bucket workflows | [`rc bucket`](bucket.md) | `rc ls`, `rc mb`, `rc rb`, `rc event`, `rc cors`, `rc version`, `rc anonymous`, `rc quota`, `rc ilm`, `rc replicate`, `rc retention --default` |
-| Object workflows | [`rc object`](object.md) | `rc ls`, `rc cp`, `rc mv`, `rc rm`, `rc cat`, `rc head`, `rc stat`, `rc find`, `rc tree`, `rc share`, [`rc retention`](retention.md), [`rc legalhold`](legalhold.md) |
+| Object workflows | [`rc object`](object.md) | `rc ls`, `rc cp`, [`rc get`](get.md), [`rc put`](put.md), `rc mv`, `rc rm`, `rc cat`, `rc head`, `rc stat`, `rc find`, `rc tree`, `rc share`, [`rc retention`](retention.md), [`rc legalhold`](legalhold.md) |
 | Administrative workflows | [`rc admin`](admin.md) | none |
 | Operational health and usage | [`rc ping`, `rc ready`, `rc du`](ops.md) | none |
 | Encryption guide | [`Encryption workflows`](encryption.md) | `rc bucket encryption`, `rc cp --enc-*`, `rc mv --enc-*`, `rc pipe --enc-*` |
@@ -31,6 +31,8 @@ Legacy command pages remain documented for users migrating from MinIO `mc`-style
 - [`rc head`](head.md)
 - [`rc stat`](stat.md)
 - [`rc cp`](cp.md)
+- [`rc get`](get.md)
+- [`rc put`](put.md)
 - [`rc mv`](mv.md)
 - [`rc rm`](rm.md)
 - [`rc find`](find.md)

--- a/docs/reference/rc/get.md
+++ b/docs/reference/rc/get.md
@@ -1,0 +1,28 @@
+# rc get
+
+## Purpose
+
+`rc get` downloads one remote object to the local filesystem. It is an
+`mc get`-compatible, direction-safe entry point to the same planner, transfer
+execution, progress, retry, error, and output path used by `rc cp`.
+
+## Syntax
+
+```bash
+rc [GLOBAL OPTIONS] get [OPTIONS] <SOURCE> <TARGET>
+```
+
+`SOURCE` must be a remote `ALIAS/BUCKET/KEY` path and `TARGET` must be a local
+filesystem path. Other directions fail with the usage exit code before a
+transfer starts.
+
+## Examples
+
+```bash
+rc get local/reports/report.json ./report.json
+rc get local/archive/releases/app.tar.gz ./downloads/app.tar.gz
+```
+
+All applicable `rc cp` options remain available, including retry, progress,
+checksum verification, version selection, and secure SSE-C source-key inputs.
+See [`rc cp`](cp.md) for the shared transfer behavior and option reference.

--- a/docs/reference/rc/put.md
+++ b/docs/reference/rc/put.md
@@ -1,0 +1,30 @@
+# rc put
+
+## Purpose
+
+`rc put` uploads one or more local paths to remote object storage. It is an
+`mc put`-compatible, direction-safe entry point to the same planner, transfer
+execution, progress, retry, error, and output path used by `rc cp`.
+
+## Syntax
+
+```bash
+rc [GLOBAL OPTIONS] put [OPTIONS] <SOURCE>... <TARGET>
+```
+
+Every `SOURCE` must be a local filesystem path and `TARGET` must be a remote
+`ALIAS/BUCKET[/KEY]` path. Other directions fail with the usage exit code
+before a transfer starts. Multiple sources require a remote prefix ending in
+`/`, matching the canonical copy planner.
+
+## Examples
+
+```bash
+rc put ./report.json local/reports/
+rc put ./january.csv ./february.csv local/reports/ --concurrency 8 --summary
+```
+
+All applicable `rc cp` options remain available, including metadata, tags,
+checksums, storage class, object-lock headers, secure encryption inputs, and
+bulk transfer controls. See [`rc cp`](cp.md) for the shared transfer behavior
+and option reference.


### PR DESCRIPTION
## Summary

- add top-level `rc get` and `rc put` compatibility commands
- route both commands through the existing `cp` planner and execution path
- enforce download/upload direction before any remote request
- keep non-existent local paths containing `/` from being misclassified as remote aliases
- add parser, direction, exit-code/equivalence, help-contract, and documentation coverage

## Why

RustFS CLI has the canonical copy implementation, but the mc-compatible `get` and `put` entry points from rustfs/backlog#1382 were still missing. Thin direction-aware wrappers provide compatibility without duplicating transfer behavior.

## User impact

`rc get` accepts exactly one remote source and a local target. `rc put` accepts one or more local sources and a remote target. Retry, progress, errors, fidelity options, and output remain identical to `rc cp` because all commands use the same implementation.

## BREAKING change assessment

BREAKING: no. These are new compatibility entry points and do not change the existing `rc cp` interface or execution behavior. The marker is included because this PR updates protected command reference documentation.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

Closes rustfs/backlog#1485
Refs rustfs/backlog#1382