### PR TITLE
feat(alias): add secret-safe export and import

### DIFF
--- a/crates/cli/src/commands/alias.rs
+++ b/crates/cli/src/commands/alias.rs
@@ -3,8 +3,12 @@
 //! Aliases are named references to S3-compatible storage endpoints,
 //! including connection details and credentials.
 
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+
 use clap::Subcommand;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::exit_code::ExitCode;
 use crate::output::{Formatter, OutputConfig};
@@ -22,6 +26,12 @@ pub enum AliasCommands {
 
     /// Remove an alias
     Remove(RemoveArgs),
+
+    /// Export aliases as a portable JSON document
+    Export(ExportArgs),
+
+    /// Import aliases from a portable JSON document
+    Import(ImportArgs),
 }
 
 /// Arguments for the `alias set` command
@@ -87,6 +97,82 @@ pub struct RemoveArgs {
     pub name: String,
 }
 
+/// Arguments for the `alias export` command
+#[derive(clap::Args, Debug)]
+pub struct ExportArgs {
+    /// Alias names to export; omit to export every configured alias
+    pub names: Vec<String>,
+
+    /// Write the export to a file instead of stdout
+    #[arg(short, long, value_name = "FILE")]
+    pub output: Option<PathBuf>,
+
+    /// Include access keys and secret keys in the export
+    #[arg(long, requires = "acknowledge_credentials")]
+    pub include_credentials: bool,
+
+    /// Acknowledge that the exported document contains plaintext credentials
+    #[arg(long, requires = "include_credentials")]
+    pub acknowledge_credentials: bool,
+
+    /// Replace an existing output file
+    #[arg(long, requires = "output")]
+    pub force: bool,
+}
+
+/// Arguments for the `alias import` command
+#[derive(clap::Args, Debug)]
+pub struct ImportArgs {
+    /// Portable alias JSON document to import
+    pub input: PathBuf,
+
+    /// Replace aliases with conflicting names
+    #[arg(long)]
+    pub replace: bool,
+}
+
+const ALIAS_EXPORT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AliasExportDocument {
+    schema_version: u32,
+    aliases: Vec<PortableAlias>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PortableAlias {
+    name: String,
+    endpoint: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    credentials: Option<PortableCredentials>,
+    #[serde(default)]
+    anonymous: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    client_cert: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    client_key: Option<String>,
+    region: String,
+    signature: String,
+    bucket_lookup: String,
+    #[serde(default)]
+    insecure: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ca_bundle: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    retry: Option<rc_core::alias::RetryConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    timeout: Option<rc_core::alias::TimeoutConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PortableCredentials {
+    access_key: String,
+    secret_key: String,
+}
+
 /// JSON output for alias list
 #[derive(Serialize)]
 struct AliasListOutput {
@@ -145,6 +231,8 @@ pub async fn execute(cmd: AliasCommands, output_config: OutputConfig) -> ExitCod
         AliasCommands::Set(args) => execute_set(*args, &alias_manager, &formatter).await,
         AliasCommands::List(args) => execute_list(args, &alias_manager, &formatter).await,
         AliasCommands::Remove(args) => execute_remove(args, &alias_manager, &formatter).await,
+        AliasCommands::Export(args) => execute_export(args, &alias_manager, &formatter),
+        AliasCommands::Import(args) => execute_import(args, &alias_manager, &formatter),
     }
 }
 
@@ -346,6 +434,272 @@ async fn execute_list(args: ListArgs, manager: &AliasManager, formatter: &Format
     }
 }
 
+fn execute_export(args: ExportArgs, manager: &AliasManager, formatter: &Formatter) -> ExitCode {
+    let aliases = if args.names.is_empty() {
+        manager.list()
+    } else {
+        args.names
+            .iter()
+            .map(|name| manager.get(name))
+            .collect::<rc_core::Result<Vec<_>>>()
+    };
+    let mut aliases = match aliases {
+        Ok(aliases) => aliases,
+        Err(error) => {
+            let code = exit_code_from_error(&error);
+            return formatter.fail(code, &error.to_string());
+        }
+    };
+    aliases.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let document = AliasExportDocument {
+        schema_version: ALIAS_EXPORT_SCHEMA_VERSION,
+        aliases: aliases
+            .iter()
+            .map(|alias| PortableAlias::from_alias(alias, args.include_credentials))
+            .collect(),
+    };
+    let mut contents = match serde_json::to_vec_pretty(&document) {
+        Ok(contents) => contents,
+        Err(error) => {
+            return formatter.fail(
+                ExitCode::GeneralError,
+                &format!("Failed to serialize aliases: {error}"),
+            );
+        }
+    };
+    contents.push(b'\n');
+
+    if let Some(output) = args.output {
+        match write_export_file(&output, &contents, args.force) {
+            Ok(()) => {
+                formatter.success(&format!(
+                    "Exported {} alias(es) to {}.",
+                    document.aliases.len(),
+                    output.display()
+                ));
+                ExitCode::Success
+            }
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => formatter.fail(
+                ExitCode::Conflict,
+                &format!(
+                    "Export file '{}' already exists; retry with --force to replace it",
+                    output.display()
+                ),
+            ),
+            Err(error) => formatter.fail(
+                ExitCode::GeneralError,
+                &format!("Failed to write export '{}': {error}", output.display()),
+            ),
+        }
+    } else {
+        match io::stdout().write_all(&contents) {
+            Ok(()) => ExitCode::Success,
+            Err(error) => formatter.fail(
+                ExitCode::GeneralError,
+                &format!("Failed to write alias export: {error}"),
+            ),
+        }
+    }
+}
+
+fn execute_import(args: ImportArgs, manager: &AliasManager, formatter: &Formatter) -> ExitCode {
+    let contents = match fs::read(&args.input) {
+        Ok(contents) => contents,
+        Err(error) => {
+            return formatter.fail(
+                ExitCode::GeneralError,
+                &format!("Failed to read import '{}': {error}", args.input.display()),
+            );
+        }
+    };
+    let document: AliasExportDocument = match serde_json::from_slice(&contents) {
+        Ok(document) => document,
+        Err(error) => {
+            return formatter.fail(
+                ExitCode::UsageError,
+                &format!("Malformed alias import document: {error}"),
+            );
+        }
+    };
+    if document.schema_version != ALIAS_EXPORT_SCHEMA_VERSION {
+        return formatter.fail(
+            ExitCode::UsageError,
+            &format!(
+                "Unsupported alias export schema version {}; expected {}",
+                document.schema_version, ALIAS_EXPORT_SCHEMA_VERSION
+            ),
+        );
+    }
+    if document.aliases.is_empty() {
+        return formatter.fail(
+            ExitCode::UsageError,
+            "Alias import document contains no aliases",
+        );
+    }
+
+    let aliases = match document
+        .aliases
+        .into_iter()
+        .map(PortableAlias::into_alias)
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(aliases) => aliases,
+        Err(error) => return formatter.fail(ExitCode::UsageError, &error),
+    };
+    let imported = aliases.len();
+    match manager.import(aliases, args.replace) {
+        Ok(()) => {
+            formatter.success(&format!("Imported {imported} alias(es)."));
+            ExitCode::Success
+        }
+        Err(error) => {
+            let code = if matches!(&error, Error::Config(_)) {
+                ExitCode::Conflict
+            } else {
+                exit_code_from_error(&error)
+            };
+            formatter.fail(code, &error.to_string())
+        }
+    }
+}
+
+impl PortableAlias {
+    fn from_alias(alias: &Alias, include_credentials: bool) -> Self {
+        Self {
+            name: alias.name.clone(),
+            endpoint: alias.endpoint.clone(),
+            credentials: (include_credentials
+                && !alias.anonymous
+                && !alias.access_key.is_empty()
+                && !alias.secret_key.is_empty())
+            .then(|| PortableCredentials {
+                access_key: alias.access_key.clone(),
+                secret_key: alias.secret_key.clone(),
+            }),
+            anonymous: alias.anonymous,
+            client_cert: alias.client_cert.clone(),
+            client_key: alias.client_key.clone(),
+            region: alias.region.clone(),
+            signature: alias.signature.clone(),
+            bucket_lookup: alias.bucket_lookup.clone(),
+            insecure: alias.insecure,
+            ca_bundle: alias.ca_bundle.clone(),
+            retry: alias.retry.clone(),
+            timeout: alias.timeout.clone(),
+        }
+    }
+
+    fn into_alias(self) -> Result<Alias, String> {
+        if !is_valid_portable_alias_name(&self.name) {
+            return Err(format!(
+                "Invalid alias name '{}'; use letters, numbers, underscores, or hyphens",
+                self.name
+            ));
+        }
+        validate_alias_endpoint(&self.endpoint)
+            .map_err(|error| format!("Alias '{}' has an invalid endpoint: {error}", self.name))?;
+        if self.signature != "v4" {
+            return Err(format!(
+                "Alias '{}' uses unsupported signature '{}'; expected v4",
+                self.name, self.signature
+            ));
+        }
+        if !matches!(self.bucket_lookup.as_str(), "auto" | "path" | "dns") {
+            return Err(format!(
+                "Alias '{}' has invalid bucket lookup '{}'",
+                self.name, self.bucket_lookup
+            ));
+        }
+        if self.client_cert.is_some() != self.client_key.is_some() {
+            return Err(format!(
+                "Alias '{}' must include both client_cert and client_key",
+                self.name
+            ));
+        }
+
+        let (access_key, secret_key) = match self.credentials {
+            Some(credentials)
+                if credentials.access_key.is_empty() || credentials.secret_key.is_empty() =>
+            {
+                return Err(format!(
+                    "Alias '{}' contains incomplete credentials",
+                    self.name
+                ));
+            }
+            Some(credentials) => (credentials.access_key, credentials.secret_key),
+            None => (String::new(), String::new()),
+        };
+        if self.anonymous && (!access_key.is_empty() || !secret_key.is_empty()) {
+            return Err(format!(
+                "Anonymous alias '{}' must not include credentials",
+                self.name
+            ));
+        }
+
+        Ok(Alias {
+            name: self.name,
+            endpoint: self.endpoint,
+            access_key,
+            secret_key,
+            anonymous: self.anonymous,
+            client_cert: self.client_cert,
+            client_key: self.client_key,
+            region: self.region,
+            signature: self.signature,
+            bucket_lookup: self.bucket_lookup,
+            insecure: self.insecure,
+            ca_bundle: self.ca_bundle,
+            retry: self.retry,
+            timeout: self.timeout,
+        })
+    }
+}
+
+fn is_valid_portable_alias_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+}
+
+fn write_export_file(destination: &Path, contents: &[u8], force: bool) -> io::Result<()> {
+    let directory = destination.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "export destination has no parent directory",
+        )
+    })?;
+    let directory = if directory.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        directory
+    };
+    fs::create_dir_all(directory)?;
+
+    let mut temporary = tempfile::NamedTempFile::new_in(directory)?;
+    temporary.write_all(contents)?;
+    temporary.as_file_mut().sync_all()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temporary
+            .as_file_mut()
+            .set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+
+    if force {
+        temporary
+            .persist(destination)
+            .map_err(|error| error.error)?;
+    } else {
+        temporary
+            .persist_noclobber(destination)
+            .map_err(|error| error.error)?;
+    }
+    Ok(())
+}
+
 async fn execute_remove(
     args: RemoveArgs,
     manager: &AliasManager,
@@ -392,8 +746,11 @@ fn exit_code_from_error(error: &rc_core::Error) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    use crate::commands::{Cli, Commands};
 
     #[test]
     fn test_set_args_defaults() {
@@ -427,6 +784,130 @@ mod tests {
         assert_eq!(info.name, "test");
         assert_eq!(info.endpoint, "http://localhost:9000");
         assert_eq!(info.region, "us-east-1");
+    }
+
+    #[test]
+    fn export_redacts_credentials_by_default() {
+        let alias = Alias::new(
+            "local",
+            "http://localhost:9000",
+            "visible-access",
+            "visible-secret",
+        );
+
+        let encoded = serde_json::to_string(&PortableAlias::from_alias(&alias, false)).unwrap();
+
+        assert!(!encoded.contains("visible-access"));
+        assert!(!encoded.contains("visible-secret"));
+        assert!(!encoded.contains("credentials"));
+    }
+
+    #[test]
+    fn export_includes_credentials_only_when_requested() {
+        let alias = Alias::new(
+            "local",
+            "http://localhost:9000",
+            "visible-access",
+            "visible-secret",
+        );
+
+        let encoded = serde_json::to_string(&PortableAlias::from_alias(&alias, true)).unwrap();
+
+        assert!(encoded.contains("visible-access"));
+        assert!(encoded.contains("visible-secret"));
+    }
+
+    #[test]
+    fn cli_requires_explicit_credential_export_acknowledgement() {
+        let error =
+            Cli::try_parse_from(["rc", "alias", "export", "--include-credentials"]).unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+
+        let cli = Cli::try_parse_from([
+            "rc",
+            "alias",
+            "export",
+            "--include-credentials",
+            "--acknowledge-credentials",
+        ])
+        .unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Alias(AliasCommands::Export(ExportArgs {
+                include_credentials: true,
+                acknowledge_credentials: true,
+                ..
+            }))
+        ));
+    }
+
+    #[test]
+    fn import_rejects_unknown_fields_and_invalid_endpoints() {
+        let malformed = br#"{
+            "schema_version": 1,
+            "aliases": [],
+            "unexpected": true
+        }"#;
+        assert!(serde_json::from_slice::<AliasExportDocument>(malformed).is_err());
+
+        let portable = PortableAlias {
+            name: "local".to_string(),
+            endpoint: "ftp://localhost:9000".to_string(),
+            credentials: None,
+            anonymous: false,
+            client_cert: None,
+            client_key: None,
+            region: "us-east-1".to_string(),
+            signature: "v4".to_string(),
+            bucket_lookup: "auto".to_string(),
+            insecure: false,
+            ca_bundle: None,
+            retry: None,
+            timeout: None,
+        };
+        assert!(portable.into_alias().is_err());
+    }
+
+    #[test]
+    fn redacted_alias_imports_without_synthesizing_credentials() {
+        let portable = PortableAlias {
+            name: "local".to_string(),
+            endpoint: "http://localhost:9000".to_string(),
+            credentials: None,
+            anonymous: false,
+            client_cert: None,
+            client_key: None,
+            region: "us-east-1".to_string(),
+            signature: "v4".to_string(),
+            bucket_lookup: "auto".to_string(),
+            insecure: false,
+            ca_bundle: None,
+            retry: None,
+            timeout: None,
+        };
+
+        let alias = portable.into_alias().unwrap();
+
+        assert!(alias.access_key.is_empty());
+        assert!(alias.secret_key.is_empty());
+        assert!(!alias.anonymous);
+    }
+
+    #[test]
+    fn export_file_refuses_implicit_overwrite_and_force_is_atomic() {
+        let directory = tempfile::tempdir().unwrap();
+        let destination = directory.path().join("nested/aliases.json");
+        write_export_file(&destination, b"first", false).unwrap();
+
+        let error = write_export_file(&destination, b"second", false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&destination).unwrap(), b"first");
+
+        write_export_file(&destination, b"second", true).unwrap();
+        assert_eq!(fs::read(&destination).unwrap(), b"second");
     }
 
     #[tokio::test]

--- a/crates/cli/tests/alias_portability.rs
+++ b/crates/cli/tests/alias_portability.rs
@@ -1,0 +1,186 @@
+//! Alias export/import portability and exit-code contracts.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use rc_core::{Alias, ConfigManager};
+
+fn rc_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_rc") {
+        return PathBuf::from(path);
+    }
+
+    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has parent directory")
+        .parent()
+        .expect("workspace root exists")
+        .to_path_buf();
+    let debug_binary = workspace_root.join("target/debug/rc");
+    if debug_binary.exists() {
+        return debug_binary;
+    }
+    workspace_root.join("target/release/rc")
+}
+
+fn run_rc(args: &[&str], config_dir: &Path) -> Output {
+    let mut command = Command::new(rc_binary());
+    for (key, _) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("RC_HOST_") {
+            command.env_remove(key);
+        }
+    }
+    command
+        .args(args)
+        .env("RC_CONFIG_DIR", config_dir)
+        .output()
+        .expect("execute rc")
+}
+
+fn seed_alias(config_dir: &Path, alias: Alias) {
+    let manager = ConfigManager::with_path(config_dir.join("config.toml"));
+    let mut config = manager.load().unwrap();
+    config.aliases.push(alias);
+    manager.save(&config).unwrap();
+}
+
+#[test]
+fn export_succeeds_with_redacted_deterministic_json() {
+    let config_dir = tempfile::tempdir().unwrap();
+    seed_alias(
+        config_dir.path(),
+        Alias::new("zeta", "http://zeta:9000", "zeta-access", "zeta-secret"),
+    );
+    seed_alias(
+        config_dir.path(),
+        Alias::new("alpha", "http://alpha:9000", "alpha-access", "alpha-secret"),
+    );
+
+    let output = run_rc(&["alias", "export"], config_dir.path());
+
+    assert_eq!(output.status.code(), Some(0));
+    let document: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(document["schema_version"], 1);
+    assert_eq!(document["aliases"][0]["name"], "alpha");
+    assert_eq!(document["aliases"][1]["name"], "zeta");
+    let encoded = String::from_utf8(output.stdout).unwrap();
+    assert!(!encoded.contains("alpha-access"));
+    assert!(!encoded.contains("alpha-secret"));
+    assert!(!encoded.contains("zeta-access"));
+    assert!(!encoded.contains("zeta-secret"));
+}
+
+#[test]
+fn export_credentials_require_acknowledgement_exit_two() {
+    let config_dir = tempfile::tempdir().unwrap();
+
+    let output = run_rc(
+        &["alias", "export", "--include-credentials"],
+        config_dir.path(),
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("--acknowledge-credentials"));
+}
+
+#[test]
+fn import_succeeds_for_a_valid_redacted_document() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let input = config_dir.path().join("aliases.json");
+    std::fs::write(
+        &input,
+        r#"{
+          "schema_version": 1,
+          "aliases": [{
+            "name": "local",
+            "endpoint": "http://localhost:9000",
+            "region": "us-east-1",
+            "signature": "v4",
+            "bucket_lookup": "auto"
+          }]
+        }"#,
+    )
+    .unwrap();
+
+    let output = run_rc(
+        &["alias", "import", input.to_str().unwrap()],
+        config_dir.path(),
+    );
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let alias = rc_core::AliasManager::with_config_manager(ConfigManager::with_path(
+        config_dir.path().join("config.toml"),
+    ))
+    .get("local")
+    .unwrap();
+    assert!(alias.access_key.is_empty());
+    assert!(alias.secret_key.is_empty());
+}
+
+#[test]
+fn malformed_import_exits_two_without_writing() {
+    let config_dir = tempfile::tempdir().unwrap();
+    let input = config_dir.path().join("aliases.json");
+    std::fs::write(&input, r#"{"schema_version":1,"aliases":"wrong"}"#).unwrap();
+
+    let output = run_rc(
+        &["alias", "import", input.to_str().unwrap()],
+        config_dir.path(),
+    );
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(!config_dir.path().join("config.toml").exists());
+}
+
+#[test]
+fn import_conflict_exits_six_without_partial_write() {
+    let config_dir = tempfile::tempdir().unwrap();
+    seed_alias(
+        config_dir.path(),
+        Alias::new("existing", "http://old:9000", "access", "secret"),
+    );
+    let input = config_dir.path().join("aliases.json");
+    std::fs::write(
+        &input,
+        r#"{
+          "schema_version": 1,
+          "aliases": [
+            {
+              "name": "new",
+              "endpoint": "http://new:9000",
+              "region": "us-east-1",
+              "signature": "v4",
+              "bucket_lookup": "auto"
+            },
+            {
+              "name": "existing",
+              "endpoint": "http://replacement:9000",
+              "region": "us-east-1",
+              "signature": "v4",
+              "bucket_lookup": "auto"
+            }
+          ]
+        }"#,
+    )
+    .unwrap();
+
+    let output = run_rc(
+        &["alias", "import", input.to_str().unwrap()],
+        config_dir.path(),
+    );
+
+    assert_eq!(output.status.code(), Some(6));
+    let manager = rc_core::AliasManager::with_config_manager(ConfigManager::with_path(
+        config_dir.path().join("config.toml"),
+    ));
+    assert!(matches!(
+        manager.get("new"),
+        Err(rc_core::Error::AliasNotFound(_))
+    ));
+    assert_eq!(manager.get("existing").unwrap().endpoint, "http://old:9000");
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -156,7 +156,7 @@ fn top_level_command_help_contract() {
         HelpCase {
             args: &["alias"],
             usage: "Usage: rc alias [OPTIONS] <COMMAND>",
-            expected_tokens: &["set", "list", "remove"],
+            expected_tokens: &["set", "list", "remove", "export", "import"],
         },
         HelpCase {
             args: &["admin"],

--- a/crates/core/src/alias.rs
+++ b/crates/core/src/alias.rs
@@ -493,6 +493,46 @@ impl AliasManager {
         self.config_manager.save(&config)
     }
 
+    /// Import aliases in one validated configuration write.
+    ///
+    /// When `replace` is false, every conflict is reported before the
+    /// configuration is modified.
+    pub fn import(&self, aliases: Vec<Alias>, replace: bool) -> Result<()> {
+        let mut names = std::collections::HashSet::new();
+        for alias in &aliases {
+            if !names.insert(alias.name.clone()) {
+                return Err(Error::Config(format!(
+                    "Import contains duplicate alias '{}'",
+                    alias.name
+                )));
+            }
+        }
+
+        let mut config = self.config_manager.load()?;
+        if !replace {
+            let mut conflicts = config
+                .aliases
+                .iter()
+                .filter(|alias| names.contains(&alias.name))
+                .map(|alias| alias.name.clone())
+                .collect::<Vec<_>>();
+            conflicts.sort();
+            if !conflicts.is_empty() {
+                return Err(Error::Config(format!(
+                    "Aliases already exist: {}. Retry with --replace to overwrite them",
+                    conflicts.join(", ")
+                )));
+            }
+        }
+
+        config.aliases.retain(|alias| !names.contains(&alias.name));
+        config.aliases.extend(aliases);
+        config
+            .aliases
+            .sort_by(|left, right| left.name.cmp(&right.name));
+        self.config_manager.save(&config)
+    }
+
     /// Remove an alias
     pub fn remove(&self, name: &str) -> Result<()> {
         let mut config = self.config_manager.load()?;
@@ -614,6 +654,66 @@ mod tests {
         let aliases = manager.list().unwrap();
         assert_eq!(aliases.len(), 1);
         assert_eq!(aliases[0].endpoint, "http://new:9000");
+    }
+
+    #[test]
+    fn import_rejects_all_conflicts_before_writing() {
+        let (manager, _temp_dir) = temp_alias_manager();
+        manager
+            .set(Alias::new("existing", "http://old:9000", "a", "b"))
+            .unwrap();
+
+        let result = manager.import(
+            vec![
+                Alias::new("new", "http://new:9000", "", ""),
+                Alias::new("existing", "http://replacement:9000", "", ""),
+            ],
+            false,
+        );
+
+        assert!(matches!(result, Err(Error::Config(_))));
+        assert!(matches!(manager.get("new"), Err(Error::AliasNotFound(_))));
+        assert_eq!(manager.get("existing").unwrap().endpoint, "http://old:9000");
+    }
+
+    #[test]
+    fn import_replaces_conflicts_in_one_write() {
+        let (manager, _temp_dir) = temp_alias_manager();
+        manager
+            .set(Alias::new("existing", "http://old:9000", "a", "b"))
+            .unwrap();
+
+        manager
+            .import(
+                vec![
+                    Alias::new("new", "http://new:9000", "", ""),
+                    Alias::new("existing", "http://replacement:9000", "", ""),
+                ],
+                true,
+            )
+            .unwrap();
+
+        assert_eq!(manager.list().unwrap().len(), 2);
+        assert_eq!(
+            manager.get("existing").unwrap().endpoint,
+            "http://replacement:9000"
+        );
+    }
+
+    #[test]
+    fn import_rejects_duplicate_names_before_writing() {
+        let (manager, _temp_dir) = temp_alias_manager();
+
+        let result = manager.import(
+            vec![
+                Alias::new("duplicate", "http://one:9000", "", ""),
+                Alias::new("duplicate", "http://two:9000", "", ""),
+            ],
+            true,
+        );
+
+        assert!(matches!(result, Err(Error::Config(_))));
+        assert!(manager.list().unwrap().is_empty());
     }
 
     #[test]

--- a/docs/reference/rc/alias.md
+++ b/docs/reference/rc/alias.md
@@ -11,6 +11,8 @@ rc [GLOBAL OPTIONS] alias <COMMAND>
 rc [GLOBAL OPTIONS] alias set [OPTIONS] <NAME> <ENDPOINT> <ACCESS_KEY> <SECRET_KEY>
 rc [GLOBAL OPTIONS] alias list [-l|--long]
 rc [GLOBAL OPTIONS] alias remove <NAME>
+rc [GLOBAL OPTIONS] alias export [NAMES]... [--output <FILE>] [--include-credentials --acknowledge-credentials]
+rc [GLOBAL OPTIONS] alias import <FILE> [--replace]
 ```
 
 ## Commands
@@ -20,6 +22,8 @@ rc [GLOBAL OPTIONS] alias remove <NAME>
 | `set` | Add a new alias or replace an existing alias. |
 | `list` | List configured aliases. |
 | `remove` | Remove an alias from local configuration. |
+| `export` | Write selected aliases, or every alias, as portable JSON. |
+| `import` | Validate and import a portable alias JSON document. |
 
 ## Parameters
 
@@ -34,6 +38,11 @@ rc [GLOBAL OPTIONS] alias remove <NAME>
 | `--bucket-lookup` | Bucket lookup style: `auto`, `path`, or `dns`. Defaults to `auto`. |
 | `--insecure` | Allow insecure TLS connections for this alias. |
 | `-l, --long` | Show full alias details when listing aliases. |
+| `-o, --output <FILE>` | Write an alias export to a file instead of stdout. |
+| `--include-credentials` | Include plaintext access and secret keys in an export. |
+| `--acknowledge-credentials` | Explicitly acknowledge plaintext credential export. |
+| `--force` | Replace an existing export file. |
+| `--replace` | Replace conflicting local aliases during import. |
 
 ## Examples
 
@@ -61,9 +70,50 @@ Remove an alias:
 rc alias remove old-local
 ```
 
+Export connection settings without credentials:
+
+```bash
+rc alias export local s3 --output aliases.json
+```
+
+Export credentials after explicit acknowledgement:
+
+```bash
+rc alias export local \
+  --include-credentials \
+  --acknowledge-credentials \
+  --output aliases-with-credentials.json
+```
+
+Import aliases, rejecting every conflict before changing the configuration:
+
+```bash
+rc alias import aliases.json
+```
+
+Replace conflicting aliases:
+
+```bash
+rc alias import aliases.json --replace
+```
+
 ## Behavior
 
-`alias set` overwrites an existing alias with the same name. `alias list` does not print secret keys. Commands that need a remote service resolve the alias name before creating an S3 or admin client.
+`alias set` overwrites an existing alias with the same name. `alias list` does
+not print secret keys. Commands that need a remote service resolve the alias
+name before creating an S3 or admin client.
+
+Exports use a versioned JSON schema and are sorted by alias name for
+deterministic output. Credentials are absent by default. Importing a redacted
+authenticated alias preserves its endpoint and options with empty credentials;
+run `rc alias set` to supply credentials before using it. Credential-bearing
+exports require both explicit flags and files are created with owner-only
+permissions on Unix.
+
+Import validates the entire document, including schema version, duplicate
+names, endpoint URLs, signature mode, bucket lookup mode, and mTLS path pairs,
+before one configuration write. Existing aliases cause exit code 6 unless
+`--replace` is supplied. Malformed documents cause exit code 2.
 
 Global options shown in command syntax use the same meaning everywhere:
 


### PR DESCRIPTION
## Summary

- add versioned deterministic `rc alias export` JSON
- omit access and secret keys by default
- require both `--include-credentials` and `--acknowledge-credentials` for plaintext credentials
- write export files atomically, refuse implicit overwrite, and use owner-only Unix permissions
- add strict `rc alias import` schema and value validation
- detect duplicate/conflicting aliases before one config write; require `--replace` for conflicts
- add help, reference docs, core tests, and binary exit-code contracts

## Why

Aliases could not be moved safely between environments. This implements the alias-portability slice of rustfs/backlog#1382 with a redacted default and explicit handling for sensitive exports.

## User impact

Redacted exports preserve endpoints and connection options but leave authenticated credentials empty after import; users can supply them with `rc alias set`. Credential-bearing exports require explicit acknowledgement. Malformed imports exit 2, conflicts exit 6, and neither path partially changes configuration.

## BREAKING change assessment

BREAKING: no. This adds two alias subcommands and a core bulk-import method without changing existing alias set/list/remove behavior. The marker is included because this PR updates protected command reference documentation.

## Validation

- `cargo test -p rustfs-cli --test alias_portability --test help_contract`
- `cargo test -p rc-core alias::tests::import_`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

Closes rustfs/backlog#1486
Refs rustfs/backlog#1382