### PR TITLE
feat(admin): safely delete OIDC providers

### DIFF
--- a/crates/cli/src/commands/admin/idp.rs
+++ b/crates/cli/src/commands/admin/idp.rs
@@ -9,7 +9,7 @@ use rc_core::{Error, Result};
 use serde::Serialize;
 use serde_json::Value;
 use std::fs::File;
-use std::io::Read;
+use std::io::{BufRead, IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 use zeroize::Zeroizing;
 
@@ -46,6 +46,9 @@ pub enum OpenidCommands {
 
     /// Disable an existing OIDC provider
     Disable(OidcToggleArgs),
+
+    /// Delete an editable OIDC provider after explicit confirmation
+    Delete(OidcDeleteArgs),
 }
 
 #[derive(Args, Debug)]
@@ -254,6 +257,19 @@ pub struct OidcToggleArgs {
     pub dry_run: bool,
 }
 
+#[derive(Args, Debug)]
+pub struct OidcDeleteArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Exact OIDC provider ID
+    pub provider_id: String,
+
+    /// Confirm deletion without an interactive prompt
+    #[arg(long)]
+    pub yes: bool,
+}
+
 #[derive(Debug, Serialize)]
 struct OidcSuccessOutput<T> {
     schema_version: u8,
@@ -301,6 +317,13 @@ struct OidcMutationData<'a> {
     changes: &'a [OidcChange],
 }
 
+#[derive(Debug, Serialize)]
+struct OidcDeleteData<'a> {
+    operation: &'static str,
+    provider: &'a OidcProvider,
+    restart_required: bool,
+}
+
 #[derive(Debug, Clone, Copy)]
 enum MutationMode {
     Set,
@@ -344,6 +367,7 @@ pub async fn execute(command: IdpCommands, formatter: &Formatter) -> ExitCode {
             OpenidCommands::Disable(args) => {
                 execute_toggle(args, MutationMode::Disable, formatter).await
             }
+            OpenidCommands::Delete(args) => execute_delete(args, formatter).await,
         },
     }
 }
@@ -493,6 +517,71 @@ async fn execute_toggle(
             &error,
             formatter,
         ),
+    }
+}
+
+async fn execute_delete(args: OidcDeleteArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    match prepare_and_delete(&client, args, formatter).await {
+        Ok(()) => ExitCode::Success,
+        Err(error) => emit_observability_error(
+            "oidc",
+            "admin.oidc-config-write",
+            "Failed to delete OIDC provider",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn prepare_and_delete(
+    client: &rc_s3::AdminClient,
+    args: OidcDeleteArgs,
+    formatter: &Formatter,
+) -> Result<()> {
+    let provider = client.oidc_get_provider(&args.provider_id).await?;
+    ensure_editable(&provider)?;
+    if !formatter.is_json() {
+        print_delete_summary(&provider, formatter);
+    }
+    confirm_delete(&provider, args.yes, formatter)?;
+    let result = client.oidc_delete_provider(&args.provider_id).await?;
+    print_delete(&provider, result.restart_required, formatter);
+    Ok(())
+}
+
+fn confirm_delete(provider: &OidcProvider, yes: bool, formatter: &Formatter) -> Result<()> {
+    if yes {
+        return Ok(());
+    }
+    if formatter.is_json() || !std::io::stdin().is_terminal() {
+        return Err(Error::InvalidPath(
+            "OIDC provider deletion requires --yes in non-interactive or JSON mode".to_string(),
+        ));
+    }
+
+    let mut stderr = std::io::stderr().lock();
+    write!(
+        stderr,
+        "Delete OIDC provider '{}'? [y/N] ",
+        safe(&provider.provider_id, formatter)
+    )
+    .map_err(Error::Io)?;
+    stderr.flush().map_err(Error::Io)?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut answer)
+        .map_err(Error::Io)?;
+    if matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        Ok(())
+    } else {
+        Err(Error::Interrupted(
+            "OIDC provider deletion was declined".to_string(),
+        ))
     }
 }
 
@@ -931,6 +1020,47 @@ fn print_mutation(
             ));
         }
     }
+}
+
+fn print_delete_summary(provider: &OidcProvider, formatter: &Formatter) {
+    formatter.println(&formatter.style_name("OIDC Provider Deletion"));
+    formatter.println("");
+    formatter.println(&format!(
+        "Provider ID:  {}",
+        safe(&provider.provider_id, formatter)
+    ));
+    formatter.println(&format!(
+        "Display name: {}",
+        safe(&provider.display_name, formatter)
+    ));
+    formatter.println(&format!("Enabled:      {}", provider.enabled));
+    formatter.println(&format!(
+        "Source:       {}",
+        match provider.source {
+            OidcProviderSource::Env => "env",
+            OidcProviderSource::Persisted => "persisted",
+        }
+    ));
+    formatter.println(&format!("Editable:     {}", provider.editable));
+}
+
+fn print_delete(provider: &OidcProvider, restart_required: bool, formatter: &Formatter) {
+    if formatter.is_json() {
+        formatter.json(&OidcSuccessOutput {
+            schema_version: 3,
+            output_type: "oidc",
+            status: "success",
+            data: OidcDeleteData {
+                operation: "delete",
+                provider,
+                restart_required,
+            },
+        });
+        return;
+    }
+    formatter.println("");
+    formatter.println("Deleted:      true");
+    formatter.println(&format!("Restart required: {restart_required}"));
 }
 
 fn print_list(list: &OidcProviderList, formatter: &Formatter) {

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -216,6 +216,7 @@ fn observability_error_type(error: &Error) -> &'static str {
         Error::NotFound(_) | Error::AliasNotFound(_) => "not_found",
         Error::Conflict(_) | Error::AliasExists(_) => "conflict",
         Error::UnsupportedFeature(_) => "unsupported_feature",
+        Error::Interrupted(_) => "interrupted",
         _ => "general_error",
     }
 }
@@ -226,6 +227,7 @@ fn observability_error_suggestion(error: &Error) -> Option<&'static str> {
         Error::Network(_) => Some("Verify the endpoint and network connectivity, then retry."),
         Error::Auth(_) => Some("Verify credentials and required admin permissions, then retry."),
         Error::UnsupportedFeature(_) => Some("Upgrade RustFS to beta.10 or later."),
+        Error::Interrupted(_) => Some("Retry with --yes if deletion is still intended."),
         _ => None,
     }
 }

--- a/crates/cli/tests/admin_oidc.rs
+++ b/crates/cli/tests/admin_oidc.rs
@@ -639,3 +639,172 @@ fn oidc_secret_input_requires_explicit_replacement_acknowledgement() {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+#[test]
+fn oidc_delete_requires_confirmation_after_redacted_get_and_sends_no_delete() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", PROVIDERS)]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "delete", "myalias", "corp",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert_eq!(output.status.code(), Some(2));
+    let error: Value = serde_json::from_slice(&output.stderr).expect("error JSON");
+    assert_eq!(error["error"]["type"], "usage_error");
+    assert!(
+        error["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("--yes"))
+    );
+    let get = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("GET request");
+    assert_eq!(get.method, "GET");
+    assert_eq!(get.target, "/rustfs/admin/v3/oidc/config");
+    assert!(
+        receiver.try_recv().is_err(),
+        "refusal must not issue DELETE"
+    );
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("client_secret"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("SECRET_KEY"));
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_delete_uses_exact_typed_route_and_emits_secret_free_v3_output() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let delete_ok = r#"{"success":true,"message":"OIDC provider deleted","restart_required":true}"#;
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", PROVIDERS), ("200 OK", delete_ok)]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "delete", "myalias", "corp", "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("JSON stdout");
+    assert_eq!(value["data"]["operation"], "delete");
+    assert_eq!(value["data"]["provider"]["provider_id"], "corp");
+    assert_eq!(value["data"]["provider"]["client_secret_configured"], true);
+    assert_eq!(value["data"]["restart_required"], true);
+    assert!(value["data"]["provider"].get("client_secret").is_none());
+    assert_valid_v3(&value);
+
+    let get = receiver.recv().expect("GET request");
+    let delete = receiver.recv().expect("DELETE request");
+    assert_eq!(get.method, "GET");
+    assert_eq!(delete.method, "DELETE");
+    assert_eq!(delete.target, "/rustfs/admin/v3/oidc/config/corp");
+    assert!(delete.body.is_empty());
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_delete_retry_is_deterministic_not_found_without_delete() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", EMPTY_PROVIDERS)]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "delete", "myalias", "corp", "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert_eq!(output.status.code(), Some(5));
+    let error: Value = serde_json::from_slice(&output.stderr).expect("error JSON");
+    assert_eq!(error["error"]["type"], "not_found");
+    assert_eq!(receiver.recv().expect("GET").method, "GET");
+    assert!(receiver.try_recv().is_err());
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_delete_refuses_environment_provider_before_delete() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) =
+        start_admin_sequence_test_server(vec![("200 OK", ENV_PROVIDER)]);
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "delete", "myalias", "corp", "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc");
+
+    assert_eq!(output.status.code(), Some(6));
+    let error: Value = serde_json::from_slice(&output.stderr).expect("error JSON");
+    assert_eq!(error["error"]["type"], "conflict");
+    assert_eq!(receiver.recv().expect("GET").method, "GET");
+    assert!(receiver.try_recv().is_err());
+    handle.join().expect("server");
+}
+
+#[test]
+fn oidc_delete_distinguishes_permission_not_found_unsupported_and_server_failure() {
+    for (status, expected_code, expected_type) in [
+        ("403 Forbidden", 4, "auth_error"),
+        ("400 Bad Request", 5, "not_found"),
+        ("404 Not Found", 7, "unsupported_feature"),
+        ("500 Internal Server Error", 3, "network_error"),
+    ] {
+        let config_dir = tempfile::tempdir().expect("create config dir");
+        let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+            ("200 OK", PROVIDERS),
+            (status, r#"{"message":"MUST_NOT_APPEAR"}"#),
+        ]);
+        let output = Command::new(rc_binary())
+            .args([
+                "--json", "admin", "idp", "openid", "delete", "myalias", "corp", "--yes",
+            ])
+            .env("RC_CONFIG_DIR", config_dir.path())
+            .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+            .output()
+            .expect("run rc");
+
+        assert_eq!(output.status.code(), Some(expected_code));
+        assert!(!String::from_utf8_lossy(&output.stderr).contains("MUST_NOT_APPEAR"));
+        let error: Value = serde_json::from_slice(&output.stderr).expect("error JSON");
+        assert_eq!(error["error"]["type"], expected_type);
+        assert_eq!(receiver.recv().expect("GET").method, "GET");
+        assert_eq!(receiver.recv().expect("DELETE").method, "DELETE");
+        handle.join().expect("server");
+    }
+}
+
+#[test]
+fn oidc_delete_rejects_invalid_provider_id_before_network_io() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let output = Command::new(rc_binary())
+        .args([
+            "--json", "admin", "idp", "openid", "delete", "myalias", "../corp", "--yes",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env(
+            "RC_HOST_myalias",
+            "http://ACCESS_KEY:SECRET_KEY@127.0.0.1:1",
+        )
+        .output()
+        .expect("run rc");
+
+    assert_eq!(output.status.code(), Some(2));
+    let error: Value = serde_json::from_slice(&output.stderr).expect("error JSON");
+    assert_eq!(error["error"]["type"], "usage_error");
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -689,7 +689,7 @@ fn nested_subcommand_help_contract() {
             args: &["admin", "idp", "openid"],
             usage: "Usage: rc admin idp openid [OPTIONS] <COMMAND>",
             expected_tokens: &[
-                "list", "get", "validate", "set", "update", "enable", "disable",
+                "list", "get", "validate", "set", "update", "enable", "disable", "delete",
             ],
         },
         HelpCase {
@@ -731,6 +731,11 @@ fn nested_subcommand_help_contract() {
             args: &["admin", "idp", "openid", "enable"],
             usage: "Usage: rc admin idp openid enable [OPTIONS] <ALIAS> <PROVIDER_ID>",
             expected_tokens: &["--dry-run"],
+        },
+        HelpCase {
+            args: &["admin", "idp", "openid", "delete"],
+            usage: "Usage: rc admin idp openid delete [OPTIONS] <ALIAS> <PROVIDER_ID>",
+            expected_tokens: &["--yes"],
         },
         HelpCase {
             args: &["admin", "metrics"],

--- a/crates/core/src/admin/oidc.rs
+++ b/crates/core/src/admin/oidc.rs
@@ -417,6 +417,12 @@ pub trait OidcMutationApi: OidcReadApi {
         &self,
         request: OidcMutationRequest,
     ) -> Result<OidcMutationResult>;
+
+    /// Delete one persisted provider by exact ID.
+    ///
+    /// Implementations must reject invalid IDs locally and preserve not-found semantics so
+    /// callers can distinguish a completed retry from an unavailable route.
+    async fn oidc_delete_provider(&self, provider_id: &str) -> Result<OidcMutationResult>;
 }
 
 fn validate_provider_id(provider_id: &str) -> Result<()> {

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -703,6 +703,56 @@ impl AdminClient {
             .map_err(|_| Error::General("RustFS returned a malformed OIDC response".to_string()))
     }
 
+    async fn request_oidc_delete<T: for<'de> Deserialize<'de>>(&self, path: &str) -> Result<T> {
+        let url = self.admin_url(path);
+        let headers = self.request_headers(&[])?;
+        let signed_headers = self
+            .sign_request(&Method::DELETE, &url, &headers, &[])
+            .await?;
+        let mut request = self.http_client.delete(&url);
+        for (name, value) in &signed_headers {
+            request = request.header(name, value);
+        }
+        let response = request
+            .send()
+            .await
+            .map_err(|_| Error::Network("OIDC administration request failed".to_string()))?;
+        let status = response.status();
+        let response_body = read_bounded_response_body(
+            response,
+            MAX_OIDC_RESPONSE_BYTES,
+            "OIDC administration response",
+        )
+        .await?;
+        if !status.is_success() {
+            return Err(match status {
+                StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                    Error::Auth("OIDC administration permission was denied".to_string())
+                }
+                StatusCode::NOT_FOUND
+                | StatusCode::METHOD_NOT_ALLOWED
+                | StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+                    "The RustFS OIDC deletion route is unavailable".to_string(),
+                ),
+                // RustFS deliberately reports an absent persisted provider as InvalidRequest.
+                // Provider IDs are validated locally, so this status has deterministic retry
+                // semantics instead of being collapsed into a generic server rejection.
+                StatusCode::BAD_REQUEST => {
+                    Error::NotFound("OIDC provider was not found".to_string())
+                }
+                StatusCode::CONFLICT | StatusCode::PRECONDITION_FAILED => {
+                    Error::Conflict("OIDC provider changed concurrently".to_string())
+                }
+                StatusCode::UNPROCESSABLE_ENTITY => {
+                    Error::General("OIDC deletion request was rejected".to_string())
+                }
+                _ => Error::Network("OIDC administration service is unavailable".to_string()),
+            });
+        }
+        serde_json::from_slice(&response_body)
+            .map_err(|_| Error::General("RustFS returned a malformed OIDC response".to_string()))
+    }
+
     /// Send a KMS request while retaining ownership of its body in zeroizing storage.
     async fn request_sensitive<T: for<'de> Deserialize<'de>>(
         &self,
@@ -2817,6 +2867,24 @@ impl OidcMutationApi for AdminClient {
         let response: OidcMutationResult = self.request_oidc_mutation(&path, body).await?;
         response.validate_response().map_err(|_| {
             Error::General("RustFS returned an invalid OIDC mutation response".to_string())
+        })?;
+        Ok(response)
+    }
+
+    async fn oidc_delete_provider(&self, provider_id: &str) -> Result<OidcMutationResult> {
+        if provider_id.is_empty()
+            || !provider_id.chars().all(|character| {
+                character.is_ascii_alphanumeric() || matches!(character, '_' | '-')
+            })
+        {
+            return Err(Error::InvalidPath(
+                "OIDC provider ID must contain only ASCII letters, digits, '_' or '-'".to_string(),
+            ));
+        }
+        let path = format!("/oidc/config/{}", urlencoding::encode(provider_id));
+        let response: OidcMutationResult = self.request_oidc_delete(&path).await?;
+        response.validate_response().map_err(|_| {
+            Error::General("RustFS returned an invalid OIDC deletion response".to_string())
         })?;
         Ok(response)
     }

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -348,6 +348,7 @@ configuration or browser login endpoints:
 | `rc admin idp openid update <ALIAS> <PROVIDER_ID> [OPTIONS]` | Update an existing provider and fail if it does not exist. |
 | `rc admin idp openid enable <ALIAS> <PROVIDER_ID> [--dry-run]` | Enable a persisted provider while preserving every other field. |
 | `rc admin idp openid disable <ALIAS> <PROVIDER_ID> [--dry-run]` | Disable a persisted provider while preserving every other field. |
+| `rc admin idp openid delete <ALIAS> <PROVIDER_ID> [--yes]` | Display a secret-free provider summary, confirm, and delete one persisted provider. Use `--yes` for automation. |
 
 Provider output includes only the server's `client_secret_configured` boolean. Client-secret
 values are never accepted as command-line literals, sent in validation requests, or included in
@@ -369,7 +370,10 @@ exact provider uses `not_found`, conflicts use the conflict exit code, and local
 the usage exit code.
 
 JSON output uses schema v3 family `oidc` with operations `list`, `get`, `validate`, `set`, `update`,
-`enable`, and `disable`. Validation supports repeated `--scope` and `--other-audience` options,
+`enable`, `disable`, and `delete`. A delete reads the exact provider before mutation, refuses
+environment-managed or otherwise non-editable providers, and requires an interactive confirmation
+or `--yes` in non-interactive/JSON mode. A repeated delete returns deterministic `not_found`
+without issuing DELETE. Validation supports repeated `--scope` and `--other-audience` options,
 optional `--issuer`, claim-name overrides, and `--redirect-uri --static-redirect`. Mutation fields
 use the same options, while `--clear-issuer`, `--clear-redirect-uri`,
 `--replace-other-audiences`, and the paired boolean flags express explicit resets. Scopes must

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -965,12 +965,23 @@
         }
       }
     },
+    "oidcDeleteData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "provider", "restart_required"],
+      "properties": {
+        "operation": { "const": "delete" },
+        "provider": { "$ref": "#/definitions/oidcProvider" },
+        "restart_required": { "type": "boolean" }
+      }
+    },
     "oidcData": {
       "oneOf": [
         { "$ref": "#/definitions/oidcListData" },
         { "$ref": "#/definitions/oidcGetData" },
         { "$ref": "#/definitions/oidcValidationData" },
-        { "$ref": "#/definitions/oidcMutationData" }
+        { "$ref": "#/definitions/oidcMutationData" },
+        { "$ref": "#/definitions/oidcDeleteData" }
       ]
     },
     "adminOperation": {


### PR DESCRIPTION
## Summary

- add `rc admin idp openid delete <ALIAS> <PROVIDER_ID>` with explicit interactive or `--yes` confirmation
- fetch and display a typed, secret-free provider summary before deletion
- fail closed for environment-managed providers and unsupported server capabilities before mutation
- use a bounded typed DELETE path with deterministic not-found, auth, conflict, unsupported, and server error classes
- emit output-v3 success data without leaking secret values or server error bodies

## BREAKING contract update

The protected command reference is updated to document the new delete subcommand and its mandatory confirmation contract. Existing commands and output schemas remain backward compatible.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo test --test admin_oidc` (20/20)
- `git diff --check`

Closes rustfs/backlog#1491
Refs rustfs/backlog#1379