### PR TITLE
feat(admin): inspect IAM policy entity mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ For full command documentation, see the [`rc` command reference](docs/reference/
 | Command                 | Description                                                                           |
 |-------------------------|---------------------------------------------------------------------------------------|
 | `admin user`            | Manage IAM users (add, remove, list, info, enable, disable)                           |
-| `admin policy`          | Manage IAM policies (create, remove, list, info, attach)                              |
+| `admin policy`          | Manage IAM policies and inspect entity mappings (create, remove, list, info, attach, entities) |
 | `admin group`           | Manage IAM groups (add, remove, list, info, enable, disable, add-members, rm-members) |
 | `admin service-account` | Manage service accounts (create, update, remove, list, info)                          |
 | `admin access-key`      | Inspect access key identity and metadata (info)                                       |

--- a/crates/cli/src/commands/admin/policy.rs
+++ b/crates/cli/src/commands/admin/policy.rs
@@ -1,6 +1,6 @@
 //! Policy management commands
 //!
-//! Commands for managing IAM policies: list, create, info, remove, attach.
+//! Commands for managing IAM policies and inspecting their entity mappings.
 
 use clap::Subcommand;
 use serde::Serialize;
@@ -9,7 +9,12 @@ use std::fs;
 use super::get_admin_client;
 use crate::exit_code::ExitCode;
 use crate::output::Formatter;
-use rc_core::admin::{AdminApi, PolicyEntity};
+use rc_core::Error;
+use rc_core::admin::{
+    AdminApi, CapabilityApi, CapabilityAvailability, GroupPolicyEntities,
+    IAM_POLICY_ENTITIES_CAPABILITY, IamReadApi, PolicyEntitiesQuery, PolicyEntitiesResult,
+    PolicyEntity, UserPolicyEntities,
+};
 
 /// Policy management subcommands
 #[derive(Subcommand, Debug)]
@@ -30,6 +35,9 @@ pub enum PolicyCommands {
 
     /// Attach policy to a user or group
     Attach(AttachArgs),
+
+    /// Inspect policy mappings for users, groups, or policies
+    Entities(EntitiesArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -85,6 +93,24 @@ pub struct AttachArgs {
     pub group: Option<String>,
 }
 
+#[derive(clap::Args, Debug, Clone)]
+pub struct EntitiesArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// User access key to inspect; may be repeated
+    #[arg(long)]
+    pub user: Vec<String>,
+
+    /// Group name to inspect; may be repeated
+    #[arg(long)]
+    pub group: Vec<String>,
+
+    /// Policy name to inspect; may be repeated
+    #[arg(long)]
+    pub policy: Vec<String>,
+}
+
 /// JSON output for policy list
 #[derive(Serialize)]
 struct PolicyListOutput {
@@ -106,6 +132,65 @@ struct PolicyOperationOutput {
     message: String,
 }
 
+#[derive(Debug, Serialize)]
+struct PolicyEntitiesSuccessOutput<'a> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: PolicyEntitiesOutput<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyEntitiesOutput<'a> {
+    timestamp: jiff::Timestamp,
+    user_mappings: Vec<UserPolicyEntitiesOutput<'a>>,
+    group_mappings: Vec<GroupPolicyEntitiesOutput<'a>>,
+    policy_mappings: Vec<PolicyEntitiesOutputRow<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct UserPolicyEntitiesOutput<'a> {
+    user: &'a str,
+    policies: &'a [String],
+    member_of_mappings: Vec<GroupPolicyEntitiesOutput<'a>>,
+}
+
+#[derive(Debug, Serialize)]
+struct GroupPolicyEntitiesOutput<'a> {
+    group: &'a str,
+    policies: &'a [String],
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyEntitiesOutputRow<'a> {
+    policy: &'a str,
+    users: &'a [String],
+    groups: &'a [String],
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyEntitiesErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: PolicyEntitiesErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyEntitiesErrorBody {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    capability: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<&'static str>,
+    suggestion: Option<&'static str>,
+}
+
 /// Execute a policy subcommand
 pub async fn execute(cmd: PolicyCommands, formatter: &Formatter) -> ExitCode {
     match cmd {
@@ -114,6 +199,282 @@ pub async fn execute(cmd: PolicyCommands, formatter: &Formatter) -> ExitCode {
         PolicyCommands::Info(args) => execute_info(args, formatter).await,
         PolicyCommands::Remove(args) => execute_remove(args, formatter).await,
         PolicyCommands::Attach(args) => execute_attach(args, formatter).await,
+        PolicyCommands::Entities(args) => execute_entities(args, formatter).await,
+    }
+}
+
+async fn execute_entities(args: EntitiesArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_entities_with_api(args, &client, &client, formatter).await
+}
+
+async fn execute_entities_with_api(
+    args: EntitiesArgs,
+    capabilities: &dyn CapabilityApi,
+    iam: &dyn IamReadApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    let query = PolicyEntitiesQuery {
+        users: args.user,
+        groups: args.group,
+        policies: args.policy,
+    };
+    if let Err(error) = query.validate() {
+        return emit_policy_entities_error("Invalid IAM policy-entity query", &error, formatter);
+    }
+
+    let report = match capabilities.discover_capabilities(false).await {
+        Ok(report) => report,
+        Err(error) => {
+            let error = sanitize_capability_discovery_error(&error);
+            return emit_policy_entities_error(
+                "Failed to discover IAM capabilities",
+                &error,
+                formatter,
+            );
+        }
+    };
+    match report.capability(IAM_POLICY_ENTITIES_CAPABILITY) {
+        Some(capability) if capability.availability == CapabilityAvailability::Available => {}
+        Some(capability) if capability.availability == CapabilityAvailability::PermissionDenied => {
+            return emit_policy_entities_error(
+                "IAM policy-entity capability is unavailable",
+                &Error::Auth(format!(
+                    "{} is permission-denied",
+                    IAM_POLICY_ENTITIES_CAPABILITY
+                )),
+                formatter,
+            );
+        }
+        Some(capability) => {
+            return emit_policy_entities_error(
+                "IAM policy-entity capability is unavailable",
+                &Error::UnsupportedFeature(format!(
+                    "{} is {}{}",
+                    IAM_POLICY_ENTITIES_CAPABILITY,
+                    capability.availability,
+                    capability
+                        .reason
+                        .as_deref()
+                        .map(|reason| format!(": {reason}"))
+                        .unwrap_or_default()
+                )),
+                formatter,
+            );
+        }
+        None => {
+            return emit_policy_entities_error(
+                "IAM policy-entity capability is unavailable",
+                &Error::UnsupportedFeature(format!(
+                    "{IAM_POLICY_ENTITIES_CAPABILITY} was not advertised by the server"
+                )),
+                formatter,
+            );
+        }
+    }
+
+    match iam.policy_entities(&query).await {
+        Ok(result) => output_policy_entities(&result, formatter),
+        Err(error) => {
+            emit_policy_entities_error("Failed to inspect IAM policy entities", &error, formatter)
+        }
+    }
+}
+
+fn sanitize_capability_discovery_error(error: &Error) -> Error {
+    match error.exit_code() {
+        2 => Error::Config("RustFS capability discovery could not be configured".to_string()),
+        3 => Error::Network("RustFS capability discovery request failed".to_string()),
+        4 => Error::Auth("Permission denied during capability discovery".to_string()),
+        5 => Error::NotFound("RustFS capability discovery endpoint was not found".to_string()),
+        6 => Error::Conflict("RustFS capability discovery encountered a conflict".to_string()),
+        7 => Error::UnsupportedFeature(
+            "RustFS capability discovery is not supported by this server".to_string(),
+        ),
+        130 => Error::Interrupted("RustFS capability discovery was interrupted".to_string()),
+        _ => Error::General("RustFS capability discovery failed".to_string()),
+    }
+}
+
+fn output_policy_entities(result: &PolicyEntitiesResult, formatter: &Formatter) -> ExitCode {
+    if formatter.is_json() {
+        formatter.json(&policy_entities_success(result));
+    } else {
+        print_policy_entities(result, formatter);
+    }
+    ExitCode::Success
+}
+
+fn policy_entities_success(result: &PolicyEntitiesResult) -> PolicyEntitiesSuccessOutput<'_> {
+    PolicyEntitiesSuccessOutput {
+        schema_version: 3,
+        output_type: "iam_policy_entities",
+        status: "success",
+        data: PolicyEntitiesOutput {
+            timestamp: result.timestamp,
+            user_mappings: result
+                .user_mappings
+                .iter()
+                .map(user_policy_entities_output)
+                .collect(),
+            group_mappings: result
+                .group_mappings
+                .iter()
+                .map(group_policy_entities_output)
+                .collect(),
+            policy_mappings: result
+                .policy_mappings
+                .iter()
+                .map(|mapping| PolicyEntitiesOutputRow {
+                    policy: &mapping.policy,
+                    users: &mapping.users,
+                    groups: &mapping.groups,
+                })
+                .collect(),
+        },
+    }
+}
+
+fn user_policy_entities_output(mapping: &UserPolicyEntities) -> UserPolicyEntitiesOutput<'_> {
+    UserPolicyEntitiesOutput {
+        user: &mapping.user,
+        policies: &mapping.policies,
+        member_of_mappings: mapping
+            .member_of_mappings
+            .iter()
+            .map(group_policy_entities_output)
+            .collect(),
+    }
+}
+
+fn group_policy_entities_output(mapping: &GroupPolicyEntities) -> GroupPolicyEntitiesOutput<'_> {
+    GroupPolicyEntitiesOutput {
+        group: &mapping.group,
+        policies: &mapping.policies,
+    }
+}
+
+fn print_policy_entities(result: &PolicyEntitiesResult, formatter: &Formatter) {
+    formatter.println(&format!("Timestamp: {}", result.timestamp));
+    if result.user_mappings.is_empty()
+        && result.group_mappings.is_empty()
+        && result.policy_mappings.is_empty()
+    {
+        formatter.println("No matching policy entity mappings.");
+        return;
+    }
+
+    if !result.user_mappings.is_empty() {
+        formatter.println("");
+        formatter.println("Users:");
+        for mapping in &result.user_mappings {
+            formatter.println(&format!("  {}", formatter.style_name(&mapping.user)));
+            formatter.println(&format!(
+                "    Direct policies: {}",
+                display_names(&mapping.policies, formatter)
+            ));
+            for inherited in &mapping.member_of_mappings {
+                formatter.println(&format!(
+                    "    Via group {}: {}",
+                    formatter.style_name(&inherited.group),
+                    display_names(&inherited.policies, formatter)
+                ));
+            }
+        }
+    }
+
+    if !result.group_mappings.is_empty() {
+        formatter.println("");
+        formatter.println("Groups:");
+        for mapping in &result.group_mappings {
+            formatter.println(&format!(
+                "  {}: {}",
+                formatter.style_name(&mapping.group),
+                display_names(&mapping.policies, formatter)
+            ));
+        }
+    }
+
+    if !result.policy_mappings.is_empty() {
+        formatter.println("");
+        formatter.println("Policies:");
+        for mapping in &result.policy_mappings {
+            formatter.println(&format!("  {}", formatter.style_name(&mapping.policy)));
+            formatter.println(&format!(
+                "    Users:  {}",
+                display_names(&mapping.users, formatter)
+            ));
+            formatter.println(&format!(
+                "    Groups: {}",
+                display_names(&mapping.groups, formatter)
+            ));
+        }
+    }
+}
+
+fn display_names(names: &[String], formatter: &Formatter) -> String {
+    if names.is_empty() {
+        "-".to_string()
+    } else {
+        formatter.sanitize_text(&names.join(", "))
+    }
+}
+
+fn emit_policy_entities_error(context: &str, error: &Error, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    let message = format!("{context}: {error}");
+    if formatter.is_json() {
+        let unsupported = code == ExitCode::UnsupportedFeature;
+        formatter.json_error(&PolicyEntitiesErrorOutput {
+            schema_version: 3,
+            output_type: "iam_policy_entities",
+            status: "error",
+            error: PolicyEntitiesErrorBody {
+                error_type: policy_entities_error_type(code),
+                message,
+                retryable: code == ExitCode::NetworkError,
+                capability: unsupported.then_some(IAM_POLICY_ENTITIES_CAPABILITY),
+                server: unsupported.then_some("rustfs"),
+                suggestion: policy_entities_error_suggestion(code),
+            },
+        });
+    } else {
+        formatter.error_with_code(code, &message);
+    }
+    code
+}
+
+const fn policy_entities_error_type(code: ExitCode) -> &'static str {
+    match code {
+        ExitCode::UsageError => "usage_error",
+        ExitCode::NetworkError => "network_error",
+        ExitCode::AuthError => "auth_error",
+        ExitCode::NotFound => "not_found",
+        ExitCode::Conflict => "conflict",
+        ExitCode::UnsupportedFeature => "unsupported_feature",
+        ExitCode::Interrupted => "interrupted",
+        ExitCode::Success | ExitCode::GeneralError => "general_error",
+    }
+}
+
+const fn policy_entities_error_suggestion(code: ExitCode) -> Option<&'static str> {
+    match code {
+        ExitCode::UsageError => Some("Review the entity filters and retry."),
+        ExitCode::NetworkError => Some("Verify the endpoint and network connectivity, then retry."),
+        ExitCode::AuthError => Some(
+            "Verify credentials and the list-users, list-groups, and list-user-policies permissions.",
+        ),
+        ExitCode::UnsupportedFeature => {
+            Some("Use a RustFS version that advertises IAM policy-entity inspection.")
+        }
+        ExitCode::NotFound
+        | ExitCode::Conflict
+        | ExitCode::Interrupted
+        | ExitCode::Success
+        | ExitCode::GeneralError => None,
     }
 }
 
@@ -331,6 +692,137 @@ async fn execute_attach(args: AttachArgs, formatter: &Formatter) -> ExitCode {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use jsonschema::Validator;
+    use rc_core::Result;
+    use rc_core::admin::{
+        CapabilityEntry, CapabilityReport, ClusterSnapshotMetadata, GroupPolicyEntities,
+        PolicyEntities, UserPolicyEntities,
+    };
+    use serde_json::Value;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, Copy)]
+    enum ReadResult {
+        Success,
+        Auth,
+        Unsupported,
+    }
+
+    struct StubIamApi {
+        availability: Option<CapabilityAvailability>,
+        read_result: ReadResult,
+        read_calls: AtomicUsize,
+    }
+
+    impl StubIamApi {
+        fn report(&self) -> CapabilityReport {
+            CapabilityReport {
+                server_version: Some("1.0.0-beta.10".to_string()),
+                runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+                extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+                cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+                capabilities: self
+                    .availability
+                    .map(|availability| CapabilityEntry {
+                        name: IAM_POLICY_ENTITIES_CAPABILITY.to_string(),
+                        availability,
+                        reason: None,
+                    })
+                    .into_iter()
+                    .collect(),
+                extensions: Vec::new(),
+                cluster: ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CapabilityApi for StubIamApi {
+        async fn discover_capabilities(&self, _refresh: bool) -> Result<CapabilityReport> {
+            Ok(self.report())
+        }
+    }
+
+    #[async_trait]
+    impl IamReadApi for StubIamApi {
+        async fn policy_entities(
+            &self,
+            _query: &PolicyEntitiesQuery,
+        ) -> Result<PolicyEntitiesResult> {
+            self.read_calls.fetch_add(1, Ordering::Relaxed);
+            match self.read_result {
+                ReadResult::Success => Ok(policy_entities_result()),
+                ReadResult::Auth => Err(Error::Auth("permission denied".to_string())),
+                ReadResult::Unsupported => {
+                    Err(Error::UnsupportedFeature("route unavailable".to_string()))
+                }
+            }
+        }
+    }
+
+    fn policy_entities_result() -> PolicyEntitiesResult {
+        PolicyEntitiesResult {
+            timestamp: "2026-07-24T08:00:00Z".parse().expect("valid timestamp"),
+            user_mappings: vec![UserPolicyEntities {
+                user: "alice".to_string(),
+                policies: vec!["readonly".to_string()],
+                member_of_mappings: vec![GroupPolicyEntities {
+                    group: "ops".to_string(),
+                    policies: vec!["diagnostics".to_string()],
+                }],
+            }],
+            group_mappings: vec![GroupPolicyEntities {
+                group: "ops".to_string(),
+                policies: vec!["diagnostics".to_string()],
+            }],
+            policy_mappings: vec![PolicyEntities {
+                policy: "readonly".to_string(),
+                users: vec!["alice".to_string()],
+                groups: Vec::new(),
+            }],
+        }
+    }
+
+    fn args() -> EntitiesArgs {
+        EntitiesArgs {
+            alias: "local".to_string(),
+            user: vec!["alice".to_string()],
+            group: Vec::new(),
+            policy: vec!["readonly".to_string()],
+        }
+    }
+
+    fn quiet_formatter() -> Formatter {
+        Formatter::new(crate::output::OutputConfig {
+            quiet: true,
+            ..Default::default()
+        })
+    }
+
+    fn validator() -> Validator {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("schemas/output_v3.json");
+        let schema: Value = serde_json::from_str(
+            &std::fs::read_to_string(path).expect("output schema should be readable"),
+        )
+        .expect("output schema should parse");
+        jsonschema::validator_for(&schema).expect("output schema should compile")
+    }
+
+    fn assert_valid(value: &Value) {
+        let errors = validator()
+            .iter_errors(value)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        assert!(errors.is_empty(), "invalid output: {}", errors.join("\n"));
+    }
 
     #[test]
     fn test_policy_list_output_serialization() {
@@ -340,5 +832,101 @@ mod tests {
         let json = serde_json::to_string(&output).unwrap();
         assert!(json.contains("readonly"));
         assert!(json.contains("admin"));
+    }
+
+    #[test]
+    fn policy_entities_success_matches_v3_schema_and_golden_fixture() {
+        let value = serde_json::to_value(policy_entities_success(&policy_entities_result()))
+            .expect("serialize policy entities output");
+        assert_valid(&value);
+
+        let expected: Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/output_v3/iam_policy_entities/success.json"
+        ))
+        .expect("golden fixture should parse");
+        assert_eq!(value, expected);
+    }
+
+    #[test]
+    fn policy_entities_empty_success_matches_v3_schema() {
+        let result = PolicyEntitiesResult {
+            timestamp: "2026-07-24T08:00:00Z".parse().expect("valid timestamp"),
+            user_mappings: Vec::new(),
+            group_mappings: Vec::new(),
+            policy_mappings: Vec::new(),
+        };
+        let value =
+            serde_json::to_value(policy_entities_success(&result)).expect("serialize empty output");
+        assert_valid(&value);
+    }
+
+    #[tokio::test]
+    async fn policy_entities_fails_closed_when_capability_is_missing() {
+        let api = StubIamApi {
+            availability: None,
+            read_result: ReadResult::Success,
+            read_calls: AtomicUsize::new(0),
+        };
+        assert_eq!(
+            execute_entities_with_api(args(), &api, &api, &quiet_formatter()).await,
+            ExitCode::UnsupportedFeature
+        );
+        assert_eq!(api.read_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn policy_entities_preserves_auth_and_route_unsupported_exit_codes() {
+        for (read_result, expected) in [
+            (ReadResult::Auth, ExitCode::AuthError),
+            (ReadResult::Unsupported, ExitCode::UnsupportedFeature),
+        ] {
+            let api = StubIamApi {
+                availability: Some(CapabilityAvailability::Available),
+                read_result,
+                read_calls: AtomicUsize::new(0),
+            };
+            assert_eq!(
+                execute_entities_with_api(args(), &api, &api, &quiet_formatter()).await,
+                expected
+            );
+            assert_eq!(api.read_calls.load(Ordering::Relaxed), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn policy_entities_rejects_invalid_selector_before_discovery_or_read() {
+        let api = StubIamApi {
+            availability: Some(CapabilityAvailability::Available),
+            read_result: ReadResult::Success,
+            read_calls: AtomicUsize::new(0),
+        };
+        let mut invalid = args();
+        invalid.user = vec![" ".to_string()];
+        assert_eq!(
+            execute_entities_with_api(invalid, &api, &api, &quiet_formatter()).await,
+            ExitCode::UsageError
+        );
+        assert_eq!(api.read_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn capability_discovery_errors_do_not_echo_server_or_credential_text() {
+        for error in [
+            Error::Auth("access-key secret-key".to_string()),
+            Error::Network("HTTP 500: session-token".to_string()),
+            Error::General("credential material".to_string()),
+        ] {
+            let sanitized = sanitize_capability_discovery_error(&error);
+            let message = sanitized.to_string();
+            for secret in [
+                "access-key",
+                "secret-key",
+                "session-token",
+                "credential material",
+            ] {
+                assert!(!message.contains(secret));
+            }
+            assert_eq!(sanitized.exit_code(), error.exit_code());
+        }
     }
 }

--- a/crates/cli/tests/admin_policy_entities.rs
+++ b/crates/cli/tests/admin_policy_entities.rs
@@ -1,0 +1,80 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_sequence_test_server};
+
+const INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const RUNTIME_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+const POLICY_ENTITIES_RESPONSE: &str = r#"{"timestamp":"2026-07-24T08:00:00Z","userMappings":[{"user":"alice","policies":["readonly"],"memberOfMappings":[{"group":"ops/team","policies":["diagnostics"]}],"secretKey":"must-not-leak"}],"groupMappings":[{"group":"ops/team","policies":["diagnostics"]}],"policyMappings":[{"policy":"read only","users":["alice"],"groups":[]}],"sessionToken":"must-not-leak"}"#;
+
+#[test]
+fn policy_entities_dispatches_after_capability_gate_and_emits_redacted_v3_json() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", POLICY_ENTITIES_RESPONSE),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "policy",
+            "entities",
+            "myalias",
+            "--user",
+            "alice@example.com",
+            "--user",
+            "bob",
+            "--group",
+            "ops/team",
+            "--policy",
+            "read only",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "iam_policy_entities");
+    assert_eq!(value["data"]["user_mappings"][0]["user"], "alice");
+    assert_eq!(
+        value["data"]["user_mappings"][0]["member_of_mappings"][0]["group"],
+        "ops/team"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("must-not-leak"));
+    assert!(output.stderr.is_empty());
+
+    for expected in [
+        "/rustfs/admin/v3/info",
+        "/rustfs/admin/v4/runtime/capabilities",
+        "/rustfs/admin/v4/extensions/catalog",
+        "/rustfs/admin/v4/cluster/snapshot",
+        "/rustfs/admin/v3/idp/builtin/policy-entities?user=alice%40example.com&user=bob&group=ops%2Fteam&policy=read%20only",
+    ] {
+        let request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured admin request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.target, expected);
+    }
+    handle.join().expect("admin test server finished");
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_policy_entities/empty.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_policy_entities/empty.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 3,
+  "type": "iam_policy_entities",
+  "status": "success",
+  "data": {
+    "timestamp": "2026-07-24T08:00:00Z",
+    "user_mappings": [],
+    "group_mappings": [],
+    "policy_mappings": []
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_policy_entities/error.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_policy_entities/error.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 3,
+  "type": "iam_policy_entities",
+  "status": "error",
+  "error": {
+    "type": "auth_error",
+    "message": "Failed to inspect IAM policy entities: permission denied",
+    "retryable": false,
+    "suggestion": "Verify credentials and the required RustFS admin permissions."
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_policy_entities/success.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_policy_entities/success.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": 3,
+  "type": "iam_policy_entities",
+  "status": "success",
+  "data": {
+    "timestamp": "2026-07-24T08:00:00Z",
+    "user_mappings": [
+      {
+        "user": "alice",
+        "policies": ["readonly"],
+        "member_of_mappings": [
+          {
+            "group": "ops",
+            "policies": ["diagnostics"]
+          }
+        ]
+      }
+    ],
+    "group_mappings": [
+      {
+        "group": "ops",
+        "policies": ["diagnostics"]
+      }
+    ],
+    "policy_mappings": [
+      {
+        "policy": "readonly",
+        "users": ["alice"],
+        "groups": []
+      }
+    ]
+  }
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -1012,6 +1012,11 @@ fn nested_subcommand_help_contract() {
             expected_tokens: &["--user", "--group"],
         },
         HelpCase {
+            args: &["admin", "policy", "entities"],
+            usage: "Usage: rc admin policy entities [OPTIONS] <ALIAS>",
+            expected_tokens: &["--user", "--group", "--policy"],
+        },
+        HelpCase {
             args: &["admin", "group", "ls"],
             usage: "Usage: rc admin group ls [OPTIONS] <ALIAS>",
             expected_tokens: &[],

--- a/crates/cli/tests/output_schema_v3.rs
+++ b/crates/cli/tests/output_schema_v3.rs
@@ -25,6 +25,7 @@ const V3_FAMILIES: &[&str] = &[
     "replication",
     "replication_operations",
     "bucket_operations",
+    "iam_policy_entities",
 ];
 
 fn repository_root() -> PathBuf {

--- a/crates/core/src/admin/iam.rs
+++ b/crates/core/src/admin/iam.rs
@@ -1,0 +1,287 @@
+//! Typed contracts for read-only IAM policy-entity inspection.
+
+use async_trait::async_trait;
+use jiff::Timestamp;
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+/// Capability name used to guard policy-entity inspection.
+pub const IAM_POLICY_ENTITIES_CAPABILITY: &str = "admin.iam.policy-entities";
+
+/// Maximum encoded size accepted for one policy-entity response.
+pub const MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Maximum number of selectors accepted in a single request.
+pub const MAX_IAM_POLICY_ENTITY_SELECTORS: usize = 1_000;
+
+/// Maximum UTF-8 byte length accepted for one selector.
+pub const MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES: usize = 1_024;
+
+/// Filters for a policy-entity inspection request.
+///
+/// An empty query asks RustFS for every policy-to-entity mapping. User and group
+/// filters return their direct and inherited policy mappings. Policy filters
+/// return the matching users and groups.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PolicyEntitiesQuery {
+    pub users: Vec<String>,
+    pub groups: Vec<String>,
+    pub policies: Vec<String>,
+}
+
+impl PolicyEntitiesQuery {
+    /// Reject selectors that would create ambiguous or excessively large requests.
+    pub fn validate(&self) -> Result<()> {
+        let selector_count = self.users.len() + self.groups.len() + self.policies.len();
+        if selector_count > MAX_IAM_POLICY_ENTITY_SELECTORS {
+            return Err(Error::InvalidPath(format!(
+                "IAM policy-entity query accepts at most {MAX_IAM_POLICY_ENTITY_SELECTORS} selectors"
+            )));
+        }
+
+        for (kind, selectors) in [
+            ("user", self.users.as_slice()),
+            ("group", self.groups.as_slice()),
+            ("policy", self.policies.as_slice()),
+        ] {
+            for selector in selectors {
+                if selector.trim().is_empty() {
+                    return Err(Error::InvalidPath(format!(
+                        "IAM policy-entity {kind} selector cannot be empty"
+                    )));
+                }
+                if selector.len() > MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES {
+                    return Err(Error::InvalidPath(format!(
+                        "IAM policy-entity {kind} selector exceeds {MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES} bytes"
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Policy mappings returned by RustFS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyEntitiesResult {
+    pub timestamp: Timestamp,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub user_mappings: Vec<UserPolicyEntities>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub group_mappings: Vec<GroupPolicyEntities>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub policy_mappings: Vec<PolicyEntities>,
+}
+
+impl PolicyEntitiesResult {
+    /// Validate identifiers and normalize mapping order for deterministic output.
+    pub fn normalize(mut self) -> Result<Self> {
+        for mapping in &mut self.user_mappings {
+            validate_name("user", &mapping.user)?;
+            normalize_names("policy", &mut mapping.policies)?;
+            for inherited in &mut mapping.member_of_mappings {
+                normalize_group_mapping(inherited)?;
+            }
+            mapping
+                .member_of_mappings
+                .sort_by(|left, right| left.group.cmp(&right.group));
+            mapping
+                .member_of_mappings
+                .dedup_by(|left, right| left.group == right.group);
+        }
+        self.user_mappings
+            .sort_by(|left, right| left.user.cmp(&right.user));
+        self.user_mappings
+            .dedup_by(|left, right| left.user == right.user);
+
+        for mapping in &mut self.group_mappings {
+            normalize_group_mapping(mapping)?;
+        }
+        self.group_mappings
+            .sort_by(|left, right| left.group.cmp(&right.group));
+        self.group_mappings
+            .dedup_by(|left, right| left.group == right.group);
+
+        for mapping in &mut self.policy_mappings {
+            validate_name("policy", &mapping.policy)?;
+            normalize_names("user", &mut mapping.users)?;
+            normalize_names("group", &mut mapping.groups)?;
+        }
+        self.policy_mappings
+            .sort_by(|left, right| left.policy.cmp(&right.policy));
+        self.policy_mappings
+            .dedup_by(|left, right| left.policy == right.policy);
+
+        Ok(self)
+    }
+}
+
+fn normalize_group_mapping(mapping: &mut GroupPolicyEntities) -> Result<()> {
+    validate_name("group", &mapping.group)?;
+    normalize_names("policy", &mut mapping.policies)
+}
+
+fn normalize_names(kind: &str, names: &mut Vec<String>) -> Result<()> {
+    for name in names.iter() {
+        validate_name(kind, name)?;
+    }
+    names.sort();
+    names.dedup();
+    Ok(())
+}
+
+fn validate_name(kind: &str, name: &str) -> Result<()> {
+    if name.trim().is_empty() {
+        return Err(Error::General(format!(
+            "RustFS IAM policy-entity response contains an empty {kind} name"
+        )));
+    }
+    Ok(())
+}
+
+/// Direct and inherited policy mappings for one user.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserPolicyEntities {
+    pub user: String,
+    #[serde(default)]
+    pub policies: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub member_of_mappings: Vec<GroupPolicyEntities>,
+}
+
+/// Direct policy mappings for one group.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GroupPolicyEntities {
+    pub group: String,
+    #[serde(default)]
+    pub policies: Vec<String>,
+}
+
+/// Users and groups attached to one policy.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyEntities {
+    pub policy: String,
+    #[serde(default)]
+    pub users: Vec<String>,
+    #[serde(default)]
+    pub groups: Vec<String>,
+}
+
+/// Read-only RustFS IAM policy-entity operations.
+#[async_trait]
+pub trait IamReadApi: Send + Sync {
+    /// Inspect direct and inherited policy associations.
+    async fn policy_entities(&self, query: &PolicyEntitiesQuery) -> Result<PolicyEntitiesResult>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn response_decodes_current_rustfs_shape_without_secret_fields() {
+        let result: PolicyEntitiesResult = serde_json::from_str(
+            r#"{
+                "timestamp": "2026-07-24T08:00:00Z",
+                "userMappings": [{
+                    "user": "alice",
+                    "policies": ["readonly"],
+                    "memberOfMappings": [{"group": "ops", "policies": ["diagnostics"]}],
+                    "secretKey": "must-not-survive"
+                }],
+                "groupMappings": [{"group": "ops", "policies": ["diagnostics"]}],
+                "policyMappings": [{
+                    "policy": "readonly",
+                    "users": ["alice"],
+                    "groups": []
+                }],
+                "sessionToken": "must-not-survive"
+            }"#,
+        )
+        .expect("decode RustFS policy entities");
+
+        assert_eq!(result.user_mappings[0].user, "alice");
+        assert_eq!(result.user_mappings[0].member_of_mappings[0].group, "ops");
+
+        let encoded = serde_json::to_string(&result).expect("encode typed response");
+        assert!(!encoded.contains("must-not-survive"));
+        assert!(!encoded.contains("secretKey"));
+        assert!(!encoded.contains("sessionToken"));
+    }
+
+    #[test]
+    fn query_validation_rejects_empty_and_oversized_selectors() {
+        let empty = PolicyEntitiesQuery {
+            users: vec![" ".to_string()],
+            ..Default::default()
+        };
+        assert!(matches!(empty.validate(), Err(Error::InvalidPath(_))));
+
+        let oversized = PolicyEntitiesQuery {
+            policies: vec!["p".repeat(MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES + 1)],
+            ..Default::default()
+        };
+        assert!(matches!(oversized.validate(), Err(Error::InvalidPath(_))));
+    }
+
+    #[test]
+    fn query_validation_limits_aggregate_selector_count() {
+        let query = PolicyEntitiesQuery {
+            users: vec!["alice".to_string(); MAX_IAM_POLICY_ENTITY_SELECTORS + 1],
+            ..Default::default()
+        };
+        assert!(matches!(query.validate(), Err(Error::InvalidPath(_))));
+    }
+
+    #[test]
+    fn response_normalization_is_deterministic_and_rejects_empty_names() {
+        let result: PolicyEntitiesResult = serde_json::from_str(
+            r#"{
+                "timestamp": "2026-07-24T08:00:00Z",
+                "userMappings": [
+                    {"user":"bob","policies":["write","read","read"]},
+                    {"user":"alice","policies":["read"]}
+                ],
+                "groupMappings": [
+                    {"group":"ops","policies":["write","read"]},
+                    {"group":"dev","policies":["read"]}
+                ],
+                "policyMappings": [
+                    {"policy":"write","users":["bob"],"groups":["ops"]},
+                    {"policy":"read","users":["bob","alice","alice"],"groups":["ops","dev"]}
+                ]
+            }"#,
+        )
+        .expect("decode response");
+        let normalized = result.normalize().expect("normalize response");
+
+        assert_eq!(normalized.user_mappings[0].user, "alice");
+        assert_eq!(
+            normalized.user_mappings[1].policies,
+            vec!["read".to_string(), "write".to_string()]
+        );
+        assert_eq!(normalized.group_mappings[0].group, "dev");
+        assert_eq!(normalized.policy_mappings[0].policy, "read");
+        assert_eq!(
+            normalized.policy_mappings[0].users,
+            vec!["alice".to_string(), "bob".to_string()]
+        );
+
+        let invalid: PolicyEntitiesResult = serde_json::from_str(
+            r#"{
+                "timestamp": "2026-07-24T08:00:00Z",
+                "userMappings": [],
+                "groupMappings": [],
+                "policyMappings": [{"policy":" ","users":[],"groups":[]}]
+            }"#,
+        )
+        .expect("decode invalid response");
+        assert!(matches!(invalid.normalize(), Err(Error::General(_))));
+    }
+}

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -7,6 +7,7 @@ mod capabilities;
 mod cluster;
 mod configuration;
 mod diagnostics;
+mod iam;
 mod kms;
 mod kms_diagnostic;
 mod observability;
@@ -45,6 +46,12 @@ pub use diagnostics::{
     HealthMemorySnapshot, HealthOsSnapshot, HealthProcessSnapshot,
     MAX_CLIENT_DEVNULL_AGGREGATE_BYTES, MAX_CLIENT_DEVNULL_CONCURRENCY, MAX_CLIENT_DEVNULL_TIMEOUT,
     MAX_DIAGNOSTIC_RESPONSE_BYTES,
+};
+pub use iam::{
+    GroupPolicyEntities, IAM_POLICY_ENTITIES_CAPABILITY, IamReadApi,
+    MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES, MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES,
+    MAX_IAM_POLICY_ENTITY_SELECTORS, PolicyEntities, PolicyEntitiesQuery, PolicyEntitiesResult,
+    UserPolicyEntities,
 };
 pub use kms::{
     KmsApi, KmsBackendKind, KmsCacheSummary, KmsCancelKeyDeletionResult, KmsConfigSummary,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -20,22 +20,23 @@ use rc_core::admin::{
     ConfigMutationResult, CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus,
     DetailedHealthSnapshot, DiagnosticCapability, DiagnosticReadApi, ExtensionsCatalog, Group,
     GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus, HealTaskRequest,
-    KmsApi, KmsBackendKind, KmsCacheSummary, KmsCancelKeyDeletionResult, KmsConfigSummary,
-    KmsConfigureRequest, KmsCreateKeyRequest, KmsCreateKeyResult, KmsDeleteKeyRequest,
-    KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState, KmsKeyUsage, KmsServiceState, KmsStatus,
-    MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
+    IAM_POLICY_ENTITIES_CAPABILITY, IamReadApi, KmsApi, KmsBackendKind, KmsCacheSummary,
+    KmsCancelKeyDeletionResult, KmsConfigSummary, KmsConfigureRequest, KmsCreateKeyRequest,
+    KmsCreateKeyResult, KmsDeleteKeyRequest, KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState,
+    KmsKeyUsage, KmsServiceState, KmsStatus, MAX_DIAGNOSTIC_RESPONSE_BYTES,
+    MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
     MAX_METRICS_SAMPLES, MAX_OIDC_RESPONSE_BYTES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REQUEST_BYTES,
     MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, ManualTransitionRunRequest,
     ManualTransitionRunResponse, MetricsBatch, MetricsQuery, ModuleSwitches, ObservabilityApi,
     OidcProvider, OidcProviderList, OidcReadApi, OidcValidationRequest, OidcValidationResult,
-    PeerSiteSpec, Policy, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RealtimeMetrics,
-    RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
-    ReplicationDiffApi, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
-    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
-    SiteReplicationInfo, SiteReplicationPeer, SiteReplicationResyncOperation,
-    SiteReplicationResyncStatus, SiteStatusOptions, StorageInfo, UpdateGroupMembersRequest,
-    UpdateServiceAccountRequest, User, UserStatus,
+    PeerSiteSpec, Policy, PolicyEntitiesQuery, PolicyEntitiesResult, PolicyEntity, PolicyInfo,
+    PoolStatus, PoolTarget, RealtimeMetrics, RebalanceStartResult, RebalanceStatus,
+    ReplicateEditStatus, ReplicationDiff, ReplicationDiffApi, RuntimeCapabilitiesSnapshot,
+    RuntimeCapabilityStatus, ScannerStatus, ServiceAccount, ServiceAccountCreateResponse,
+    ServiceActionResult, SiteRemoveSpec, SiteReplicationInfo, SiteReplicationPeer,
+    SiteReplicationResyncOperation, SiteReplicationResyncStatus, SiteStatusOptions, StorageInfo,
+    UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -48,6 +49,12 @@ use std::time::{Duration, SystemTime};
 use zeroize::{Zeroize, Zeroizing};
 
 struct SensitiveRequestBody(Zeroizing<Vec<u8>>);
+
+struct BoundedJsonResponse {
+    max_bytes: usize,
+    name: &'static str,
+    error_mapper: fn(&AdminClient, StatusCode, &str) -> Error,
+}
 
 impl AsRef<[u8]> for SensitiveRequestBody {
     fn as_ref(&self) -> &[u8] {
@@ -542,8 +549,7 @@ impl AdminClient {
         path: &str,
         query: Option<&[(&str, &str)]>,
         body: Option<&[u8]>,
-        max_response_bytes: usize,
-        response_name: &str,
+        response: BoundedJsonResponse,
     ) -> Result<T> {
         let mut url = self.admin_url(path);
         if let Some(query) = query {
@@ -577,17 +583,19 @@ impl AdminClient {
             request_builder = request_builder.body(body_bytes.to_vec());
         }
 
-        let response = request_builder
+        let http_response = request_builder
             .send()
             .await
             .map_err(|error| Error::Network(format!("Request failed: {error}")))?;
-        let status = response.status();
+        let status = http_response.status();
         let response_body =
-            read_bounded_response_body(response, max_response_bytes, response_name).await?;
+            read_bounded_response_body(http_response, response.max_bytes, response.name).await?;
         if !status.is_success() {
-            return Err(
-                self.map_replication_diff_error(status, &String::from_utf8_lossy(&response_body))
-            );
+            return Err((response.error_mapper)(
+                self,
+                status,
+                &String::from_utf8_lossy(&response_body),
+            ));
         }
 
         serde_json::from_slice(&response_body).map_err(Error::Json)
@@ -969,6 +977,26 @@ impl AdminClient {
             .filter(|message| !message.trim().is_empty())
             .unwrap_or_else(|| "the replication diff route was not found".to_string());
         Error::UnsupportedFeature(reason)
+    }
+
+    fn map_iam_policy_entities_error(&self, status: StatusCode, _body: &str) -> Error {
+        match status {
+            StatusCode::NOT_FOUND
+            | StatusCode::METHOD_NOT_ALLOWED
+            | StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+                "IAM policy-entity inspection is not supported by this RustFS server".to_string(),
+            ),
+            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                Error::Auth("Permission denied for IAM policy-entity inspection".to_string())
+            }
+            StatusCode::BAD_REQUEST => {
+                Error::InvalidPath("RustFS rejected the IAM policy-entity query".to_string())
+            }
+            _ => Error::Network(format!(
+                "IAM policy-entity inspection failed with HTTP {}",
+                status.as_u16()
+            )),
+        }
     }
 }
 
@@ -1833,6 +1861,11 @@ fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<C
         availability: CapabilityAvailability::Available,
         reason: None,
     });
+    capabilities.push(CapabilityEntry {
+        name: IAM_POLICY_ENTITIES_CAPABILITY.to_string(),
+        availability: CapabilityAvailability::Available,
+        reason: None,
+    });
 
     for (name, reason) in [
         (
@@ -2682,6 +2715,40 @@ impl OidcReadApi for AdminClient {
             Error::General("RustFS returned an invalid OIDC validation response".to_string())
         })?;
         Ok(response)
+    }
+}
+
+#[async_trait]
+impl IamReadApi for AdminClient {
+    async fn policy_entities(&self, query: &PolicyEntitiesQuery) -> Result<PolicyEntitiesResult> {
+        query.validate()?;
+
+        let mut parameters =
+            Vec::with_capacity(query.users.len() + query.groups.len() + query.policies.len());
+        parameters.extend(query.users.iter().map(|value| ("user", value.as_str())));
+        parameters.extend(query.groups.iter().map(|value| ("group", value.as_str())));
+        parameters.extend(
+            query
+                .policies
+                .iter()
+                .map(|value| ("policy", value.as_str())),
+        );
+        let query = (!parameters.is_empty()).then_some(parameters.as_slice());
+
+        let result: PolicyEntitiesResult = self
+            .request_bounded_json(
+                Method::GET,
+                "/idp/builtin/policy-entities",
+                query,
+                None,
+                BoundedJsonResponse {
+                    max_bytes: MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES,
+                    name: "IAM policy-entity response",
+                    error_mapper: Self::map_iam_policy_entities_error,
+                },
+            )
+            .await?;
+        result.normalize()
     }
 }
 
@@ -3769,8 +3836,11 @@ impl ReplicationDiffApi for AdminClient {
             "/replication/diff",
             Some(&query),
             None,
-            MAX_REPLICATION_DIFF_RESPONSE_BYTES,
-            "Replication diff response",
+            BoundedJsonResponse {
+                max_bytes: MAX_REPLICATION_DIFF_RESPONSE_BYTES,
+                name: "Replication diff response",
+                error_mapper: Self::map_replication_diff_error,
+            },
         )
         .await
     }
@@ -4184,6 +4254,10 @@ mod tests {
         assert_eq!(report.server_version.as_deref(), Some("1.0.0-beta.10"));
         assert_eq!(report.extensions.len(), 1);
         assert!(report.cluster.summary.is_some());
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == IAM_POLICY_ENTITIES_CAPABILITY
+                && capability.availability == CapabilityAvailability::Available
+        }));
         assert!(report.capabilities.iter().any(|capability| {
             capability.name == "runtime.userspace-profiling"
                 && capability.availability == CapabilityAvailability::Disabled
@@ -5043,6 +5117,104 @@ mod tests {
             let error = client.map_error(StatusCode::BAD_REQUEST, body);
             assert!(matches!(error, Error::Auth(_)));
         }
+    }
+
+    #[tokio::test]
+    async fn iam_policy_entities_uses_repeated_typed_filters_and_drops_unknown_secrets() {
+        let response = r#"{
+            "timestamp":"2026-07-24T08:00:00Z",
+            "userMappings":[{
+                "user":"alice",
+                "policies":["readonly"],
+                "memberOfMappings":[{"group":"ops","policies":["diagnostics"]}],
+                "secretKey":"server-secret"
+            }],
+            "groupMappings":[{"group":"ops","policies":["diagnostics"]}],
+            "policyMappings":[{"policy":"readonly","users":["alice"],"groups":[]}],
+            "sessionToken":"server-token"
+        }"#;
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let result = client
+            .policy_entities(&PolicyEntitiesQuery {
+                users: vec!["alice@example.com".to_string(), "bob".to_string()],
+                groups: vec!["ops/team".to_string()],
+                policies: vec!["read only".to_string()],
+            })
+            .await
+            .expect("policy entities request");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/idp/builtin/policy-entities?user=alice%40example.com&user=bob&group=ops%2Fteam&policy=read%20only"
+        );
+        assert!(request.body.is_empty());
+        assert_eq!(result.user_mappings[0].user, "alice");
+        let encoded = serde_json::to_string(&result).expect("serialize typed result");
+        assert!(!encoded.contains("server-secret"));
+        assert!(!encoded.contains("server-token"));
+        handle.join().expect("join policy entities server");
+    }
+
+    #[tokio::test]
+    async fn iam_policy_entities_maps_route_absence_and_permission_without_echoing_body() {
+        for (status, body, expected) in [
+            (
+                "404 Not Found",
+                r#"{"Code":"NoSuchRoute","Message":"access secret leaked"}"#,
+                "unsupported",
+            ),
+            (
+                "405 Method Not Allowed",
+                "access secret leaked",
+                "unsupported",
+            ),
+            ("501 Not Implemented", "access secret leaked", "unsupported"),
+            ("403 Forbidden", "access secret leaked", "auth"),
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server(status, body);
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .policy_entities(&PolicyEntitiesQuery::default())
+                .await
+                .expect_err("request must fail");
+
+            match expected {
+                "unsupported" => assert!(matches!(error, Error::UnsupportedFeature(_))),
+                "auth" => assert!(matches!(error, Error::Auth(_))),
+                _ => unreachable!(),
+            }
+            assert!(!error.to_string().contains("access secret leaked"));
+            handle.join().expect("join policy entities error server");
+        }
+    }
+
+    #[tokio::test]
+    async fn iam_policy_entities_rejects_malformed_and_oversized_responses() {
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", "{");
+        let client = admin_client_for_endpoint(&endpoint);
+        let malformed = client
+            .policy_entities(&PolicyEntitiesQuery::default())
+            .await
+            .expect_err("malformed JSON must fail");
+        assert!(matches!(malformed, Error::Json(_)));
+        handle.join().expect("join malformed response server");
+
+        let (endpoint, _receiver, handle) = start_admin_declared_length_server(
+            "200 OK",
+            MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES + 1,
+        );
+        let client = admin_client_for_endpoint(&endpoint);
+        let oversized = client
+            .policy_entities(&PolicyEntitiesQuery::default())
+            .await
+            .expect_err("oversized response must fail");
+        assert!(
+            matches!(oversized, Error::General(message) if message.contains("IAM policy-entity response exceeded"))
+        );
+        handle.join().expect("join oversized response server");
     }
 
     #[test]

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -37,7 +37,8 @@ rc admin decommission <start|cancel|clear> <ALIAS> <POOL> [OPTIONS]
 rc admin decommission status <ALIAS> [POOL] [OPTIONS]
 rc admin rebalance <start|status|stop> <ALIAS>
 rc admin user <ls|add|info|rm|enable|disable> ...
-rc admin policy <ls|create|info|rm|attach> ...
+rc admin policy <ls|create|info|rm|attach|entities> ...
+rc admin policy entities <ALIAS> [--user USER]... [--group GROUP]... [--policy POLICY]...
 rc admin group <ls|add|info|rm|enable|disable|add-members|rm-members> ...
 rc admin service-account <ls|create|info|rm> ...
 rc admin service <restart|stop|freeze|unfreeze> <ALIAS>
@@ -190,6 +191,19 @@ rc admin user add local analyst STRONG_PASSWORD
 rc admin policy attach local readonly --user analyst
 ```
 
+Inspect policy-to-entity mappings:
+
+```bash
+# List every policy with its directly attached users and groups.
+rc admin policy entities local
+
+# Inspect direct and inherited policies for selected users and groups.
+rc admin policy entities local --user analyst --group operations
+
+# Find the users and groups attached to selected policies.
+rc --json admin policy entities local --policy readonly --policy diagnostics
+```
+
 Create a service account with a policy file:
 
 ```bash
@@ -260,6 +274,26 @@ Missing observations are shown as `unavailable` in human output and `null` in
 JSON rather than being fabricated as zero.
 
 Permission failures return the authentication exit code. A missing observability route returns `unsupported_feature`, allowing automation to distinguish an older RustFS server from missing credentials. Malformed and oversized responses fail without emitting partial normalized records.
+
+## IAM Policy-Entity Inspection
+
+`rc admin policy entities` is a read-only view of the native RustFS
+`/rustfs/admin/v3/idp/builtin/policy-entities` route. With no filters it returns
+policy-to-user/group mappings. Repeated `--user`, `--group`, and `--policy`
+filters are URL encoded independently, so names containing spaces, slashes, or
+identity-provider characters are not split or concatenated.
+
+Before sending the IAM request, the CLI requires capability discovery to
+advertise `admin.iam.policy-entities` as available. Missing, unknown, disabled,
+stubbed, and version-gated states fail closed with the
+`unsupported_feature` exit code. Permission denial remains an authentication
+error. Responses are limited to 8 MiB.
+
+JSON output uses schema v3 with the `iam_policy_entities` family. It includes
+only the server timestamp, user mappings, inherited group mappings, group
+mappings, and policy mappings. Unknown response fields are discarded, and
+secret keys, session tokens, credentials, and raw server error bodies are never
+included in output.
 
 ## KMS Key Lifecycle Workflow
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -42,7 +42,8 @@
         "health_snapshot",
         "cluster_snapshot",
         "extension_catalog",
-        "oidc"
+        "oidc",
+        "iam_policy_entities"
       ]
     },
     "pagination": {
@@ -970,6 +971,66 @@
         }
       }
     },
+    "iamGroupPolicyMapping": {
+      "type": "object",
+      "required": ["group", "policies"],
+      "properties": {
+        "group": { "type": "string", "minLength": 1 },
+        "policies": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "iamUserPolicyMapping": {
+      "type": "object",
+      "required": ["user", "policies", "member_of_mappings"],
+      "properties": {
+        "user": { "type": "string", "minLength": 1 },
+        "policies": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "member_of_mappings": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/iamGroupPolicyMapping" }
+        }
+      }
+    },
+    "iamPolicyEntityMapping": {
+      "type": "object",
+      "required": ["policy", "users", "groups"],
+      "properties": {
+        "policy": { "type": "string", "minLength": 1 },
+        "users": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "groups": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "iamPolicyEntitiesData": {
+      "type": "object",
+      "required": ["timestamp", "user_mappings", "group_mappings", "policy_mappings"],
+      "properties": {
+        "timestamp": { "$ref": "#/definitions/timestamp" },
+        "user_mappings": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/iamUserPolicyMapping" }
+        },
+        "group_mappings": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/iamGroupPolicyMapping" }
+        },
+        "policy_mappings": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/iamPolicyEntityMapping" }
+        }
+      }
+    },
     "replicationDiffEntry": {
       "type": "object",
       "required": [
@@ -1245,6 +1306,17 @@
           "properties": {
             "type": { "const": "capabilities" },
             "data": { "$ref": "#/definitions/capabilitiesData" }
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        { "$ref": "#/definitions/successEnvelope" },
+        {
+          "properties": {
+            "type": { "const": "iam_policy_entities" },
+            "data": { "$ref": "#/definitions/iamPolicyEntitiesData" }
           }
         }
       ]


### PR DESCRIPTION
## Summary

- add `rc admin policy entities` for the implemented RustFS policy-entities route
- support repeatable user, group, and policy filters with direct and inherited mappings
- use typed, bounded, capability-gated responses and discard unknown secret-bearing fields
- add deterministic human and output-v3 contracts, documentation, and tests

## Validation

- targeted core, S3, CLI, binary integration, help-contract, and output-v3 tests pass
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --lib --bins --all-features -- -D warnings`
- targeted all-feature test clippy passes
- `git diff --check`

Closes rustfs/backlog#1488
Refs rustfs/backlog#1380

BREAKING: no