### PR TITLE
feat(admin): add read-only OIDC inspection and validation

### DIFF
--- a/crates/cli/src/commands/admin/idp.rs
+++ b/crates/cli/src/commands/admin/idp.rs
@@ -1,0 +1,358 @@
+//! Read-only RustFS identity-provider administration.
+
+use clap::{Args, Subcommand};
+use rc_core::admin::{
+    OidcProvider, OidcProviderList, OidcReadApi, OidcValidationRequest, OidcValidationResult,
+};
+use serde::Serialize;
+
+use super::{emit_observability_error, get_admin_client};
+use crate::exit_code::ExitCode;
+use crate::output::Formatter;
+
+#[derive(Subcommand, Debug)]
+pub enum IdpCommands {
+    /// Inspect and validate OpenID Connect providers
+    #[command(subcommand)]
+    Openid(OpenidCommands),
+}
+
+#[derive(Subcommand, Debug)]
+pub enum OpenidCommands {
+    /// List effective OIDC provider configurations
+    List(OidcListArgs),
+
+    /// Display one effective OIDC provider configuration
+    Get(OidcGetArgs),
+
+    /// Validate OIDC discovery without saving configuration
+    Validate(Box<OidcValidateArgs>),
+}
+
+#[derive(Args, Debug)]
+pub struct OidcListArgs {
+    /// Alias name of the server
+    pub alias: String,
+}
+
+#[derive(Args, Debug)]
+pub struct OidcGetArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Exact OIDC provider ID
+    pub provider_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct OidcValidateArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// OIDC provider ID used only for validation
+    pub provider_id: String,
+
+    /// Provider issuer or discovery base URL
+    #[arg(long)]
+    pub config_url: String,
+
+    /// OIDC client identifier
+    #[arg(long)]
+    pub client_id: String,
+
+    /// Expected issuer URL, when it must differ from the configuration URL
+    #[arg(long)]
+    pub issuer: Option<String>,
+
+    /// Requested scope; may be repeated and must include openid
+    #[arg(long = "scope", default_values_t = [
+        "openid".to_string(),
+        "profile".to_string(),
+        "email".to_string()
+    ])]
+    pub scopes: Vec<String>,
+
+    /// Additional trusted token audience; may be repeated
+    #[arg(long = "other-audience")]
+    pub other_audiences: Vec<String>,
+
+    /// Explicit callback URI
+    #[arg(long)]
+    pub redirect_uri: Option<String>,
+
+    /// Require the explicit callback URI instead of a server-derived URI
+    #[arg(long, requires = "redirect_uri")]
+    pub static_redirect: bool,
+
+    /// Policy claim name
+    #[arg(long, default_value = "policy")]
+    pub claim_name: String,
+
+    /// Prefix applied to policy claims
+    #[arg(long, default_value = "")]
+    pub claim_prefix: String,
+
+    /// Fixed fallback policy
+    #[arg(long, default_value = "")]
+    pub role_policy: String,
+
+    /// Group claim name
+    #[arg(long, default_value = "groups")]
+    pub groups_claim: String,
+
+    /// Roles claim name
+    #[arg(long, default_value = "roles")]
+    pub roles_claim: String,
+
+    /// Email claim name
+    #[arg(long, default_value = "email")]
+    pub email_claim: String,
+
+    /// Username claim name
+    #[arg(long, default_value = "preferred_username")]
+    pub username_claim: String,
+}
+
+#[derive(Debug, Serialize)]
+struct OidcSuccessOutput<T> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: T,
+}
+
+#[derive(Debug, Serialize)]
+struct OidcListData<'a> {
+    operation: &'static str,
+    restart_required: bool,
+    providers: &'a [OidcProvider],
+}
+
+#[derive(Debug, Serialize)]
+struct OidcGetData<'a> {
+    operation: &'static str,
+    provider: &'a OidcProvider,
+}
+
+#[derive(Debug, Serialize)]
+struct OidcValidateData<'a> {
+    operation: &'static str,
+    provider_id: &'a str,
+    #[serde(flatten)]
+    result: &'a OidcValidationResult,
+}
+
+pub async fn execute(command: IdpCommands, formatter: &Formatter) -> ExitCode {
+    match command {
+        IdpCommands::Openid(command) => match command {
+            OpenidCommands::List(args) => execute_list(args, formatter).await,
+            OpenidCommands::Get(args) => execute_get(args, formatter).await,
+            OpenidCommands::Validate(args) => execute_validate(*args, formatter).await,
+        },
+    }
+}
+
+async fn execute_list(args: OidcListArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    match client.oidc_list_providers().await {
+        Ok(list) => {
+            print_list(&list, formatter);
+            ExitCode::Success
+        }
+        Err(error) => emit_observability_error(
+            "oidc",
+            "admin.oidc-config-read",
+            "Failed to list OIDC providers",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn execute_get(args: OidcGetArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    match client.oidc_get_provider(&args.provider_id).await {
+        Ok(provider) => {
+            print_provider(&provider, formatter);
+            ExitCode::Success
+        }
+        Err(error) => emit_observability_error(
+            "oidc",
+            "admin.oidc-config-read",
+            "Failed to get OIDC provider",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn execute_validate(args: OidcValidateArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    let mut request =
+        OidcValidationRequest::new(args.provider_id.clone(), args.config_url, args.client_id);
+    request.issuer = args.issuer;
+    request.scopes = args.scopes;
+    request.other_audiences = args.other_audiences;
+    request.redirect_uri = args.redirect_uri;
+    request.redirect_uri_dynamic = !args.static_redirect;
+    request.claim_name = args.claim_name;
+    request.claim_prefix = args.claim_prefix;
+    request.role_policy = args.role_policy;
+    request.groups_claim = args.groups_claim;
+    request.roles_claim = args.roles_claim;
+    request.email_claim = args.email_claim;
+    request.username_claim = args.username_claim;
+
+    match client.oidc_validate(request).await {
+        Ok(result) => {
+            if formatter.is_json() {
+                formatter.json(&OidcSuccessOutput {
+                    schema_version: 3,
+                    output_type: "oidc",
+                    status: "success",
+                    data: OidcValidateData {
+                        operation: "validate",
+                        provider_id: &args.provider_id,
+                        result: &result,
+                    },
+                });
+            } else {
+                formatter.println(&formatter.style_name("OIDC Validation"));
+                formatter.println("");
+                formatter.println(&format!(
+                    "Provider:               {}",
+                    safe(&args.provider_id, formatter)
+                ));
+                formatter.println(&format!("Valid:                  {}", result.valid));
+                formatter.println(&format!(
+                    "Issuer:                 {}",
+                    optional(result.issuer.as_deref(), formatter)
+                ));
+                formatter.println(&format!(
+                    "Authorization endpoint: {}",
+                    optional(result.authorization_endpoint.as_deref(), formatter)
+                ));
+                formatter.println(&format!(
+                    "Token endpoint:         {}",
+                    optional(result.token_endpoint.as_deref(), formatter)
+                ));
+            }
+            ExitCode::Success
+        }
+        Err(error) => emit_observability_error(
+            "oidc",
+            "admin.oidc-config-validate",
+            "Failed to validate OIDC provider",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+fn print_list(list: &OidcProviderList, formatter: &Formatter) {
+    if formatter.is_json() {
+        formatter.json(&OidcSuccessOutput {
+            schema_version: 3,
+            output_type: "oidc",
+            status: "success",
+            data: OidcListData {
+                operation: "list",
+                restart_required: list.restart_required,
+                providers: &list.providers,
+            },
+        });
+        return;
+    }
+    formatter.println(&formatter.style_name("OIDC Providers"));
+    formatter.println("");
+    formatter.println(&format!("Restart required: {}", list.restart_required));
+    if list.providers.is_empty() {
+        formatter.println("No OIDC providers configured.");
+        return;
+    }
+    for provider in &list.providers {
+        formatter.println(&format!(
+            "{}\t{}\t{}\t{}",
+            safe(&provider.provider_id, formatter),
+            safe(&provider.display_name, formatter),
+            if provider.enabled {
+                "enabled"
+            } else {
+                "disabled"
+            },
+            match provider.source {
+                rc_core::admin::OidcProviderSource::Env => "env",
+                rc_core::admin::OidcProviderSource::Persisted => "persisted",
+            }
+        ));
+    }
+}
+
+fn print_provider(provider: &OidcProvider, formatter: &Formatter) {
+    if formatter.is_json() {
+        formatter.json(&OidcSuccessOutput {
+            schema_version: 3,
+            output_type: "oidc",
+            status: "success",
+            data: OidcGetData {
+                operation: "get",
+                provider,
+            },
+        });
+        return;
+    }
+    formatter.println(&formatter.style_name("OIDC Provider"));
+    formatter.println("");
+    formatter.println(&format!(
+        "Provider ID:              {}",
+        safe(&provider.provider_id, formatter)
+    ));
+    formatter.println(&format!(
+        "Display name:             {}",
+        safe(&provider.display_name, formatter)
+    ));
+    formatter.println(&format!("Enabled:                  {}", provider.enabled));
+    formatter.println(&format!("Editable:                 {}", provider.editable));
+    formatter.println(&format!(
+        "Configuration URL:        {}",
+        safe(&provider.config_url, formatter)
+    ));
+    formatter.println(&format!(
+        "Issuer:                   {}",
+        optional(provider.issuer.as_deref(), formatter)
+    ));
+    formatter.println(&format!(
+        "Client ID:                {}",
+        safe(&provider.client_id, formatter)
+    ));
+    formatter.println(&format!(
+        "Client secret configured: {}",
+        provider.client_secret_configured
+    ));
+    formatter.println(&format!(
+        "Scopes:                   {}",
+        safe(&provider.scopes.join(","), formatter)
+    ));
+    formatter.println(&format!(
+        "Redirect URI:             {}",
+        optional(provider.redirect_uri.as_deref(), formatter)
+    ));
+}
+
+fn optional(value: Option<&str>, formatter: &Formatter) -> String {
+    value.map_or_else(|| "-".to_string(), |value| safe(value, formatter))
+}
+
+fn safe(value: &str, formatter: &Formatter) -> String {
+    formatter.sanitize_text(value)
+}

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -11,6 +11,7 @@ mod diagnostics;
 mod expand;
 mod group;
 mod heal;
+mod idp;
 mod ilm;
 mod info;
 mod kms;
@@ -61,6 +62,10 @@ pub enum AdminCommands {
     /// Manage lifecycle transition operations
     #[command(subcommand)]
     Ilm(ilm::IlmCommands),
+
+    /// Inspect identity-provider configuration
+    #[command(subcommand)]
+    Idp(idp::IdpCommands),
 
     /// Display cluster information (servers, disks, usage)
     #[command(subcommand)]
@@ -127,6 +132,7 @@ pub async fn execute(cmd: AdminCommands, output_config: OutputConfig) -> ExitCod
         AdminCommands::Kms(kms_cmd) => kms::execute(kms_cmd, &formatter).await,
         AdminCommands::Scanner(scanner_cmd) => scanner::execute(scanner_cmd, &formatter).await,
         AdminCommands::Ilm(ilm_cmd) => ilm::execute(ilm_cmd, &formatter).await,
+        AdminCommands::Idp(idp_cmd) => idp::execute(idp_cmd, &formatter).await,
         AdminCommands::Info(info_cmd) => info::execute(info_cmd, &formatter).await,
         AdminCommands::Heal(heal_cmd) => heal::execute(heal_cmd, &formatter).await,
         AdminCommands::Pool(pool_cmd) => pool::execute(pool_cmd, &formatter).await,

--- a/crates/cli/tests/admin_oidc.rs
+++ b/crates/cli/tests/admin_oidc.rs
@@ -1,0 +1,236 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::path::Path;
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_response_test_server};
+use jsonschema::Validator;
+use serde_json::Value;
+
+const PROVIDERS: &str = r#"{
+  "providers":[{
+    "provider_id":"corp",
+    "source":"persisted",
+    "editable":true,
+    "enabled":true,
+    "display_name":"Corporate",
+    "config_url":"https://idp.example",
+    "issuer":"https://idp.example",
+    "client_id":"rustfs-console",
+    "client_secret_configured":true,
+    "scopes":["openid","profile","email"],
+    "other_audiences":["rustfs"],
+    "redirect_uri":null,
+    "redirect_uri_dynamic":true,
+    "claim_name":"policy",
+    "claim_prefix":"",
+    "role_policy":"",
+    "groups_claim":"groups",
+    "roles_claim":"roles",
+    "email_claim":"email",
+    "username_claim":"preferred_username",
+    "hide_from_ui":false
+  }],
+  "restart_required":false
+}"#;
+
+fn output_v3_validator() -> Validator {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../schemas/output_v3.json");
+    let schema: Value = serde_json::from_str(
+        &std::fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display())),
+    )
+    .expect("output v3 schema should parse");
+    jsonschema::validator_for(&schema).expect("output v3 schema should compile")
+}
+
+fn assert_valid_v3(value: &Value) {
+    let errors = output_v3_validator()
+        .iter_errors(value)
+        .map(|error| error.to_string())
+        .collect::<Vec<_>>();
+    assert!(
+        errors.is_empty(),
+        "invalid v3 output:\n{}",
+        errors.join("\n")
+    );
+}
+
+#[test]
+fn oidc_list_uses_typed_secret_free_schema() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_response_test_server("200 OK", "application/json", PROVIDERS.to_string());
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "idp", "openid", "list", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("UTF-8 stdout");
+    assert!(!stdout.contains("client_secret\""));
+    assert!(!stdout.contains("MUST_NOT_APPEAR"));
+    let value: Value = serde_json::from_str(&stdout).expect("JSON stdout");
+    assert_eq!(value["type"], "oidc");
+    assert_eq!(value["data"]["operation"], "list");
+    assert_eq!(value["data"]["providers"][0]["provider_id"], "corp");
+    assert_eq!(
+        value["data"]["providers"][0]["client_secret_configured"],
+        true
+    );
+    assert_valid_v3(&value);
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("request");
+    assert_eq!(request.method, "GET");
+    assert_eq!(request.target, "/rustfs/admin/v3/oidc/config");
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_get_filters_exact_provider_without_an_unbacked_route() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_response_test_server("200 OK", "application/json", PROVIDERS.to_string());
+
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "idp", "openid", "get", "myalias", "corp"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert!(output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(value["data"]["operation"], "get");
+    assert_eq!(value["data"]["provider"]["provider_id"], "corp");
+    assert_valid_v3(&value);
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("request");
+    assert_eq!(request.target, "/rustfs/admin/v3/oidc/config");
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_validate_is_non_mutating_and_never_sends_a_client_secret() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let response = r#"{
+      "valid":true,
+      "message":"OIDC configuration is valid",
+      "issuer":"https://idp.example",
+      "authorization_endpoint":"https://idp.example/authorize",
+      "token_endpoint":"https://idp.example/token"
+    }"#;
+    let (endpoint, receiver, handle) =
+        start_admin_response_test_server("200 OK", "application/json", response.to_string());
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "idp",
+            "openid",
+            "validate",
+            "myalias",
+            "corp",
+            "--config-url",
+            "https://idp.example",
+            "--client-id",
+            "rustfs-console",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(value["data"]["operation"], "validate");
+    assert_eq!(value["data"]["valid"], true);
+    assert_valid_v3(&value);
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(request.target, "/rustfs/admin/v3/oidc/validate");
+    let request_body = String::from_utf8(request.body).expect("UTF-8 request");
+    assert!(!request_body.contains("client_secret"));
+    let body: Value = serde_json::from_str(&request_body).expect("JSON request");
+    assert_eq!(body["provider_id"], "corp");
+    assert_eq!(body["scopes"][0], "openid");
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_routes_fail_closed_and_redact_server_error_bodies() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_response_test_server(
+        "404 Not Found",
+        "application/json",
+        r#"{"message":"MUST_NOT_APPEAR"}"#.to_string(),
+    );
+    let output = Command::new(rc_binary())
+        .args(["--json", "admin", "idp", "openid", "list", "myalias"])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert_eq!(output.status.code(), Some(7));
+    let stderr = String::from_utf8(output.stderr).expect("UTF-8 stderr");
+    assert!(!stderr.contains("MUST_NOT_APPEAR"));
+    let value: Value = serde_json::from_str(&stderr).expect("JSON stderr");
+    assert_eq!(value["error"]["type"], "unsupported_feature");
+    assert_eq!(value["error"]["capability"], "admin.oidc-config-read");
+    assert_valid_v3(&value);
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_validate_rejects_invalid_urls_before_network_io() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "idp",
+            "openid",
+            "validate",
+            "myalias",
+            "corp",
+            "--config-url",
+            "file:///etc/passwd",
+            "--client-id",
+            "console",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_myalias",
+            "http://ACCESS_KEY:SECRET_KEY@127.0.0.1:1",
+        )
+        .output()
+        .expect("run rc");
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("absolute HTTP URL"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -653,6 +653,34 @@ fn nested_subcommand_help_contract() {
             expected_tokens: &[],
         },
         HelpCase {
+            args: &["admin", "idp"],
+            usage: "Usage: rc admin idp [OPTIONS] <COMMAND>",
+            expected_tokens: &["openid"],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid"],
+            usage: "Usage: rc admin idp openid [OPTIONS] <COMMAND>",
+            expected_tokens: &["list", "get", "validate"],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid", "get"],
+            usage: "Usage: rc admin idp openid get [OPTIONS] <ALIAS> <PROVIDER_ID>",
+            expected_tokens: &[],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid", "validate"],
+            usage: "Usage: rc admin idp openid validate [OPTIONS] --config-url <CONFIG_URL> --client-id <CLIENT_ID> <ALIAS> <PROVIDER_ID>",
+            expected_tokens: &[
+                "--config-url",
+                "--client-id",
+                "--issuer",
+                "--scope",
+                "--other-audience",
+                "--redirect-uri",
+                "--static-redirect",
+            ],
+        },
+        HelpCase {
             args: &["admin", "metrics"],
             usage: "Usage: rc admin metrics [OPTIONS] <ALIAS>",
             expected_tokens: &[

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -10,6 +10,7 @@ mod diagnostics;
 mod kms;
 mod kms_diagnostic;
 mod observability;
+mod oidc;
 mod replication;
 mod site;
 pub mod tier;
@@ -62,6 +63,10 @@ pub use observability::{
     ScannerCycleSchedule, ScannerFreshness, ScannerHealth, ScannerMetrics, ScannerRuntimeConfig,
     ScannerRuntimeConfigValue, ScannerStatus, StorageBackend, StorageBackendKind, StorageDisk,
     StorageDiskMetrics, StorageInfo,
+};
+pub use oidc::{
+    MAX_OIDC_RESPONSE_BYTES, OidcProvider, OidcProviderList, OidcProviderSource, OidcReadApi,
+    OidcValidationRequest, OidcValidationResult,
 };
 pub use replication::{
     MAX_REPLICATION_DIFF_RESPONSE_BYTES, ReplicationDiff, ReplicationDiffApi, ReplicationDiffEntry,

--- a/crates/core/src/admin/oidc.rs
+++ b/crates/core/src/admin/oidc.rs
@@ -1,0 +1,305 @@
+//! Typed, secret-free contracts for RustFS OIDC inspection and validation.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+/// Maximum encoded size accepted for one OIDC administration response.
+pub const MAX_OIDC_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Source that owns an effective OIDC provider configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OidcProviderSource {
+    Env,
+    Persisted,
+}
+
+/// Secret-free view of one effective RustFS OIDC provider.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OidcProvider {
+    pub provider_id: String,
+    pub source: OidcProviderSource,
+    pub editable: bool,
+    pub enabled: bool,
+    pub display_name: String,
+    pub config_url: String,
+    pub issuer: Option<String>,
+    pub client_id: String,
+    pub client_secret_configured: bool,
+    pub scopes: Vec<String>,
+    pub other_audiences: Vec<String>,
+    pub redirect_uri: Option<String>,
+    pub redirect_uri_dynamic: bool,
+    pub claim_name: String,
+    pub claim_prefix: String,
+    pub role_policy: String,
+    pub groups_claim: String,
+    pub roles_claim: String,
+    pub email_claim: String,
+    pub username_claim: String,
+    pub hide_from_ui: bool,
+}
+
+impl OidcProvider {
+    /// Validate invariants that distinguish a real typed provider response from a placeholder.
+    pub fn validate_response(&self) -> Result<()> {
+        validate_provider_id(&self.provider_id)?;
+        validate_http_url(&self.config_url, "config_url")?;
+        if let Some(issuer) = self.issuer.as_deref() {
+            validate_http_url(issuer, "issuer")?;
+        }
+        if let Some(redirect_uri) = self.redirect_uri.as_deref() {
+            validate_http_url(redirect_uri, "redirect_uri")?;
+        }
+        if self.client_id.trim().is_empty() {
+            return Err(Error::General(
+                "OIDC provider response is missing client_id".to_string(),
+            ));
+        }
+        if !self.scopes.iter().any(|scope| scope == "openid") {
+            return Err(Error::General(
+                "OIDC provider response scopes do not include openid".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Effective OIDC provider collection and restart state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OidcProviderList {
+    pub providers: Vec<OidcProvider>,
+    pub restart_required: bool,
+}
+
+impl OidcProviderList {
+    pub fn validate_response(&self) -> Result<()> {
+        let mut ids = std::collections::BTreeSet::new();
+        for provider in &self.providers {
+            provider.validate_response()?;
+            if !ids.insert(provider.provider_id.as_str()) {
+                return Err(Error::General(
+                    "OIDC provider response contains duplicate provider IDs".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Secret-free OIDC discovery validation request.
+///
+/// RustFS discovery validation does not authenticate to the token endpoint, so this read-only
+/// contract deliberately has no client-secret field.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OidcValidationRequest {
+    pub provider_id: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub config_url: String,
+    pub issuer: Option<String>,
+    pub client_id: String,
+    pub scopes: Vec<String>,
+    pub other_audiences: Vec<String>,
+    pub redirect_uri: Option<String>,
+    pub redirect_uri_dynamic: bool,
+    pub claim_name: String,
+    pub claim_prefix: String,
+    pub role_policy: String,
+    pub groups_claim: String,
+    pub roles_claim: String,
+    pub email_claim: String,
+    pub username_claim: String,
+    pub hide_from_ui: bool,
+}
+
+impl OidcValidationRequest {
+    pub fn new(provider_id: String, config_url: String, client_id: String) -> Self {
+        Self {
+            display_name: provider_id.clone(),
+            provider_id,
+            enabled: true,
+            config_url,
+            issuer: None,
+            client_id,
+            scopes: vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+            ],
+            other_audiences: Vec::new(),
+            redirect_uri: None,
+            redirect_uri_dynamic: true,
+            claim_name: "policy".to_string(),
+            claim_prefix: String::new(),
+            role_policy: String::new(),
+            groups_claim: "groups".to_string(),
+            roles_claim: "roles".to_string(),
+            email_claim: "email".to_string(),
+            username_claim: "preferred_username".to_string(),
+            hide_from_ui: false,
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        validate_provider_id(&self.provider_id)?;
+        validate_http_url(&self.config_url, "config_url")?;
+        if let Some(issuer) = self.issuer.as_deref() {
+            validate_http_url(issuer, "issuer")?;
+        }
+        if self.client_id.trim().is_empty() {
+            return Err(Error::InvalidPath(
+                "OIDC client ID cannot be empty".to_string(),
+            ));
+        }
+        if !self.scopes.iter().any(|scope| scope == "openid") {
+            return Err(Error::InvalidPath(
+                "OIDC scopes must include openid".to_string(),
+            ));
+        }
+        if !self.redirect_uri_dynamic && self.redirect_uri.is_none() {
+            return Err(Error::InvalidPath(
+                "OIDC redirect URI is required when dynamic redirect is disabled".to_string(),
+            ));
+        }
+        if let Some(redirect_uri) = self.redirect_uri.as_deref() {
+            validate_http_url(redirect_uri, "redirect_uri")?;
+        }
+        Ok(())
+    }
+}
+
+/// Result of a live, non-mutating OIDC discovery validation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OidcValidationResult {
+    pub valid: bool,
+    pub message: String,
+    pub issuer: Option<String>,
+    pub authorization_endpoint: Option<String>,
+    pub token_endpoint: Option<String>,
+}
+
+impl OidcValidationResult {
+    pub fn validate_response(&self) -> Result<()> {
+        if !self.valid {
+            return Err(Error::General(
+                "OIDC validation returned an unsuccessful result".to_string(),
+            ));
+        }
+        for (value, field) in [
+            (self.issuer.as_deref(), "issuer"),
+            (
+                self.authorization_endpoint.as_deref(),
+                "authorization_endpoint",
+            ),
+            (self.token_endpoint.as_deref(), "token_endpoint"),
+        ] {
+            if let Some(value) = value {
+                validate_http_url(value, field)?;
+            }
+        }
+        if self.issuer.is_none() || self.authorization_endpoint.is_none() {
+            return Err(Error::General(
+                "OIDC validation response is incomplete".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+pub trait OidcReadApi: Send + Sync {
+    async fn oidc_list_providers(&self) -> Result<OidcProviderList>;
+    async fn oidc_get_provider(&self, provider_id: &str) -> Result<OidcProvider>;
+    async fn oidc_validate(&self, request: OidcValidationRequest) -> Result<OidcValidationResult>;
+}
+
+fn validate_provider_id(provider_id: &str) -> Result<()> {
+    if provider_id.is_empty()
+        || !provider_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '_' | '-'))
+    {
+        return Err(Error::InvalidPath(
+            "OIDC provider ID must contain only ASCII letters, digits, '_' or '-'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_http_url(value: &str, field: &str) -> Result<()> {
+    let parsed = url::Url::parse(value)
+        .map_err(|_| Error::InvalidPath(format!("OIDC {field} must be an absolute HTTP URL")))?;
+    if !matches!(parsed.scheme(), "http" | "https") || parsed.host_str().is_none() {
+        return Err(Error::InvalidPath(format!(
+            "OIDC {field} must be an absolute HTTP URL"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validation_request_is_secret_free_and_checks_openid_scope() {
+        let mut request = OidcValidationRequest::new(
+            "corp".to_string(),
+            "https://idp.example".to_string(),
+            "console".to_string(),
+        );
+        assert!(request.validate().is_ok());
+        request.scopes = vec!["profile".to_string()];
+        assert!(matches!(request.validate(), Err(Error::InvalidPath(_))));
+    }
+
+    #[test]
+    fn provider_list_rejects_duplicates_and_incomplete_placeholders() {
+        let provider = OidcProvider {
+            provider_id: "corp".to_string(),
+            source: OidcProviderSource::Persisted,
+            editable: true,
+            enabled: true,
+            display_name: "Corporate".to_string(),
+            config_url: "https://idp.example".to_string(),
+            issuer: Some("https://idp.example".to_string()),
+            client_id: "console".to_string(),
+            client_secret_configured: true,
+            scopes: vec!["openid".to_string()],
+            other_audiences: Vec::new(),
+            redirect_uri: None,
+            redirect_uri_dynamic: true,
+            claim_name: "policy".to_string(),
+            claim_prefix: String::new(),
+            role_policy: String::new(),
+            groups_claim: "groups".to_string(),
+            roles_claim: "roles".to_string(),
+            email_claim: "email".to_string(),
+            username_claim: "preferred_username".to_string(),
+            hide_from_ui: false,
+        };
+        assert!(
+            OidcProviderList {
+                providers: vec![provider.clone()],
+                restart_required: false,
+            }
+            .validate_response()
+            .is_ok()
+        );
+        assert!(
+            OidcProviderList {
+                providers: vec![provider.clone(), provider],
+                restart_required: false,
+            }
+            .validate_response()
+            .is_err()
+        );
+    }
+}

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -24,10 +24,11 @@ use rc_core::admin::{
     KmsConfigureRequest, KmsCreateKeyRequest, KmsCreateKeyResult, KmsDeleteKeyRequest,
     KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState, KmsKeyUsage, KmsServiceState, KmsStatus,
     MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
-    MAX_METRICS_SAMPLES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
+    MAX_METRICS_SAMPLES, MAX_OIDC_RESPONSE_BYTES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REQUEST_BYTES,
     MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, ManualTransitionRunRequest,
     ManualTransitionRunResponse, MetricsBatch, MetricsQuery, ModuleSwitches, ObservabilityApi,
+    OidcProvider, OidcProviderList, OidcReadApi, OidcValidationRequest, OidcValidationResult,
     PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RealtimeMetrics,
     RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
     ReplicationDiffApi, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
@@ -590,6 +591,58 @@ impl AdminClient {
         }
 
         serde_json::from_slice(&response_body).map_err(Error::Json)
+    }
+
+    async fn request_oidc<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: Method,
+        path: &str,
+        body: Option<&[u8]>,
+    ) -> Result<T> {
+        let url = self.admin_url(path);
+        let body_bytes = body.unwrap_or_default();
+        let headers = self.request_headers(body_bytes)?;
+        let signed_headers = self
+            .sign_request(&method, &url, &headers, body_bytes)
+            .await?;
+        let mut request = self.http_client.request(method, &url);
+        for (name, value) in &signed_headers {
+            request = request.header(name, value);
+        }
+        if !body_bytes.is_empty() {
+            request = request.body(body_bytes.to_vec());
+        }
+
+        let response = request
+            .send()
+            .await
+            .map_err(|_| Error::Network("OIDC administration request failed".to_string()))?;
+        let status = response.status();
+        let response_body = read_bounded_response_body(
+            response,
+            MAX_OIDC_RESPONSE_BYTES,
+            "OIDC administration response",
+        )
+        .await?;
+        if !status.is_success() {
+            return Err(match status {
+                StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                    Error::Auth("OIDC administration permission was denied".to_string())
+                }
+                StatusCode::NOT_FOUND
+                | StatusCode::METHOD_NOT_ALLOWED
+                | StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+                    "The RustFS OIDC administration route is unavailable".to_string(),
+                ),
+                StatusCode::BAD_REQUEST => {
+                    Error::General("OIDC validation request was rejected".to_string())
+                }
+                _ => Error::Network("OIDC administration service is unavailable".to_string()),
+            });
+        }
+
+        serde_json::from_slice(&response_body)
+            .map_err(|_| Error::General("RustFS returned a malformed OIDC response".to_string()))
     }
 
     /// Send a KMS request while retaining ownership of its body in zeroizing storage.
@@ -2586,6 +2639,49 @@ impl CapabilityApi for AdminClient {
         let report = self.discover_capabilities_uncached().await?;
         self.store_capabilities(&report)?;
         Ok(report)
+    }
+}
+
+#[async_trait]
+impl OidcReadApi for AdminClient {
+    async fn oidc_list_providers(&self) -> Result<OidcProviderList> {
+        let response: OidcProviderList =
+            self.request_oidc(Method::GET, "/oidc/config", None).await?;
+        response.validate_response().map_err(|_| {
+            Error::General("RustFS returned an invalid OIDC provider list".to_string())
+        })?;
+        Ok(response)
+    }
+
+    async fn oidc_get_provider(&self, provider_id: &str) -> Result<OidcProvider> {
+        if provider_id.is_empty()
+            || !provider_id.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+            })
+        {
+            return Err(Error::InvalidPath(
+                "OIDC provider ID must contain only ASCII letters, digits, '_' or '-'".to_string(),
+            ));
+        }
+        self.oidc_list_providers()
+            .await?
+            .providers
+            .into_iter()
+            .find(|provider| provider.provider_id == provider_id)
+            .ok_or_else(|| Error::NotFound(format!("OIDC provider '{provider_id}' was not found")))
+    }
+
+    async fn oidc_validate(&self, request: OidcValidationRequest) -> Result<OidcValidationResult> {
+        request.validate()?;
+        let body = serde_json::to_vec(&request)
+            .map_err(|_| Error::General("Failed to encode OIDC validation request".to_string()))?;
+        let response: OidcValidationResult = self
+            .request_oidc(Method::POST, "/oidc/validate", Some(&body))
+            .await?;
+        response.validate_response().map_err(|_| {
+            Error::General("RustFS returned an invalid OIDC validation response".to_string())
+        })?;
+        Ok(response)
     }
 }
 

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -13,6 +13,9 @@ rc [GLOBAL OPTIONS] admin <COMMAND>
 rc admin diagnostics <health|cluster|extensions> <ALIAS>
 rc admin info <cluster|server|disk|storage> <ALIAS> [OPTIONS]
 rc admin scanner status <ALIAS>
+rc admin idp openid list <ALIAS>
+rc admin idp openid get <ALIAS> <PROVIDER_ID>
+rc admin idp openid validate <ALIAS> <PROVIDER_ID> --config-url URL --client-id ID
 rc admin metrics <ALIAS> [OPTIONS]
 rc admin kms status <ALIAS>
 rc admin kms configure <ALIAS> <--config-file PATH|--stdin>
@@ -58,6 +61,7 @@ rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 | `scanner` | Inspect scanner health, freshness, and cycle state. |
 | `metrics` | Query bounded realtime metrics as normalized JSON Lines or raw server records. |
 | `kms` | Inspect KMS state and manage safe native key lifecycle operations. |
+| `idp openid` | Inspect effective OIDC providers and run non-persisting discovery validation. |
 | `heal` | Start, stop, or inspect healing operations. |
 | `pool` | List pools and inspect pool status. |
 | `expand` | Manage post-expansion data rebalancing. Alias: `scale`. |
@@ -292,6 +296,30 @@ The v3 lifecycle success operations are `configure`, `reconfigure`, `start`, `re
 `kms roundtrip` refuses to run without `--yes`. It generates exactly 4 KiB of random test content internally, writes one randomly named temporary object with explicit SSE-KMS headers, reads and compares the decrypted bytes without creating or reporting a digest, and always attempts permanent deletion even when write, read, or verification fails. The read is bounded to 4 KiB. Application-owned plaintext buffers are zeroized; the temporary object name, plaintext, ciphertext, digest, and generated key material never appear in debug, human, JSON, or error output. A successful v3 result reports only `bucket`, `key_id`, `passed`, `cleanup_passed`, and write/read/cleanup/total milliseconds. Cleanup failure is a distinct error, and a primary failure explicitly reports when cleanup also failed.
 
 `kms key status` describes native RustFS key lifecycle metadata. It does not claim compatibility with the `mc admin kms key status` encryption/decryption probe. The round-trip diagnostic uses only the S3 object API and does not call an Admin API key-generation route. RustFS beta.10 has no direct decrypt-test Admin API or KMS-specific metrics route/selector contract, so `rc` does not offer KMS-specific metrics and intentionally does not expose the legacy `generate-data-key` response because that response contains plaintext data-key material.
+
+## OIDC Read-Only Administration
+
+These commands target RustFS's native typed OIDC routes. They do not use LDAP compatibility
+configuration, browser login endpoints, or a guessed per-provider route:
+
+| Command | Behavior |
+|---|---|
+| `rc admin idp openid list <ALIAS>` | List all effective persisted and environment-managed providers. |
+| `rc admin idp openid get <ALIAS> <PROVIDER_ID>` | Select one exact provider from the server's typed configuration list. |
+| `rc admin idp openid validate <ALIAS> <PROVIDER_ID> --config-url URL --client-id ID` | Run live discovery validation without saving or changing server configuration. |
+
+Provider output includes only the server's `client_secret_configured` boolean. Client-secret
+values are not accepted by this read-only command family, sent in validation requests, or included
+in human/JSON output. Remote text is terminal-sanitized, response bodies are bounded, and unknown
+or incomplete provider shapes fail closed. Missing/unsupported routes use the
+`unsupported_feature` exit code, permission failures use the authentication exit code, a missing
+exact provider uses `not_found`, and locally invalid URLs use the usage exit code.
+
+JSON output uses schema v3 family `oidc` with operations `list`, `get`, and `validate`. Validation
+supports repeated `--scope` and `--other-audience` options, optional `--issuer`, claim-name
+overrides, and `--redirect-uri --static-redirect`. Scopes must include `openid`; URLs must be
+absolute HTTP(S) URLs. RustFS still applies its server-side outbound URL safety policy before
+performing discovery.
 
 `rc admin heal status <ALIAS>` reports aggregate background heal status. Manual heals started with `rc admin heal start` are token-scoped tasks; the start output includes a client token. Root recursive tasks are inspected or stopped with `--client-token`, while bucket or prefix tasks additionally pass `--bucket` and optional `--prefix`.
 

--- a/docs/reference/rc/output.md
+++ b/docs/reference/rc/output.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | [`output_v1.json`](../../../schemas/output_v1.json) | Original S3 and alias command output | Preserved unchanged |
 | [`output_v2.json`](../../../schemas/output_v2.json) | Existing cluster and administrative output | Preserved unchanged |
-| [`output_v3.json`](../../../schemas/output_v3.json) | New capability, version, lock, multipart, watch, health, usage, metrics, diagnostic snapshot, scanner-status, storage-info, KMS, admin-operation, replication, and bucket-operation families | Contract for new implementations |
+| [`output_v3.json`](../../../schemas/output_v3.json) | New capability, version, lock, multipart, watch, health, usage, metrics, diagnostic snapshot, scanner-status, storage-info, KMS, OIDC, admin-operation, replication, and bucket-operation families | Contract for new implementations |
 
 Adding v3 does not silently change the JSON emitted by existing commands. Each command implementation must document when it adopts v3. Consumers should choose a parser from the command's documented output version instead of inferring a version from the installed `rc` release.
 
@@ -76,6 +76,7 @@ When migrating:
 6. For normalized metrics, retain labels and per-sample `collected_at` timestamps; do not infer one timestamp for the entire stream.
 7. Ignore unknown object properties while continuing to require documented fields and types.
 8. For KMS operations, treat `not-configured` as a successful status state; dispatch configuration/service results by `configure`, `reconfigure`, `start`, `restart`, or `stop`; dispatch key results by `key_create`, `key_delete`, or `key_cancel_deletion`; dispatch the non-exporting object diagnostic by `roundtrip`; and never expect temporary object names, content, digests, secret configuration, ciphertext, or data-key fields.
+9. For OIDC operations, dispatch `list`, `get`, and `validate`; provider records expose only `client_secret_configured`, never a client-secret value.
 
 Commands adopting version-operation records migrate only their version-aware JSON paths. Legacy JSON remains unchanged for unversioned `stat`, `rm`, and `cp` results where the server reports no version identifiers. Scripts selecting versions must dispatch on `schema_version: 3` and read operation fields under `data`.
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -41,7 +41,8 @@
         "kms",
         "health_snapshot",
         "cluster_snapshot",
-        "extension_catalog"
+        "extension_catalog",
+        "oidc"
       ]
     },
     "pagination": {
@@ -863,6 +864,85 @@
         { "$ref": "#/definitions/kmsRoundTripData" }
       ]
     },
+    "oidcProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "provider_id", "source", "editable", "enabled", "display_name", "config_url",
+        "issuer", "client_id", "client_secret_configured", "scopes", "other_audiences",
+        "redirect_uri", "redirect_uri_dynamic", "claim_name", "claim_prefix", "role_policy",
+        "groups_claim", "roles_claim", "email_claim", "username_claim", "hide_from_ui"
+      ],
+      "properties": {
+        "provider_id": { "type": "string", "minLength": 1 },
+        "source": { "type": "string", "enum": ["env", "persisted"] },
+        "editable": { "type": "boolean" },
+        "enabled": { "type": "boolean" },
+        "display_name": { "type": "string" },
+        "config_url": { "type": "string", "minLength": 1 },
+        "issuer": { "$ref": "#/definitions/nullableString" },
+        "client_id": { "type": "string", "minLength": 1 },
+        "client_secret_configured": { "type": "boolean" },
+        "scopes": { "type": "array", "items": { "type": "string" } },
+        "other_audiences": { "type": "array", "items": { "type": "string" } },
+        "redirect_uri": { "$ref": "#/definitions/nullableString" },
+        "redirect_uri_dynamic": { "type": "boolean" },
+        "claim_name": { "type": "string" },
+        "claim_prefix": { "type": "string" },
+        "role_policy": { "type": "string" },
+        "groups_claim": { "type": "string" },
+        "roles_claim": { "type": "string" },
+        "email_claim": { "type": "string" },
+        "username_claim": { "type": "string" },
+        "hide_from_ui": { "type": "boolean" }
+      }
+    },
+    "oidcListData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "restart_required", "providers"],
+      "properties": {
+        "operation": { "const": "list" },
+        "restart_required": { "type": "boolean" },
+        "providers": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/oidcProvider" }
+        }
+      }
+    },
+    "oidcGetData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "provider"],
+      "properties": {
+        "operation": { "const": "get" },
+        "provider": { "$ref": "#/definitions/oidcProvider" }
+      }
+    },
+    "oidcValidationData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation", "provider_id", "valid", "message", "issuer",
+        "authorization_endpoint", "token_endpoint"
+      ],
+      "properties": {
+        "operation": { "const": "validate" },
+        "provider_id": { "type": "string", "minLength": 1 },
+        "valid": { "const": true },
+        "message": { "type": "string" },
+        "issuer": { "type": "string", "minLength": 1 },
+        "authorization_endpoint": { "type": "string", "minLength": 1 },
+        "token_endpoint": { "$ref": "#/definitions/nullableString" }
+      }
+    },
+    "oidcData": {
+      "oneOf": [
+        { "$ref": "#/definitions/oidcListData" },
+        { "$ref": "#/definitions/oidcGetData" },
+        { "$ref": "#/definitions/oidcValidationData" }
+      ]
+    },
     "adminOperation": {
       "type": "object",
       "required": [
@@ -1308,6 +1388,17 @@
           "properties": {
             "type": { "const": "kms" },
             "data": { "$ref": "#/definitions/kmsData" }
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        { "$ref": "#/definitions/successEnvelope" },
+        {
+          "properties": {
+            "type": { "const": "oidc" },
+            "data": { "$ref": "#/definitions/oidcData" }
           }
         }
       ]


### PR DESCRIPTION
## Summary

- add `rc admin idp openid list`, `get`, and non-persisting `validate`
- model the RustFS OIDC read surface with secret-free typed core DTOs and `OidcReadApi`
- call the native `GET /rustfs/admin/v3/oidc/config` and `POST /rustfs/admin/v3/oidc/validate` routes
- enforce a 1 MiB response limit and strict response-shape invariants
- fail closed on 404/405/501 and normalize remote discovery errors to avoid secret leakage
- add v3 `oidc` schema, help, reference docs, and integration coverage

## Why

RustFS exposes provider inspection and live discovery validation, but rc had no OIDC management entry point. This is the first read-only slice of rustfs/backlog#1379.

## User impact

Operators can list providers, select one exact provider, and validate discovery without persisting a change. Provider secrets are never returned; only safe configuration and secret-presence metadata are exposed.

## Capability note

RustFS does not yet advertise a dedicated OIDC runtime capability marker. The native route response is therefore authoritative: missing/unimplemented routes return `unsupported_feature`, while auth, transport, malformed, and oversized responses remain distinct failures.

## BREAKING change assessment

BREAKING: no. This adds a new read-only admin command group and a new output-v3 family without changing existing command behavior. The marker is included because the PR updates protected command reference documentation.

## Validation

- OIDC integration tests (5/5)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes rustfs/backlog#1487
Refs rustfs/backlog#1379