### PR TITLE
feat(admin): report observed storage metrics safely

### DIFF
--- a/crates/cli/src/commands/admin/info.rs
+++ b/crates/cli/src/commands/admin/info.rs
@@ -9,9 +9,10 @@ use std::collections::BTreeSet;
 use super::{emit_observability_error, get_admin_client};
 use crate::exit_code::ExitCode;
 use crate::output::Formatter;
+use rc_core::Error;
 use rc_core::admin::{
-    AdminApi, ClusterInfo, DiskInfo, ObservabilityApi, ServerInfo, StorageBackend, StorageDisk,
-    StorageInfo,
+    AdminApi, CapabilityApi, CapabilityAvailability, ClusterInfo, DiagnosticCapability, DiskInfo,
+    ObservabilityApi, ServerInfo, StorageBackend, StorageDisk, StorageDiskMetrics, StorageInfo,
 };
 
 /// Info subcommands
@@ -64,6 +65,10 @@ pub struct DiskArgs {
 pub struct StorageArgs {
     /// Alias name of the server
     pub alias: String,
+
+    /// Include observed drive metrics from storage information
+    #[arg(long)]
+    pub metrics: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -115,6 +120,20 @@ struct StorageDiskOutput<'a> {
     set_index: i32,
     disk_index: i32,
     offline_duration_seconds: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    observations: Option<StorageDiskObservations<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct StorageDiskObservations<'a> {
+    source: &'static str,
+    mode: &'static str,
+    read_throughput: Option<f64>,
+    write_throughput: Option<f64>,
+    read_latency: Option<f64>,
+    write_latency: Option<f64>,
+    utilization: Option<f64>,
+    operation_counters: Option<&'a StorageDiskMetrics>,
 }
 
 /// JSON output for cluster info
@@ -228,12 +247,42 @@ async fn execute_storage(args: StorageArgs, formatter: &Formatter) -> ExitCode {
         Err(code) => return code,
     };
 
+    if args.metrics {
+        let report = match client.discover_capabilities(false).await {
+            Ok(report) => report,
+            Err(error) => {
+                return emit_observability_error(
+                    "storage_info",
+                    DiagnosticCapability::DriveObservations.name(),
+                    "Failed to discover storage metric capabilities",
+                    &error,
+                    formatter,
+                );
+            }
+        };
+        if let Err(error) =
+            report.require_diagnostic_capability(DiagnosticCapability::DriveObservations)
+        {
+            let error = match error.availability() {
+                CapabilityAvailability::PermissionDenied => Error::Auth(error.to_string()),
+                _ => Error::UnsupportedFeature(error.to_string()),
+            };
+            return emit_observability_error(
+                "storage_info",
+                DiagnosticCapability::DriveObservations.name(),
+                "Observed storage metrics are unavailable",
+                &error,
+                formatter,
+            );
+        }
+    }
+
     match client.storage_info().await {
         Ok(info) => {
             if formatter.is_json() {
-                formatter.json(&storage_success_output(&info));
+                formatter.json(&storage_success_output(&info, args.metrics));
             } else {
-                print_storage_info(&info, formatter);
+                print_storage_info(&info, args.metrics, formatter);
             }
             ExitCode::Success
         }
@@ -247,7 +296,7 @@ async fn execute_storage(args: StorageArgs, formatter: &Formatter) -> ExitCode {
     }
 }
 
-fn storage_success_output(info: &StorageInfo) -> StorageSuccessOutput<'_> {
+fn storage_success_output(info: &StorageInfo, include_metrics: bool) -> StorageSuccessOutput<'_> {
     let online_disks = info.online_disks();
     let total_capacity = info.total_capacity();
     let used_capacity = info.used_capacity();
@@ -266,7 +315,11 @@ fn storage_success_output(info: &StorageInfo) -> StorageSuccessOutput<'_> {
                 available_capacity_bytes: total_capacity.saturating_sub(used_capacity),
             },
             backend: storage_backend_output(&info.backend),
-            disks: info.disks.iter().map(storage_disk_output).collect(),
+            disks: info
+                .disks
+                .iter()
+                .map(|disk| storage_disk_output(disk, include_metrics))
+                .collect(),
         },
     }
 }
@@ -279,7 +332,7 @@ fn storage_backend_output(backend: &StorageBackend) -> StorageBackendOutput<'_> 
     }
 }
 
-fn storage_disk_output(disk: &StorageDisk) -> StorageDiskOutput<'_> {
+fn storage_disk_output(disk: &StorageDisk, include_metrics: bool) -> StorageDiskOutput<'_> {
     StorageDiskOutput {
         endpoint: &disk.endpoint,
         path: &disk.drive_path,
@@ -294,10 +347,20 @@ fn storage_disk_output(disk: &StorageDisk) -> StorageDiskOutput<'_> {
         set_index: disk.set_index,
         disk_index: disk.disk_index,
         offline_duration_seconds: disk.offline_duration_seconds,
+        observations: include_metrics.then_some(StorageDiskObservations {
+            source: "storage_info",
+            mode: "observed",
+            read_throughput: disk.read_throughput,
+            write_throughput: disk.write_throughput,
+            read_latency: disk.read_latency,
+            write_latency: disk.write_latency,
+            utilization: disk.utilization,
+            operation_counters: disk.metrics.as_ref(),
+        }),
     }
 }
 
-fn print_storage_info(info: &StorageInfo, formatter: &Formatter) {
+fn print_storage_info(info: &StorageInfo, include_metrics: bool, formatter: &Formatter) {
     let online = info.online_disks();
     let offline = info.disks.len().saturating_sub(online);
     formatter.println(&formatter.style_name("Storage Information"));
@@ -329,6 +392,50 @@ fn print_storage_info(info: &StorageInfo, formatter: &Formatter) {
             ));
         }
     }
+    if include_metrics {
+        formatter.println("");
+        formatter.println("Observed storage metrics (server-reported; not a benchmark)");
+        for disk in &info.disks {
+            formatter.println(&format!(
+                "{} {}",
+                formatter.sanitize_text(&disk.endpoint),
+                formatter.sanitize_text(&disk.drive_path)
+            ));
+            formatter.println(&format!(
+                "  read_throughput={} write_throughput={} read_latency={} write_latency={} utilization={}",
+                observed_value(disk.read_throughput),
+                observed_value(disk.write_throughput),
+                observed_value(disk.read_latency),
+                observed_value(disk.write_latency),
+                observed_value(disk.utilization),
+            ));
+            if let Some(metrics) = &disk.metrics {
+                formatter.println(&format!(
+                    "  waiting={} availability_errors={} timeout_errors={} writes={} deletes={}",
+                    metrics.total_waiting,
+                    metrics.total_errors_availability,
+                    metrics.total_errors_timeout,
+                    metrics.total_writes,
+                    metrics.total_deletes,
+                ));
+                if !metrics.api_calls.is_empty() {
+                    let api_calls = metrics
+                        .api_calls
+                        .iter()
+                        .map(|(name, count)| format!("{}={count}", formatter.sanitize_text(name)))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    formatter.println(&format!("  api_calls: {api_calls}"));
+                }
+            } else {
+                formatter.println("  operation_counters=unavailable");
+            }
+        }
+    }
+}
+
+fn observed_value(value: Option<f64>) -> String {
+    value.map_or_else(|| "unavailable".to_string(), |value| value.to_string())
 }
 
 async fn execute_cluster(args: ClusterArgs, formatter: &Formatter) -> ExitCode {

--- a/crates/cli/tests/admin_storage_info.rs
+++ b/crates/cli/tests/admin_storage_info.rs
@@ -6,7 +6,9 @@ use std::path::Path;
 use std::process::Command;
 use std::time::Duration;
 
-use admin_support::{rc_binary, rc_host_alias, start_admin_response_test_server};
+use admin_support::{
+    rc_binary, rc_host_alias, start_admin_response_test_server, start_admin_sequence_test_server,
+};
 use jsonschema::Validator;
 use serde_json::Value;
 
@@ -19,6 +21,55 @@ const STORAGE_RESPONSE: &str = r#"{
     "backend":{"BackendType":"Erasure","OnlineDisks":{"set-1":1},"OfflineDisks":{"set-1":1},"StandardSCParity":1,"TotalSets":[1],"DrivesPerSet":[2]}
   },
   "admin_discovery":{"runtimeCapabilities":"/rustfs/admin/v4/runtime/capabilities"}
+}"#;
+const CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const UNKNOWN_CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.11","drives":[]}]}}"#;
+const RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled"},"memory_sampling":{"state":"unsupported"},"platform":{"state":"supported"},"topology":{"state":"supported"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"supported"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"supported"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+const STORAGE_METRICS_RESPONSE: &str = r#"{
+  "info":{
+    "disks":[
+      {
+        "endpoint":"http://node1:9000",
+        "path":"/data1",
+        "state":"online",
+        "runtimeState":"online",
+        "totalspace":100,
+        "usedspace":40,
+        "availspace":60,
+        "readthroughput":125.5,
+        "writethroughput":81.25,
+        "readlatency":0.75,
+        "writelatency":1.25,
+        "utilization":40.0,
+        "metrics":{
+          "last_minute":{"read":{"count":4}},
+          "api_calls":{"GetObject":9},
+          "total_waiting":2,
+          "total_errors_availability":3,
+          "total_errors_timeout":4,
+          "total_writes":5,
+          "total_deletes":6
+        },
+        "pool_index":0,
+        "set_index":0,
+        "disk_index":0
+      },
+      {
+        "endpoint":"http://node1:9000",
+        "path":"/data2",
+        "state":"online",
+        "totalspace":200,
+        "usedspace":50,
+        "availspace":150,
+        "pool_index":0,
+        "set_index":0,
+        "disk_index":1
+      }
+    ],
+    "backend":{"BackendType":"Erasure","OnlineDisks":{"set-1":2},"OfflineDisks":{}}
+  }
 }"#;
 
 fn output_v3_validator() -> Validator {
@@ -142,5 +193,146 @@ fn storage_info_rejects_malformed_payload() {
         .expect("run rc command");
 
     assert_eq!(output.status.code(), Some(1));
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn storage_metrics_json_is_capability_gated_and_labels_observations() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", CAPABILITY_INFO_RESPONSE),
+        ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", STORAGE_METRICS_RESPONSE),
+    ]);
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "info", "storage", "myalias", "--metrics"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    let first = &value["data"]["disks"][0]["observations"];
+    assert_eq!(first["source"], "storage_info");
+    assert_eq!(first["mode"], "observed");
+    assert_eq!(first["read_throughput"], 125.5);
+    assert_eq!(first["write_latency"], 1.25);
+    assert_eq!(first["utilization"], 40.0);
+    assert_eq!(first["operation_counters"]["total_waiting"], 2);
+    assert_eq!(first["operation_counters"]["api_calls"]["GetObject"], 9);
+
+    let missing = &value["data"]["disks"][1]["observations"];
+    assert_eq!(missing["source"], "storage_info");
+    assert_eq!(missing["mode"], "observed");
+    assert!(missing["read_throughput"].is_null());
+    assert!(missing["write_throughput"].is_null());
+    assert!(missing["read_latency"].is_null());
+    assert!(missing["write_latency"].is_null());
+    assert!(missing["utilization"].is_null());
+    assert!(missing["operation_counters"].is_null());
+    assert!(output_v3_validator().is_valid(&value));
+
+    let requests = (0..5)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured admin request")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.target.as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "/rustfs/admin/v3/info",
+            "/rustfs/admin/v4/runtime/capabilities",
+            "/rustfs/admin/v4/extensions/catalog",
+            "/rustfs/admin/v4/cluster/snapshot",
+            "/rustfs/admin/v3/storageinfo",
+        ]
+    );
+    assert!(
+        requests
+            .iter()
+            .all(|request| !request.target.contains("/speedtest/drive"))
+    );
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn storage_metrics_human_output_is_observed_and_explicitly_unavailable() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", CAPABILITY_INFO_RESPONSE),
+        ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", STORAGE_METRICS_RESPONSE),
+    ]);
+    let output = Command::new(rc_binary())
+        .args(["admin", "info", "storage", "myalias", "--metrics"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(
+        stdout.contains("Observed storage metrics"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("not a benchmark"), "stdout: {stdout}");
+    assert!(stdout.contains("read_throughput=125.5"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("read_throughput=unavailable"),
+        "stdout: {stdout}"
+    );
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn storage_metrics_fail_closed_when_capability_is_unknown() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", UNKNOWN_CAPABILITY_INFO_RESPONSE),
+        ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+    ]);
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "info", "storage", "myalias", "--metrics"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(7));
+    let value: Value = serde_json::from_slice(&output.stderr).expect("stderr should be JSON");
+    assert_eq!(value["error"]["type"], "unsupported_feature");
+    assert_eq!(
+        value["error"]["capability"],
+        "admin.diagnostics.drive-observations"
+    );
+    let requests = (0..4)
+        .map(|_| {
+            receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("captured admin request")
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.target != "/rustfs/admin/v3/storageinfo")
+    );
     handle.join().expect("admin test server finished");
 }

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -640,7 +640,7 @@ fn nested_subcommand_help_contract() {
         HelpCase {
             args: &["admin", "info", "storage"],
             usage: "Usage: rc admin info storage [OPTIONS] <ALIAS>",
-            expected_tokens: &[],
+            expected_tokens: &["--metrics"],
         },
         HelpCase {
             args: &["admin", "scanner"],

--- a/crates/core/src/admin/observability.rs
+++ b/crates/core/src/admin/observability.rs
@@ -463,15 +463,15 @@ pub struct StorageDisk {
     #[serde(rename = "availspace", default)]
     pub available_space: u64,
     #[serde(rename = "readthroughput", default)]
-    pub read_throughput: f64,
+    pub read_throughput: Option<f64>,
     #[serde(rename = "writethroughput", default)]
-    pub write_throughput: f64,
+    pub write_throughput: Option<f64>,
     #[serde(rename = "readlatency", default)]
-    pub read_latency: f64,
+    pub read_latency: Option<f64>,
     #[serde(rename = "writelatency", default)]
-    pub write_latency: f64,
+    pub write_latency: Option<f64>,
     #[serde(default)]
-    pub utilization: f64,
+    pub utilization: Option<f64>,
     #[serde(default)]
     pub metrics: Option<StorageDiskMetrics>,
     #[serde(default)]
@@ -718,6 +718,31 @@ mod tests {
         assert_eq!(info.disks[0].used_space, 40);
         assert_eq!(info.backend.kind, StorageBackendKind::Erasure);
         assert_eq!(info.backend.online_disks.values().sum::<usize>(), 1);
+    }
+
+    #[test]
+    fn storage_info_preserves_missing_observations_as_unavailable() {
+        let info: StorageInfo = serde_json::from_str(
+            r#"{
+                "disks":[{
+                    "endpoint":"http://node1:9000",
+                    "path":"/data1",
+                    "state":"online",
+                    "totalspace":100,
+                    "usedspace":40,
+                    "availspace":60
+                }],
+                "backend":{"BackendType":"Erasure"}
+            }"#,
+        )
+        .expect("storage info should deserialize");
+
+        assert!(info.disks[0].read_throughput.is_none());
+        assert!(info.disks[0].write_throughput.is_none());
+        assert!(info.disks[0].read_latency.is_none());
+        assert!(info.disks[0].write_latency.is_none());
+        assert!(info.disks[0].utilization.is_none());
+        assert!(info.disks[0].metrics.is_none());
     }
 
     fn scanner_fixture(

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -97,6 +97,7 @@ Inspect scanner health and storage topology:
 ```bash
 rc admin scanner status local
 rc admin info storage local
+rc admin info storage local --metrics
 ```
 
 Collect two scanner and disk metric snapshots:
@@ -230,7 +231,7 @@ The read-only observability commands target RustFS Admin API v3 routes introduce
 | Command | Description |
 | --- | --- |
 | `rc admin scanner status <ALIAS>` | Classify scanner state as `healthy`, `stale`, `empty`, `partial`, or `disabled` and retain current server diagnostic fields. |
-| `rc admin info storage <ALIAS>` | Show backend topology, disk health, and aggregate capacity. |
+| `rc admin info storage <ALIAS> [--metrics]` | Show backend topology, disk health, and aggregate capacity; optionally include observed drive telemetry. |
 | `rc admin metrics <ALIAS> [OPTIONS]` | Stream bounded realtime metric snapshots. |
 
 `admin metrics` accepts these query and output options:
@@ -246,6 +247,13 @@ The read-only observability commands target RustFS Admin API v3 routes introduce
 | `--metrics-format normalized\|raw` | Emit v3 normalized JSON Lines or bounded raw server JSON records. |
 
 Normalized metrics always use one compact v3 JSON object per line, including numeric samples, labels, per-sample timestamps, errors, partial/final markers, and the retained raw snapshot. Raw mode intentionally omits the v3 wrapper. The client rejects responses above 16 MiB, individual records above 1 MiB, and records beyond the requested sample count.
+
+`admin info storage --metrics` reads only `/rustfs/admin/v3/storageinfo` after
+confirming the `admin.diagnostics.drive-observations` capability. It reports
+server-observed throughput, latency, utilization, and operation counters; it
+does not run `/v3/speedtest/drive` and must not be interpreted as a benchmark.
+Missing observations are shown as `unavailable` in human output and `null` in
+JSON rather than being fabricated as zero.
 
 Permission failures return the authentication exit code. A missing observability route returns `unsupported_feature`, allowing automation to distinguish an older RustFS server from missing credentials. Malformed and oversized responses fail without emitting partial normalized records.
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -633,7 +633,76 @@
       "properties": {
         "summary": { "$ref": "#/definitions/storageSummary" },
         "backend": { "type": "object" },
-        "disks": { "type": "array", "items": { "type": "object" } }
+        "disks": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/storageInfoDisk" }
+        }
+      }
+    },
+    "storageInfoDisk": {
+      "type": "object",
+      "required": [
+        "endpoint", "path", "state", "runtime_state", "total_space",
+        "used_space", "available_space", "healing", "scanning", "pool_index",
+        "set_index", "disk_index", "offline_duration_seconds"
+      ],
+      "properties": {
+        "endpoint": { "type": "string" },
+        "path": { "type": "string" },
+        "state": { "type": "string" },
+        "runtime_state": { "$ref": "#/definitions/nullableString" },
+        "total_space": { "type": "integer", "minimum": 0 },
+        "used_space": { "type": "integer", "minimum": 0 },
+        "available_space": { "type": "integer", "minimum": 0 },
+        "healing": { "type": "boolean" },
+        "scanning": { "type": "boolean" },
+        "pool_index": { "type": "integer" },
+        "set_index": { "type": "integer" },
+        "disk_index": { "type": "integer" },
+        "offline_duration_seconds": { "type": ["integer", "null"], "minimum": 0 },
+        "observations": { "$ref": "#/definitions/storageDiskObservations" }
+      }
+    },
+    "storageDiskObservations": {
+      "type": "object",
+      "required": [
+        "source", "mode", "read_throughput", "write_throughput",
+        "read_latency", "write_latency", "utilization", "operation_counters"
+      ],
+      "properties": {
+        "source": { "const": "storage_info" },
+        "mode": { "const": "observed" },
+        "read_throughput": { "type": ["number", "null"] },
+        "write_throughput": { "type": ["number", "null"] },
+        "read_latency": { "type": ["number", "null"] },
+        "write_latency": { "type": ["number", "null"] },
+        "utilization": { "type": ["number", "null"] },
+        "operation_counters": {
+          "oneOf": [
+            { "$ref": "#/definitions/storageDiskOperationCounters" },
+            { "type": "null" }
+          ]
+        }
+      }
+    },
+    "storageDiskOperationCounters": {
+      "type": "object",
+      "required": [
+        "last_minute", "api_calls", "total_waiting",
+        "total_errors_availability", "total_errors_timeout",
+        "total_writes", "total_deletes"
+      ],
+      "properties": {
+        "last_minute": { "type": "object" },
+        "api_calls": {
+          "type": "object",
+          "additionalProperties": { "type": "integer", "minimum": 0 }
+        },
+        "total_waiting": { "type": "integer", "minimum": 0 },
+        "total_errors_availability": { "type": "integer", "minimum": 0 },
+        "total_errors_timeout": { "type": "integer", "minimum": 0 },
+        "total_writes": { "type": "integer", "minimum": 0 },
+        "total_deletes": { "type": "integer", "minimum": 0 }
       }
     },
     "kmsCacheSummary": {


### PR DESCRIPTION
## Summary

- add `rc admin info storage <ALIAS> --metrics`
- fail closed on the `admin.diagnostics.drive-observations` capability
- read only `/rustfs/admin/v3/storageinfo`; never invoke the mutating drive speed-test endpoint
- label output as `source=storage_info` and `mode=observed`, with unavailable values represented as `null`/`unavailable`
- add typed output, schema v3, help, documentation, request-sequence, and golden coverage

## Why

rustfs/backlog#1407 requires diagnostic storage observations without accidentally starting a benchmark. Existing deserialization also defaulted absent numeric fields to `0`, which fabricated measurements for older payloads.

## User impact

Operators can inspect server-observed throughput, latency, utilization, and operation counts. Output explicitly states that it is not a benchmark, and missing observations are never presented as zero.

## BREAKING change assessment

BREAKING: `StorageDisk` observation fields change from `f64` to `Option<f64>` so an absent server observation cannot be misrepresented as a real zero. This is a source-level model change for external `rc-core` consumers; all repository consumers and tests have been migrated.

## Validation

- focused core, S3, CLI storage-info, help-contract, schema, and golden tests
- request capture proving `/speedtest/drive` is never called
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

Closes rustfs/backlog#1407
Refs rustfs/backlog#1383