### PR TITLE
feat(admin): add safe OIDC provider mutations

### DIFF
--- a/crates/cli/src/commands/admin/idp.rs
+++ b/crates/cli/src/commands/admin/idp.rs
@@ -1,10 +1,17 @@
-//! Read-only RustFS identity-provider administration.
+//! RustFS identity-provider administration.
 
 use clap::{Args, Subcommand};
 use rc_core::admin::{
-    OidcProvider, OidcProviderList, OidcReadApi, OidcValidationRequest, OidcValidationResult,
+    OidcMutationApi, OidcMutationRequest, OidcProvider, OidcProviderList, OidcProviderSource,
+    OidcReadApi, OidcValidationRequest, OidcValidationResult,
 };
+use rc_core::{Error, Result};
 use serde::Serialize;
+use serde_json::Value;
+use std::fs::File;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use zeroize::Zeroizing;
 
 use super::{emit_observability_error, get_admin_client};
 use crate::exit_code::ExitCode;
@@ -27,6 +34,18 @@ pub enum OpenidCommands {
 
     /// Validate OIDC discovery without saving configuration
     Validate(Box<OidcValidateArgs>),
+
+    /// Create or replace an OIDC provider while preserving omitted fields
+    Set(Box<OidcSetArgs>),
+
+    /// Update an existing OIDC provider while preserving omitted fields
+    Update(Box<OidcSetArgs>),
+
+    /// Enable an existing OIDC provider
+    Enable(OidcToggleArgs),
+
+    /// Disable an existing OIDC provider
+    Disable(OidcToggleArgs),
 }
 
 #[derive(Args, Debug)]
@@ -113,6 +132,128 @@ pub struct OidcValidateArgs {
     pub username_claim: String,
 }
 
+#[derive(Args, Debug)]
+pub struct OidcSetArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Exact OIDC provider ID
+    pub provider_id: String,
+
+    /// Provider issuer or discovery base URL
+    #[arg(long)]
+    pub config_url: Option<String>,
+
+    /// OIDC client identifier
+    #[arg(long)]
+    pub client_id: Option<String>,
+
+    /// Human-readable provider name
+    #[arg(long)]
+    pub display_name: Option<String>,
+
+    /// Expected issuer URL
+    #[arg(long, conflicts_with = "clear_issuer")]
+    pub issuer: Option<String>,
+
+    /// Remove an existing explicit issuer
+    #[arg(long)]
+    pub clear_issuer: bool,
+
+    /// Requested scope; may be repeated and must include openid
+    #[arg(long = "scope")]
+    pub scopes: Vec<String>,
+
+    /// Additional trusted token audience; may be repeated
+    #[arg(long = "other-audience")]
+    pub other_audiences: Vec<String>,
+
+    /// Replace all additional trusted token audiences, including with an empty list
+    #[arg(long)]
+    pub replace_other_audiences: bool,
+
+    /// Explicit callback URI
+    #[arg(long, conflicts_with = "clear_redirect_uri")]
+    pub redirect_uri: Option<String>,
+
+    /// Remove an existing explicit callback URI
+    #[arg(long)]
+    pub clear_redirect_uri: bool,
+
+    /// Require the explicit callback URI instead of a server-derived URI
+    #[arg(long, conflicts_with = "dynamic_redirect")]
+    pub static_redirect: bool,
+
+    /// Use a server-derived callback URI
+    #[arg(long)]
+    pub dynamic_redirect: bool,
+
+    /// Policy claim name
+    #[arg(long)]
+    pub claim_name: Option<String>,
+
+    /// Prefix applied to policy claims
+    #[arg(long)]
+    pub claim_prefix: Option<String>,
+
+    /// Fixed fallback policy
+    #[arg(long)]
+    pub role_policy: Option<String>,
+
+    /// Group claim name
+    #[arg(long)]
+    pub groups_claim: Option<String>,
+
+    /// Roles claim name
+    #[arg(long)]
+    pub roles_claim: Option<String>,
+
+    /// Email claim name
+    #[arg(long)]
+    pub email_claim: Option<String>,
+
+    /// Username claim name
+    #[arg(long)]
+    pub username_claim: Option<String>,
+
+    /// Hide this provider from the login UI
+    #[arg(long, conflicts_with = "show_in_ui")]
+    pub hide_from_ui: bool,
+
+    /// Show this provider in the login UI
+    #[arg(long)]
+    pub show_in_ui: bool,
+
+    /// Read a replacement client secret from standard input
+    #[arg(long, conflicts_with = "client_secret_file")]
+    pub client_secret_stdin: bool,
+
+    /// Read a replacement client secret from a protected regular file
+    #[arg(long, value_name = "PATH")]
+    pub client_secret_file: Option<PathBuf>,
+
+    /// Acknowledge that the currently persisted client secret will be replaced
+    #[arg(long)]
+    pub replace_client_secret: bool,
+
+    /// Validate and display the redacted change plan without saving
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct OidcToggleArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Exact OIDC provider ID
+    pub provider_id: String,
+
+    /// Validate and display the change without saving
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
 #[derive(Debug, Serialize)]
 struct OidcSuccessOutput<T> {
     schema_version: u8,
@@ -143,12 +284,66 @@ struct OidcValidateData<'a> {
     result: &'a OidcValidationResult,
 }
 
+#[derive(Debug, Serialize)]
+struct OidcChange {
+    field: &'static str,
+    before: Value,
+    after: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct OidcMutationData<'a> {
+    operation: &'static str,
+    provider_id: &'a str,
+    created: bool,
+    dry_run: bool,
+    restart_required: bool,
+    changes: &'a [OidcChange],
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MutationMode {
+    Set,
+    Update,
+    Enable,
+    Disable,
+}
+
+impl MutationMode {
+    const fn operation(self) -> &'static str {
+        match self {
+            Self::Set => "set",
+            Self::Update => "update",
+            Self::Enable => "enable",
+            Self::Disable => "disable",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ClientSecretSource {
+    Stdin,
+    File(PathBuf),
+}
+
 pub async fn execute(command: IdpCommands, formatter: &Formatter) -> ExitCode {
     match command {
         IdpCommands::Openid(command) => match command {
             OpenidCommands::List(args) => execute_list(args, formatter).await,
             OpenidCommands::Get(args) => execute_get(args, formatter).await,
             OpenidCommands::Validate(args) => execute_validate(*args, formatter).await,
+            OpenidCommands::Set(args) => {
+                execute_mutation(*args, MutationMode::Set, formatter).await
+            }
+            OpenidCommands::Update(args) => {
+                execute_mutation(*args, MutationMode::Update, formatter).await
+            }
+            OpenidCommands::Enable(args) => {
+                execute_toggle(args, MutationMode::Enable, formatter).await
+            }
+            OpenidCommands::Disable(args) => {
+                execute_toggle(args, MutationMode::Disable, formatter).await
+            }
         },
     }
 }
@@ -256,6 +451,485 @@ async fn execute_validate(args: OidcValidateArgs, formatter: &Formatter) -> Exit
             &error,
             formatter,
         ),
+    }
+}
+
+async fn execute_mutation(
+    args: OidcSetArgs,
+    mode: MutationMode,
+    formatter: &Formatter,
+) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    match prepare_and_apply_mutation(&client, args, mode, formatter).await {
+        Ok(()) => ExitCode::Success,
+        Err(error) => emit_observability_error(
+            "oidc",
+            "admin.oidc-config-write",
+            "Failed to update OIDC provider",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn execute_toggle(
+    args: OidcToggleArgs,
+    mode: MutationMode,
+    formatter: &Formatter,
+) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    match prepare_and_apply_toggle(&client, args, mode, formatter).await {
+        Ok(()) => ExitCode::Success,
+        Err(error) => emit_observability_error(
+            "oidc",
+            "admin.oidc-config-write",
+            "Failed to update OIDC provider state",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn prepare_and_apply_mutation(
+    client: &rc_s3::AdminClient,
+    args: OidcSetArgs,
+    mode: MutationMode,
+    formatter: &Formatter,
+) -> Result<()> {
+    let secret_source = resolve_secret_source(&args)?;
+    let list = client.oidc_list_providers().await?;
+    let current = list
+        .providers
+        .iter()
+        .find(|provider| provider.provider_id == args.provider_id);
+    if let Some(provider) = current {
+        ensure_editable(provider)?;
+    } else if matches!(mode, MutationMode::Update) {
+        return Err(Error::NotFound(format!(
+            "OIDC provider '{}' was not found",
+            args.provider_id
+        )));
+    }
+
+    let mut request = match current {
+        Some(provider) => OidcMutationRequest::from_provider(provider),
+        None => OidcMutationRequest::new(
+            args.provider_id.clone(),
+            args.config_url.clone().ok_or_else(|| {
+                Error::InvalidPath("--config-url is required when creating a provider".to_string())
+            })?,
+            args.client_id.clone().ok_or_else(|| {
+                Error::InvalidPath("--client-id is required when creating a provider".to_string())
+            })?,
+        ),
+    };
+    apply_patch(&mut request, &args);
+    request.validate()?;
+
+    let changes = mutation_diff(
+        current,
+        &request,
+        secret_source.is_some(),
+        args.replace_client_secret,
+    );
+    client
+        .oidc_validate(OidcValidationRequest::from_mutation(&request))
+        .await?;
+    if args.dry_run || changes.is_empty() {
+        print_mutation(
+            mode,
+            &request.provider_id,
+            current.is_none(),
+            args.dry_run,
+            !changes.is_empty(),
+            &changes,
+            formatter,
+        );
+        return Ok(());
+    }
+
+    if let Some(source) = secret_source {
+        request.client_secret = Some(read_client_secret(source)?.to_string());
+    }
+    let result = client.oidc_upsert_provider(request).await?;
+    print_mutation(
+        mode,
+        &args.provider_id,
+        current.is_none(),
+        false,
+        result.restart_required,
+        &changes,
+        formatter,
+    );
+    Ok(())
+}
+
+async fn prepare_and_apply_toggle(
+    client: &rc_s3::AdminClient,
+    args: OidcToggleArgs,
+    mode: MutationMode,
+    formatter: &Formatter,
+) -> Result<()> {
+    let provider = client.oidc_get_provider(&args.provider_id).await?;
+    ensure_editable(&provider)?;
+    let mut request = OidcMutationRequest::from_provider(&provider);
+    request.enabled = matches!(mode, MutationMode::Enable);
+    request.validate()?;
+    let changes = mutation_diff(Some(&provider), &request, false, false);
+    client
+        .oidc_validate(OidcValidationRequest::from_mutation(&request))
+        .await?;
+    if args.dry_run || changes.is_empty() {
+        print_mutation(
+            mode,
+            &args.provider_id,
+            false,
+            args.dry_run,
+            !changes.is_empty(),
+            &changes,
+            formatter,
+        );
+        return Ok(());
+    }
+    let result = client.oidc_upsert_provider(request).await?;
+    print_mutation(
+        mode,
+        &args.provider_id,
+        false,
+        false,
+        result.restart_required,
+        &changes,
+        formatter,
+    );
+    Ok(())
+}
+
+fn ensure_editable(provider: &OidcProvider) -> Result<()> {
+    if provider.source == OidcProviderSource::Env || !provider.editable {
+        return Err(Error::Conflict(format!(
+            "OIDC provider '{}' is managed by the environment and cannot be edited",
+            provider.provider_id
+        )));
+    }
+    Ok(())
+}
+
+fn apply_patch(request: &mut OidcMutationRequest, args: &OidcSetArgs) {
+    if let Some(value) = &args.config_url {
+        request.config_url.clone_from(value);
+    }
+    if let Some(value) = &args.client_id {
+        request.client_id.clone_from(value);
+    }
+    if let Some(value) = &args.display_name {
+        request.display_name.clone_from(value);
+    }
+    if args.clear_issuer {
+        request.issuer = None;
+    } else if let Some(value) = &args.issuer {
+        request.issuer = Some(value.clone());
+    }
+    if !args.scopes.is_empty() {
+        request.scopes.clone_from(&args.scopes);
+    }
+    if args.replace_other_audiences || !args.other_audiences.is_empty() {
+        request.other_audiences.clone_from(&args.other_audiences);
+    }
+    if args.clear_redirect_uri {
+        request.redirect_uri = None;
+    } else if let Some(value) = &args.redirect_uri {
+        request.redirect_uri = Some(value.clone());
+    }
+    if args.static_redirect {
+        request.redirect_uri_dynamic = false;
+    } else if args.dynamic_redirect {
+        request.redirect_uri_dynamic = true;
+    }
+    for (target, value) in [
+        (&mut request.claim_name, &args.claim_name),
+        (&mut request.claim_prefix, &args.claim_prefix),
+        (&mut request.role_policy, &args.role_policy),
+        (&mut request.groups_claim, &args.groups_claim),
+        (&mut request.roles_claim, &args.roles_claim),
+        (&mut request.email_claim, &args.email_claim),
+        (&mut request.username_claim, &args.username_claim),
+    ] {
+        if let Some(value) = value {
+            target.clone_from(value);
+        }
+    }
+    if args.hide_from_ui {
+        request.hide_from_ui = true;
+    } else if args.show_in_ui {
+        request.hide_from_ui = false;
+    }
+}
+
+fn resolve_secret_source(args: &OidcSetArgs) -> Result<Option<ClientSecretSource>> {
+    let source = if args.client_secret_stdin {
+        Some(ClientSecretSource::Stdin)
+    } else {
+        args.client_secret_file
+            .clone()
+            .map(ClientSecretSource::File)
+    };
+    match (source.is_some(), args.replace_client_secret) {
+        (true, false) => Err(Error::InvalidPath(
+            "--replace-client-secret is required with a client secret input".to_string(),
+        )),
+        (false, true) => Err(Error::InvalidPath(
+            "--replace-client-secret requires --client-secret-stdin or --client-secret-file"
+                .to_string(),
+        )),
+        _ => Ok(source),
+    }
+}
+
+const MAX_OIDC_SECRET_BYTES: u64 = 64 * 1024;
+
+fn read_client_secret(source: ClientSecretSource) -> Result<Zeroizing<String>> {
+    match source {
+        ClientSecretSource::Stdin => {
+            let stdin = std::io::stdin();
+            read_secret_text(stdin.lock())
+        }
+        ClientSecretSource::File(path) => read_protected_secret_file(&path),
+    }
+}
+
+fn read_protected_secret_file(path: &Path) -> Result<Zeroizing<String>> {
+    let path_metadata = std::fs::symlink_metadata(path)
+        .map_err(|_| Error::InvalidPath("Failed to inspect OIDC secret file".to_string()))?;
+    if path_metadata.file_type().is_symlink() || !path_metadata.is_file() {
+        return Err(Error::InvalidPath(
+            "OIDC secret input must be a regular file, not a symlink".to_string(),
+        ));
+    }
+    let file = File::open(path)
+        .map_err(|_| Error::InvalidPath("Failed to open OIDC secret file".to_string()))?;
+    let file_metadata = file
+        .metadata()
+        .map_err(|_| Error::InvalidPath("Failed to inspect opened OIDC secret file".to_string()))?;
+    if !file_metadata.is_file() {
+        return Err(Error::InvalidPath(
+            "OIDC secret input must remain a regular file while opening".to_string(),
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{MetadataExt as _, PermissionsExt as _};
+        if path_metadata.dev() != file_metadata.dev() || path_metadata.ino() != file_metadata.ino()
+        {
+            return Err(Error::InvalidPath(
+                "OIDC secret file changed while being opened".to_string(),
+            ));
+        }
+        if file_metadata.permissions().mode() & 0o077 != 0 {
+            return Err(Error::InvalidPath(
+                "OIDC secret file cannot grant group or other permissions".to_string(),
+            ));
+        }
+    }
+    read_secret_text(file)
+}
+
+fn read_secret_text(reader: impl Read) -> Result<Zeroizing<String>> {
+    let mut bytes = Zeroizing::new(Vec::new());
+    reader
+        .take(MAX_OIDC_SECRET_BYTES + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|_| Error::InvalidPath("Failed to read OIDC client secret".to_string()))?;
+    if bytes.len() as u64 > MAX_OIDC_SECRET_BYTES {
+        return Err(Error::InvalidPath(format!(
+            "OIDC client secret exceeds the {MAX_OIDC_SECRET_BYTES} byte limit"
+        )));
+    }
+    while matches!(bytes.last(), Some(b'\n' | b'\r')) {
+        bytes.pop();
+    }
+    let value = std::str::from_utf8(&bytes)
+        .map_err(|_| Error::InvalidPath("OIDC client secret must be UTF-8".to_string()))?;
+    if value.is_empty() || value.contains(['\n', '\r', '\0']) {
+        return Err(Error::InvalidPath(
+            "OIDC client secret must contain one non-empty text line".to_string(),
+        ));
+    }
+    Ok(Zeroizing::new(value.to_string()))
+}
+
+fn mutation_diff(
+    current: Option<&OidcProvider>,
+    requested: &OidcMutationRequest,
+    replaces_secret: bool,
+    replacement_acknowledged: bool,
+) -> Vec<OidcChange> {
+    let mut changes = Vec::new();
+    macro_rules! changed {
+        ($field:literal, $before:expr, $after:expr) => {{
+            let before = serde_json::to_value($before).unwrap_or(Value::Null);
+            let after = serde_json::to_value($after).unwrap_or(Value::Null);
+            if before != after {
+                changes.push(OidcChange {
+                    field: $field,
+                    before,
+                    after,
+                });
+            }
+        }};
+    }
+    changed!(
+        "enabled",
+        current.map(|value| value.enabled),
+        requested.enabled
+    );
+    changed!(
+        "display_name",
+        current.map(|value| value.display_name.as_str()),
+        requested.display_name.as_str()
+    );
+    changed!(
+        "config_url",
+        current.map(|value| value.config_url.as_str()),
+        requested.config_url.as_str()
+    );
+    changed!(
+        "issuer",
+        current.and_then(|value| value.issuer.as_deref()),
+        requested.issuer.as_deref()
+    );
+    changed!(
+        "client_id",
+        current.map(|value| value.client_id.as_str()),
+        requested.client_id.as_str()
+    );
+    let previous_secret = if current.is_some_and(|value| value.client_secret_configured) {
+        "[configured]"
+    } else {
+        "[not configured]"
+    };
+    if replaces_secret && replacement_acknowledged {
+        changes.push(OidcChange {
+            field: "client_secret",
+            before: Value::String(previous_secret.to_string()),
+            after: Value::String("[replaced]".to_string()),
+        });
+    }
+    changed!(
+        "scopes",
+        current.map(|value| value.scopes.as_slice()),
+        requested.scopes.as_slice()
+    );
+    changed!(
+        "other_audiences",
+        current.map(|value| value.other_audiences.as_slice()),
+        requested.other_audiences.as_slice()
+    );
+    changed!(
+        "redirect_uri",
+        current.and_then(|value| value.redirect_uri.as_deref()),
+        requested.redirect_uri.as_deref()
+    );
+    changed!(
+        "redirect_uri_dynamic",
+        current.map(|value| value.redirect_uri_dynamic),
+        requested.redirect_uri_dynamic
+    );
+    changed!(
+        "claim_name",
+        current.map(|value| value.claim_name.as_str()),
+        requested.claim_name.as_str()
+    );
+    changed!(
+        "claim_prefix",
+        current.map(|value| value.claim_prefix.as_str()),
+        requested.claim_prefix.as_str()
+    );
+    changed!(
+        "role_policy",
+        current.map(|value| value.role_policy.as_str()),
+        requested.role_policy.as_str()
+    );
+    changed!(
+        "groups_claim",
+        current.map(|value| value.groups_claim.as_str()),
+        requested.groups_claim.as_str()
+    );
+    changed!(
+        "roles_claim",
+        current.map(|value| value.roles_claim.as_str()),
+        requested.roles_claim.as_str()
+    );
+    changed!(
+        "email_claim",
+        current.map(|value| value.email_claim.as_str()),
+        requested.email_claim.as_str()
+    );
+    changed!(
+        "username_claim",
+        current.map(|value| value.username_claim.as_str()),
+        requested.username_claim.as_str()
+    );
+    changed!(
+        "hide_from_ui",
+        current.map(|value| value.hide_from_ui),
+        requested.hide_from_ui
+    );
+    changes
+}
+
+fn print_mutation(
+    mode: MutationMode,
+    provider_id: &str,
+    created: bool,
+    dry_run: bool,
+    restart_required: bool,
+    changes: &[OidcChange],
+    formatter: &Formatter,
+) {
+    if formatter.is_json() {
+        formatter.json(&OidcSuccessOutput {
+            schema_version: 3,
+            output_type: "oidc",
+            status: "success",
+            data: OidcMutationData {
+                operation: mode.operation(),
+                provider_id,
+                created,
+                dry_run,
+                restart_required,
+                changes,
+            },
+        });
+        return;
+    }
+    formatter.println(&formatter.style_name("OIDC Provider Change"));
+    formatter.println("");
+    formatter.println(&format!("Operation:        {}", mode.operation()));
+    formatter.println(&format!(
+        "Provider:         {}",
+        safe(provider_id, formatter)
+    ));
+    formatter.println(&format!("Created:          {created}"));
+    formatter.println(&format!("Dry run:          {dry_run}"));
+    formatter.println(&format!("Restart required: {restart_required}"));
+    formatter.println("Changes:");
+    if changes.is_empty() {
+        formatter.println("  (none)");
+    } else {
+        for change in changes {
+            formatter.println(&format!(
+                "  {}: {} -> {}",
+                change.field,
+                safe(&change.before.to_string(), formatter),
+                safe(&change.after.to_string(), formatter)
+            ));
+        }
     }
 }
 

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -63,7 +63,7 @@ pub enum AdminCommands {
     #[command(subcommand)]
     Ilm(ilm::IlmCommands),
 
-    /// Inspect identity-provider configuration
+    /// Inspect, validate, and manage identity-provider configuration
     #[command(subcommand)]
     Idp(idp::IdpCommands),
 

--- a/crates/cli/tests/admin_oidc.rs
+++ b/crates/cli/tests/admin_oidc.rs
@@ -3,10 +3,12 @@
 mod admin_support;
 
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::time::Duration;
 
-use admin_support::{rc_binary, rc_host_alias, start_admin_response_test_server};
+use admin_support::{
+    rc_binary, rc_host_alias, start_admin_response_test_server, start_admin_sequence_test_server,
+};
 use jsonschema::Validator;
 use serde_json::Value;
 
@@ -23,6 +25,43 @@ const PROVIDERS: &str = r#"{
     "client_secret_configured":true,
     "scopes":["openid","profile","email"],
     "other_audiences":["rustfs"],
+    "redirect_uri":null,
+    "redirect_uri_dynamic":true,
+    "claim_name":"policy",
+    "claim_prefix":"",
+    "role_policy":"",
+    "groups_claim":"groups",
+    "roles_claim":"roles",
+    "email_claim":"email",
+    "username_claim":"preferred_username",
+    "hide_from_ui":false
+  }],
+  "restart_required":false
+}"#;
+
+const EMPTY_PROVIDERS: &str = r#"{"providers":[],"restart_required":false}"#;
+const VALIDATION_OK: &str = r#"{
+  "valid":true,
+  "message":"OIDC configuration is valid",
+  "issuer":"https://idp.example",
+  "authorization_endpoint":"https://idp.example/authorize",
+  "token_endpoint":"https://idp.example/token"
+}"#;
+const MUTATION_OK: &str =
+    r#"{"success":true,"message":"OIDC provider saved","restart_required":true}"#;
+const ENV_PROVIDER: &str = r#"{
+  "providers":[{
+    "provider_id":"corp",
+    "source":"env",
+    "editable":false,
+    "enabled":true,
+    "display_name":"Corporate",
+    "config_url":"https://idp.example",
+    "issuer":"https://idp.example",
+    "client_id":"rustfs-console",
+    "client_secret_configured":true,
+    "scopes":["openid"],
+    "other_audiences":[],
     "redirect_uri":null,
     "redirect_uri_dynamic":true,
     "claim_name":"policy",
@@ -230,6 +269,372 @@ fn oidc_validate_rejects_invalid_urls_before_network_io() {
     assert_eq!(output.status.code(), Some(2));
     assert!(
         String::from_utf8_lossy(&output.stderr).contains("absolute HTTP URL"),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn oidc_set_creates_a_complete_provider_after_preflight() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", EMPTY_PROVIDERS),
+        ("200 OK", VALIDATION_OK),
+        ("200 OK", MUTATION_OK),
+    ]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "idp",
+            "openid",
+            "set",
+            "myalias",
+            "corp",
+            "--config-url",
+            "https://idp.example",
+            "--client-id",
+            "rustfs-console",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(value["data"]["operation"], "set");
+    assert_eq!(value["data"]["created"], true);
+    assert_eq!(value["data"]["restart_required"], true);
+    assert_valid_v3(&value);
+
+    let get = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("GET request");
+    let validate = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("validate request");
+    let put = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("PUT request");
+    assert_eq!(get.method, "GET");
+    assert_eq!(validate.method, "POST");
+    assert_eq!(validate.target, "/rustfs/admin/v3/oidc/validate");
+    assert_eq!(put.method, "PUT");
+    assert_eq!(put.target, "/rustfs/admin/v3/oidc/config/corp");
+    let body: Value = serde_json::from_slice(&put.body).expect("PUT JSON");
+    assert_eq!(body["config_url"], "https://idp.example");
+    assert_eq!(body["client_id"], "rustfs-console");
+    assert_eq!(body["scopes"][0], "openid");
+    assert!(body.get("provider_id").is_none());
+    assert!(body.get("client_secret").is_none());
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_set_preserves_omitted_fields_and_secret() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", PROVIDERS),
+        ("200 OK", VALIDATION_OK),
+        ("200 OK", MUTATION_OK),
+    ]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "idp",
+            "openid",
+            "update",
+            "myalias",
+            "corp",
+            "--display-name",
+            "Updated Corporate",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert!(output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(value["data"]["operation"], "update");
+    assert_eq!(value["data"]["changes"].as_array().map(Vec::len), Some(1));
+
+    let _get = receiver.recv().expect("GET");
+    let _validate = receiver.recv().expect("validate");
+    let put = receiver.recv().expect("PUT");
+    let body: Value = serde_json::from_slice(&put.body).expect("PUT JSON");
+    assert_eq!(body["display_name"], "Updated Corporate");
+    assert_eq!(body["config_url"], "https://idp.example");
+    assert_eq!(body["issuer"], "https://idp.example");
+    assert_eq!(body["other_audiences"][0], "rustfs");
+    assert!(body.get("client_secret").is_none());
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_secret_file_replacement_is_acknowledged_and_redacted() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let secret_file = config_dir.path().join("oidc-secret");
+    let secret = format!("generated-secret-{}", std::process::id());
+    std::fs::write(&secret_file, format!("{secret}\n")).expect("write secret file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&secret_file, std::fs::Permissions::from_mode(0o600))
+            .expect("protect secret file");
+    }
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", PROVIDERS),
+        ("200 OK", VALIDATION_OK),
+        ("200 OK", MUTATION_OK),
+    ]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "idp",
+            "openid",
+            "set",
+            "myalias",
+            "corp",
+            "--client-secret-file",
+            secret_file.to_str().expect("UTF-8 path"),
+            "--replace-client-secret",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert!(output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains(&secret));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(&secret));
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(
+        value["data"]["changes"]
+            .as_array()
+            .and_then(|changes| changes
+                .iter()
+                .find(|change| change["field"] == "client_secret"))
+            .map(|change| &change["after"]),
+        Some(&Value::String("[replaced]".to_string()))
+    );
+    let _get = receiver.recv().expect("GET");
+    let validate = receiver.recv().expect("validate");
+    assert!(!String::from_utf8_lossy(&validate.body).contains(&secret));
+    assert!(
+        serde_json::from_slice::<Value>(&validate.body)
+            .expect("validate JSON")
+            .get("client_secret")
+            .is_none()
+    );
+    let put = receiver.recv().expect("PUT");
+    let body: Value = serde_json::from_slice(&put.body).expect("PUT JSON");
+    assert_eq!(body["client_secret"], secret);
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_secret_can_be_replaced_from_stdin_without_argv_exposure() {
+    use std::io::Write as _;
+
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let secret = format!("stdin-generated-secret-{}", std::process::id());
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", PROVIDERS),
+        ("200 OK", VALIDATION_OK),
+        ("200 OK", MUTATION_OK),
+    ]);
+    let mut child = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "idp",
+            "openid",
+            "set",
+            "myalias",
+            "corp",
+            "--client-secret-stdin",
+            "--replace-client-secret",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn rc");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(format!("{secret}\n").as_bytes())
+        .expect("write client secret");
+    let output = child.wait_with_output().expect("wait for rc");
+    assert!(output.status.success());
+    assert!(!String::from_utf8_lossy(&output.stdout).contains(&secret));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(&secret));
+    let _get = receiver.recv().expect("GET");
+    let validate = receiver.recv().expect("validate");
+    assert!(!String::from_utf8_lossy(&validate.body).contains(&secret));
+    let put = receiver.recv().expect("PUT");
+    assert_eq!(
+        serde_json::from_slice::<Value>(&put.body).expect("PUT JSON")["client_secret"],
+        secret
+    );
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_dry_run_validates_but_never_puts() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", PROVIDERS), ("200 OK", VALIDATION_OK)]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "idp",
+            "openid",
+            "disable",
+            "myalias",
+            "corp",
+            "--dry-run",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert!(output.status.success());
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(value["data"]["operation"], "disable");
+    assert_eq!(value["data"]["dry_run"], true);
+    assert_eq!(receiver.recv().expect("GET").method, "GET");
+    assert_eq!(receiver.recv().expect("validate").method, "POST");
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_disable_preserves_unrelated_fields_in_put() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", PROVIDERS),
+        ("200 OK", VALIDATION_OK),
+        ("200 OK", MUTATION_OK),
+    ]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "disable", "myalias", "corp",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert!(output.status.success());
+    let _get = receiver.recv().expect("GET");
+    let _validate = receiver.recv().expect("validate");
+    let put = receiver.recv().expect("PUT");
+    let body: Value = serde_json::from_slice(&put.body).expect("PUT JSON");
+    assert_eq!(body["enabled"], false);
+    assert_eq!(body["display_name"], "Corporate");
+    assert_eq!(body["client_id"], "rustfs-console");
+    assert!(body.get("client_secret").is_none());
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_environment_provider_fails_before_validation_or_mutation() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", ENV_PROVIDER)]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "disable", "myalias", "corp",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert_eq!(output.status.code(), Some(6));
+    let value: Value = serde_json::from_slice(&output.stderr).expect("JSON stderr");
+    assert_eq!(value["error"]["type"], "conflict");
+    assert_eq!(receiver.recv().expect("GET").method, "GET");
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_validation_and_mutation_failures_have_distinct_classes() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", PROVIDERS),
+        ("400 Bad Request", r#"{"message":"issuer unavailable"}"#),
+    ]);
+    let validation_failure = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "disable", "myalias", "corp",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert_eq!(validation_failure.status.code(), Some(1));
+    let error: Value =
+        serde_json::from_slice(&validation_failure.stderr).expect("validation error JSON");
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.ends_with("OIDC issuer validation failed"))
+    );
+    assert!(!String::from_utf8_lossy(&validation_failure.stderr).contains("issuer unavailable"));
+    handle.join().expect("validation server");
+
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", PROVIDERS),
+        ("200 OK", VALIDATION_OK),
+        ("409 Conflict", r#"{"message":"changed"}"#),
+    ]);
+    let conflict = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "disable", "myalias", "corp",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+    assert_eq!(conflict.status.code(), Some(6));
+    let error: Value = serde_json::from_slice(&conflict.stderr).expect("conflict JSON");
+    assert_eq!(error["error"]["type"], "conflict");
+    assert!(!String::from_utf8_lossy(&conflict.stderr).contains("\"changed\""));
+    handle.join().expect("conflict server");
+}
+
+#[test]
+fn oidc_secret_input_requires_explicit_replacement_acknowledgement() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "idp",
+            "openid",
+            "set",
+            "myalias",
+            "corp",
+            "--client-secret-stdin",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_myalias",
+            "http://ACCESS_KEY:SECRET_KEY@127.0.0.1:1",
+        )
+        .output()
+        .expect("run rc");
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("--replace-client-secret"),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -688,7 +688,9 @@ fn nested_subcommand_help_contract() {
         HelpCase {
             args: &["admin", "idp", "openid"],
             usage: "Usage: rc admin idp openid [OPTIONS] <COMMAND>",
-            expected_tokens: &["list", "get", "validate"],
+            expected_tokens: &[
+                "list", "get", "validate", "set", "update", "enable", "disable",
+            ],
         },
         HelpCase {
             args: &["admin", "idp", "openid", "get"],
@@ -707,6 +709,28 @@ fn nested_subcommand_help_contract() {
                 "--redirect-uri",
                 "--static-redirect",
             ],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid", "set"],
+            usage: "Usage: rc admin idp openid set [OPTIONS] <ALIAS> <PROVIDER_ID>",
+            expected_tokens: &[
+                "--config-url",
+                "--client-id",
+                "--client-secret-stdin",
+                "--client-secret-file",
+                "--replace-client-secret",
+                "--dry-run",
+            ],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid", "update"],
+            usage: "Usage: rc admin idp openid update [OPTIONS] <ALIAS> <PROVIDER_ID>",
+            expected_tokens: &["--display-name", "--clear-issuer", "--dry-run"],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid", "enable"],
+            usage: "Usage: rc admin idp openid enable [OPTIONS] <ALIAS> <PROVIDER_ID>",
+            expected_tokens: &["--dry-run"],
         },
         HelpCase {
             args: &["admin", "metrics"],

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -72,8 +72,9 @@ pub use observability::{
     StorageDiskMetrics, StorageInfo,
 };
 pub use oidc::{
-    MAX_OIDC_RESPONSE_BYTES, OidcProvider, OidcProviderList, OidcProviderSource, OidcReadApi,
-    OidcValidationRequest, OidcValidationResult,
+    MAX_OIDC_RESPONSE_BYTES, OidcMutationApi, OidcMutationRequest, OidcMutationResult,
+    OidcProvider, OidcProviderList, OidcProviderSource, OidcReadApi, OidcValidationRequest,
+    OidcValidationResult,
 };
 pub use replication::{
     MAX_REPLICATION_DIFF_RESPONSE_BYTES, ReplicationDiff, ReplicationDiffApi, ReplicationDiffEntry,

--- a/crates/core/src/admin/oidc.rs
+++ b/crates/core/src/admin/oidc.rs
@@ -1,7 +1,8 @@
-//! Typed, secret-free contracts for RustFS OIDC inspection and validation.
+//! Typed contracts for RustFS OIDC administration.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroize;
 
 use crate::{Error, Result};
 
@@ -146,6 +147,30 @@ impl OidcValidationRequest {
         }
     }
 
+    /// Build a secret-free validation request from a complete mutation request.
+    pub fn from_mutation(request: &OidcMutationRequest) -> Self {
+        Self {
+            provider_id: request.provider_id.clone(),
+            enabled: request.enabled,
+            display_name: request.display_name.clone(),
+            config_url: request.config_url.clone(),
+            issuer: request.issuer.clone(),
+            client_id: request.client_id.clone(),
+            scopes: request.scopes.clone(),
+            other_audiences: request.other_audiences.clone(),
+            redirect_uri: request.redirect_uri.clone(),
+            redirect_uri_dynamic: request.redirect_uri_dynamic,
+            claim_name: request.claim_name.clone(),
+            claim_prefix: request.claim_prefix.clone(),
+            role_policy: request.role_policy.clone(),
+            groups_claim: request.groups_claim.clone(),
+            roles_claim: request.roles_claim.clone(),
+            email_claim: request.email_claim.clone(),
+            username_claim: request.username_claim.clone(),
+            hide_from_ui: request.hide_from_ui,
+        }
+    }
+
     pub fn validate(&self) -> Result<()> {
         validate_provider_id(&self.provider_id)?;
         validate_http_url(&self.config_url, "config_url")?;
@@ -213,11 +238,185 @@ impl OidcValidationResult {
     }
 }
 
+/// Complete provider document accepted by RustFS' OIDC upsert endpoint.
+///
+/// The server treats an omitted `client_secret` as "preserve the currently persisted secret".
+/// Debug output is implemented manually so accidental diagnostics cannot expose a replacement.
+#[derive(Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OidcMutationRequest {
+    #[serde(skip)]
+    pub provider_id: String,
+    pub enabled: bool,
+    pub display_name: String,
+    pub config_url: String,
+    pub issuer: Option<String>,
+    pub client_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<String>,
+    pub scopes: Vec<String>,
+    pub other_audiences: Vec<String>,
+    pub redirect_uri: Option<String>,
+    pub redirect_uri_dynamic: bool,
+    pub claim_name: String,
+    pub claim_prefix: String,
+    pub role_policy: String,
+    pub groups_claim: String,
+    pub roles_claim: String,
+    pub email_claim: String,
+    pub username_claim: String,
+    pub hide_from_ui: bool,
+}
+
+impl std::fmt::Debug for OidcMutationRequest {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OidcMutationRequest")
+            .field("provider_id", &self.provider_id)
+            .field("enabled", &self.enabled)
+            .field("display_name", &self.display_name)
+            .field("config_url", &self.config_url)
+            .field("issuer", &self.issuer)
+            .field("client_id", &self.client_id)
+            .field(
+                "client_secret",
+                &self.client_secret.as_ref().map(|_| "[REDACTED]"),
+            )
+            .field("scopes", &self.scopes)
+            .field("other_audiences", &self.other_audiences)
+            .field("redirect_uri", &self.redirect_uri)
+            .field("redirect_uri_dynamic", &self.redirect_uri_dynamic)
+            .field("claim_name", &self.claim_name)
+            .field("claim_prefix", &self.claim_prefix)
+            .field("role_policy", &self.role_policy)
+            .field("groups_claim", &self.groups_claim)
+            .field("roles_claim", &self.roles_claim)
+            .field("email_claim", &self.email_claim)
+            .field("username_claim", &self.username_claim)
+            .field("hide_from_ui", &self.hide_from_ui)
+            .finish()
+    }
+}
+
+impl Drop for OidcMutationRequest {
+    fn drop(&mut self) {
+        if let Some(secret) = &mut self.client_secret {
+            secret.zeroize();
+        }
+    }
+}
+
+impl OidcMutationRequest {
+    pub fn new(provider_id: String, config_url: String, client_id: String) -> Self {
+        Self {
+            display_name: provider_id.clone(),
+            provider_id,
+            enabled: true,
+            config_url,
+            issuer: None,
+            client_id,
+            client_secret: None,
+            scopes: vec![
+                "openid".to_string(),
+                "profile".to_string(),
+                "email".to_string(),
+            ],
+            other_audiences: Vec::new(),
+            redirect_uri: None,
+            redirect_uri_dynamic: true,
+            claim_name: "policy".to_string(),
+            claim_prefix: String::new(),
+            role_policy: String::new(),
+            groups_claim: "groups".to_string(),
+            roles_claim: "roles".to_string(),
+            email_claim: "email".to_string(),
+            username_claim: "preferred_username".to_string(),
+            hide_from_ui: false,
+        }
+    }
+
+    pub fn from_provider(provider: &OidcProvider) -> Self {
+        Self {
+            provider_id: provider.provider_id.clone(),
+            enabled: provider.enabled,
+            display_name: provider.display_name.clone(),
+            config_url: provider.config_url.clone(),
+            issuer: provider.issuer.clone(),
+            client_id: provider.client_id.clone(),
+            client_secret: None,
+            scopes: provider.scopes.clone(),
+            other_audiences: provider.other_audiences.clone(),
+            redirect_uri: provider.redirect_uri.clone(),
+            redirect_uri_dynamic: provider.redirect_uri_dynamic,
+            claim_name: provider.claim_name.clone(),
+            claim_prefix: provider.claim_prefix.clone(),
+            role_policy: provider.role_policy.clone(),
+            groups_claim: provider.groups_claim.clone(),
+            roles_claim: provider.roles_claim.clone(),
+            email_claim: provider.email_claim.clone(),
+            username_claim: provider.username_claim.clone(),
+            hide_from_ui: provider.hide_from_ui,
+        }
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        OidcValidationRequest::from_mutation(self).validate()?;
+        if self.display_name.trim().is_empty() {
+            return Err(Error::InvalidPath(
+                "OIDC display name cannot be empty".to_string(),
+            ));
+        }
+        if self
+            .client_secret
+            .as_ref()
+            .is_some_and(|secret| secret.is_empty())
+        {
+            return Err(Error::InvalidPath(
+                "OIDC client secret cannot be empty".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Result returned after a retry-safe OIDC provider upsert.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OidcMutationResult {
+    pub success: bool,
+    pub message: String,
+    pub restart_required: bool,
+}
+
+impl OidcMutationResult {
+    pub fn validate_response(&self) -> Result<()> {
+        if !self.success {
+            return Err(Error::General(
+                "RustFS reported an unsuccessful OIDC mutation".to_string(),
+            ));
+        }
+        if self.message.trim().is_empty() {
+            return Err(Error::General(
+                "RustFS returned an incomplete OIDC mutation response".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 #[async_trait]
 pub trait OidcReadApi: Send + Sync {
     async fn oidc_list_providers(&self) -> Result<OidcProviderList>;
     async fn oidc_get_provider(&self, provider_id: &str) -> Result<OidcProvider>;
     async fn oidc_validate(&self, request: OidcValidationRequest) -> Result<OidcValidationResult>;
+}
+
+#[async_trait]
+pub trait OidcMutationApi: OidcReadApi {
+    async fn oidc_upsert_provider(
+        &self,
+        request: OidcMutationRequest,
+    ) -> Result<OidcMutationResult>;
 }
 
 fn validate_provider_id(provider_id: &str) -> Result<()> {
@@ -296,6 +495,49 @@ mod tests {
         assert!(
             OidcProviderList {
                 providers: vec![provider.clone(), provider],
+                restart_required: false,
+            }
+            .validate_response()
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn mutation_request_preserves_secret_by_omission_and_redacts_debug() {
+        let mut request = OidcMutationRequest::new(
+            "corp".to_string(),
+            "https://idp.example".to_string(),
+            "console".to_string(),
+        );
+        let without_secret = serde_json::to_value(&request).expect("serialize request");
+        assert!(without_secret.get("client_secret").is_none());
+
+        let secret = ["runtime", "replacement"].join("-");
+        request.client_secret = Some(secret.clone());
+        let debug = format!("{request:?}");
+        assert!(!debug.contains(&secret));
+        assert!(debug.contains("[REDACTED]"));
+        let validation = OidcValidationRequest::from_mutation(&request);
+        let validation_json = serde_json::to_string(&validation).expect("serialize validation");
+        assert!(!validation_json.contains(&secret));
+        assert!(!validation_json.contains("client_secret"));
+    }
+
+    #[test]
+    fn mutation_response_rejects_unsuccessful_or_incomplete_results() {
+        assert!(
+            OidcMutationResult {
+                success: true,
+                message: "saved".to_string(),
+                restart_required: true,
+            }
+            .validate_response()
+            .is_ok()
+        );
+        assert!(
+            OidcMutationResult {
+                success: false,
+                message: "not saved".to_string(),
                 restart_required: false,
             }
             .validate_response()

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -29,14 +29,15 @@ use rc_core::admin::{
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REQUEST_BYTES,
     MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, ManualTransitionRunRequest,
     ManualTransitionRunResponse, MetricsBatch, MetricsQuery, ModuleSwitches, ObservabilityApi,
-    OidcProvider, OidcProviderList, OidcReadApi, OidcValidationRequest, OidcValidationResult,
-    PeerSiteSpec, Policy, PolicyEntitiesQuery, PolicyEntitiesResult, PolicyEntity, PolicyInfo,
-    PoolStatus, PoolTarget, RealtimeMetrics, RebalanceStartResult, RebalanceStatus,
-    ReplicateEditStatus, ReplicationDiff, ReplicationDiffApi, RuntimeCapabilitiesSnapshot,
-    RuntimeCapabilityStatus, ScannerStatus, ServiceAccount, ServiceAccountCreateResponse,
-    ServiceActionResult, SiteRemoveSpec, SiteReplicationInfo, SiteReplicationPeer,
-    SiteReplicationResyncOperation, SiteReplicationResyncStatus, SiteStatusOptions, StorageInfo,
-    UpdateGroupMembersRequest, UpdateServiceAccountRequest, User, UserStatus,
+    OidcMutationApi, OidcMutationRequest, OidcMutationResult, OidcProvider, OidcProviderList,
+    OidcReadApi, OidcValidationRequest, OidcValidationResult, PeerSiteSpec, Policy,
+    PolicyEntitiesQuery, PolicyEntitiesResult, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
+    RealtimeMetrics, RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
+    ReplicationDiffApi, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
+    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
+    SiteReplicationInfo, SiteReplicationPeer, SiteReplicationResyncOperation,
+    SiteReplicationResyncStatus, SiteStatusOptions, StorageInfo, UpdateGroupMembersRequest,
+    UpdateServiceAccountRequest, User, UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -643,12 +644,61 @@ impl AdminClient {
                     "The RustFS OIDC administration route is unavailable".to_string(),
                 ),
                 StatusCode::BAD_REQUEST => {
-                    Error::General("OIDC validation request was rejected".to_string())
+                    Error::General("OIDC issuer validation failed".to_string())
                 }
                 _ => Error::Network("OIDC administration service is unavailable".to_string()),
             });
         }
 
+        serde_json::from_slice(&response_body)
+            .map_err(|_| Error::General("RustFS returned a malformed OIDC response".to_string()))
+    }
+
+    async fn request_oidc_mutation<T: for<'de> Deserialize<'de>>(
+        &self,
+        path: &str,
+        body: Zeroizing<Vec<u8>>,
+    ) -> Result<T> {
+        let url = self.admin_url(path);
+        let headers = self.request_headers(body.as_slice())?;
+        let signed_headers = self
+            .sign_request(&Method::PUT, &url, &headers, body.as_slice())
+            .await?;
+        let mut request = self.http_client.put(&url);
+        for (name, value) in &signed_headers {
+            request = request.header(name, value);
+        }
+        let response = request
+            .body(Bytes::from_owner(SensitiveRequestBody(body)))
+            .send()
+            .await
+            .map_err(|_| Error::Network("OIDC administration request failed".to_string()))?;
+        let status = response.status();
+        let response_body = read_bounded_response_body(
+            response,
+            MAX_OIDC_RESPONSE_BYTES,
+            "OIDC administration response",
+        )
+        .await?;
+        if !status.is_success() {
+            return Err(match status {
+                StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                    Error::Auth("OIDC administration permission was denied".to_string())
+                }
+                StatusCode::NOT_FOUND
+                | StatusCode::METHOD_NOT_ALLOWED
+                | StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+                    "The RustFS OIDC mutation route is unavailable".to_string(),
+                ),
+                StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED => {
+                    Error::Conflict("OIDC provider changed concurrently".to_string())
+                }
+                StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => {
+                    Error::General("OIDC configuration request was rejected".to_string())
+                }
+                _ => Error::Network("OIDC administration service is unavailable".to_string()),
+            });
+        }
         serde_json::from_slice(&response_body)
             .map_err(|_| Error::General("RustFS returned a malformed OIDC response".to_string()))
     }
@@ -2749,6 +2799,26 @@ impl IamReadApi for AdminClient {
             )
             .await?;
         result.normalize()
+    }
+}
+
+#[async_trait]
+impl OidcMutationApi for AdminClient {
+    async fn oidc_upsert_provider(
+        &self,
+        request: OidcMutationRequest,
+    ) -> Result<OidcMutationResult> {
+        request.validate()?;
+        let provider_id = request.provider_id.clone();
+        let body = Zeroizing::new(serde_json::to_vec(&request).map_err(|_| {
+            Error::General("Failed to encode OIDC configuration request".to_string())
+        })?);
+        let path = format!("/oidc/config/{}", urlencoding::encode(&provider_id));
+        let response: OidcMutationResult = self.request_oidc_mutation(&path, body).await?;
+        response.validate_response().map_err(|_| {
+            Error::General("RustFS returned an invalid OIDC mutation response".to_string())
+        })?;
+        Ok(response)
     }
 }
 

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -16,6 +16,9 @@ rc admin scanner status <ALIAS>
 rc admin idp openid list <ALIAS>
 rc admin idp openid get <ALIAS> <PROVIDER_ID>
 rc admin idp openid validate <ALIAS> <PROVIDER_ID> --config-url URL --client-id ID
+rc admin idp openid set <ALIAS> <PROVIDER_ID> [OPTIONS]
+rc admin idp openid update <ALIAS> <PROVIDER_ID> [OPTIONS]
+rc admin idp openid <enable|disable> <ALIAS> <PROVIDER_ID> [--dry-run]
 rc admin metrics <ALIAS> [OPTIONS]
 rc admin kms status <ALIAS>
 rc admin kms configure <ALIAS> <--config-file PATH|--stdin>
@@ -62,7 +65,7 @@ rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 | `scanner` | Inspect scanner health, freshness, and cycle state. |
 | `metrics` | Query bounded realtime metrics as normalized JSON Lines or raw server records. |
 | `kms` | Inspect KMS state and manage safe native key lifecycle operations. |
-| `idp openid` | Inspect effective OIDC providers and run non-persisting discovery validation. |
+| `idp openid` | Inspect, validate, and safely mutate effective OIDC providers. |
 | `heal` | Start, stop, or inspect healing operations. |
 | `pool` | List pools and inspect pool status. |
 | `expand` | Manage post-expansion data rebalancing. Alias: `scale`. |
@@ -331,29 +334,47 @@ The v3 lifecycle success operations are `configure`, `reconfigure`, `start`, `re
 
 `kms key status` describes native RustFS key lifecycle metadata. It does not claim compatibility with the `mc admin kms key status` encryption/decryption probe. The round-trip diagnostic uses only the S3 object API and does not call an Admin API key-generation route. RustFS beta.10 has no direct decrypt-test Admin API or KMS-specific metrics route/selector contract, so `rc` does not offer KMS-specific metrics and intentionally does not expose the legacy `generate-data-key` response because that response contains plaintext data-key material.
 
-## OIDC Read-Only Administration
+## OIDC Administration
 
 These commands target RustFS's native typed OIDC routes. They do not use LDAP compatibility
-configuration, browser login endpoints, or a guessed per-provider route:
+configuration or browser login endpoints:
 
 | Command | Behavior |
 |---|---|
 | `rc admin idp openid list <ALIAS>` | List all effective persisted and environment-managed providers. |
 | `rc admin idp openid get <ALIAS> <PROVIDER_ID>` | Select one exact provider from the server's typed configuration list. |
 | `rc admin idp openid validate <ALIAS> <PROVIDER_ID> --config-url URL --client-id ID` | Run live discovery validation without saving or changing server configuration. |
+| `rc admin idp openid set <ALIAS> <PROVIDER_ID> [OPTIONS]` | Create a provider or update an existing provider after GET-and-merge and discovery preflight. |
+| `rc admin idp openid update <ALIAS> <PROVIDER_ID> [OPTIONS]` | Update an existing provider and fail if it does not exist. |
+| `rc admin idp openid enable <ALIAS> <PROVIDER_ID> [--dry-run]` | Enable a persisted provider while preserving every other field. |
+| `rc admin idp openid disable <ALIAS> <PROVIDER_ID> [--dry-run]` | Disable a persisted provider while preserving every other field. |
 
 Provider output includes only the server's `client_secret_configured` boolean. Client-secret
-values are not accepted by this read-only command family, sent in validation requests, or included
-in human/JSON output. Remote text is terminal-sanitized, response bodies are bounded, and unknown
-or incomplete provider shapes fail closed. Missing/unsupported routes use the
-`unsupported_feature` exit code, permission failures use the authentication exit code, a missing
-exact provider uses `not_found`, and locally invalid URLs use the usage exit code.
+values are never accepted as command-line literals, sent in validation requests, or included in
+human/JSON output. A replacement must use `--client-secret-stdin` or
+`--client-secret-file <PATH>` together with `--replace-client-secret`. Secret files must be regular
+files, must not be symbolic links, and on Unix must grant no group or other permissions. Omitting a
+secret preserves the server-side value.
 
-JSON output uses schema v3 family `oidc` with operations `list`, `get`, and `validate`. Validation
-supports repeated `--scope` and `--other-audience` options, optional `--issuer`, claim-name
-overrides, and `--redirect-uri --static-redirect`. Scopes must include `openid`; URLs must be
-absolute HTTP(S) URLs. RustFS still applies its server-side outbound URL safety policy before
-performing discovery.
+Every mutation first reads the current effective provider, rejects environment-managed or
+otherwise non-editable providers, merges only explicitly supplied options, and runs the native
+validation endpoint. `--dry-run` performs GET and validation and emits the same deterministic,
+redacted change list without issuing PUT. Successful changes explicitly report
+`restart_required`; multiple providers are addressed independently by exact provider ID.
+
+Remote text is terminal-sanitized, response bodies are bounded, and unknown or incomplete provider
+or mutation shapes fail closed. Missing/unsupported routes use the
+`unsupported_feature` exit code, permission failures use the authentication exit code, a missing
+exact provider uses `not_found`, conflicts use the conflict exit code, and locally invalid URLs use
+the usage exit code.
+
+JSON output uses schema v3 family `oidc` with operations `list`, `get`, `validate`, `set`, `update`,
+`enable`, and `disable`. Validation supports repeated `--scope` and `--other-audience` options,
+optional `--issuer`, claim-name overrides, and `--redirect-uri --static-redirect`. Mutation fields
+use the same options, while `--clear-issuer`, `--clear-redirect-uri`,
+`--replace-other-audiences`, and the paired boolean flags express explicit resets. Scopes must
+include `openid`; URLs must be absolute HTTP(S) URLs. RustFS still applies its server-side outbound
+URL safety policy before performing discovery.
 
 `rc admin heal status <ALIAS>` reports aggregate background heal status. Manual heals started with `rc admin heal start` are token-scoped tasks; the start output includes a client token. Root recursive tasks are inspected or stopped with `--client-token`, while bucket or prefix tasks additionally pass `--bucket` and optional `--prefix`.
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -937,11 +937,40 @@
         "token_endpoint": { "$ref": "#/definitions/nullableString" }
       }
     },
+    "oidcChange": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["field", "before", "after"],
+      "properties": {
+        "field": { "type": "string", "minLength": 1 },
+        "before": {},
+        "after": {}
+      }
+    },
+    "oidcMutationData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation", "provider_id", "created", "dry_run", "restart_required", "changes"
+      ],
+      "properties": {
+        "operation": { "type": "string", "enum": ["set", "update", "enable", "disable"] },
+        "provider_id": { "type": "string", "minLength": 1 },
+        "created": { "type": "boolean" },
+        "dry_run": { "type": "boolean" },
+        "restart_required": { "type": "boolean" },
+        "changes": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/oidcChange" }
+        }
+      }
+    },
     "oidcData": {
       "oneOf": [
         { "$ref": "#/definitions/oidcListData" },
         { "$ref": "#/definitions/oidcGetData" },
-        { "$ref": "#/definitions/oidcValidationData" }
+        { "$ref": "#/definitions/oidcValidationData" },
+        { "$ref": "#/definitions/oidcMutationData" }
       ]
     },
     "adminOperation": {


### PR DESCRIPTION
## Summary

- add `rc admin idp openid set`, `update`, `enable`, and `disable`
- merge updates with the current provider so omitted fields and existing secrets are preserved
- accept replacement secrets only from stdin or protected regular files with explicit acknowledgement
- validate with the server before mutation and emit deterministic redacted diffs
- support dry-run/no-op paths that never send PUT, plus typed bounded sensitive responses and output-v3

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- OIDC integration tests: 14 passed
- `git diff --check`

Closes rustfs/backlog#1490
Refs rustfs/backlog#1379

BREAKING: no