### PR TITLE
feat(admin): add typed IAM policy detach

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ rc admin policy create local/ readonly --file policy.json
 # Attach policy to user
 rc admin policy attach local/ readonly --user newuser
 
+# Detach multiple policies from a user
+rc admin policy detach local/ readonly diagnostics --user newuser
+
 # Create a service account (access_key + secret_key)
 rc admin service-account create local/ AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
@@ -395,7 +398,7 @@ For full command documentation, see the [`rc` command reference](docs/reference/
 | Command                 | Description                                                                           |
 |-------------------------|---------------------------------------------------------------------------------------|
 | `admin user`            | Manage IAM users (add, remove, list, info, enable, disable)                           |
-| `admin policy`          | Manage IAM policies and inspect entity mappings (create, remove, list, info, attach, entities) |
+| `admin policy`          | Manage IAM policies and inspect entity mappings (create, remove, list, info, attach, detach, entities) |
 | `admin group`           | Manage IAM groups (add, remove, list, info, enable, disable, add-members, rm-members) |
 | `admin service-account` | Manage service accounts (create, update, remove, list, info)                          |
 | `admin access-key`      | Inspect access key identity and metadata (info)                                       |

--- a/crates/cli/src/commands/admin/policy.rs
+++ b/crates/cli/src/commands/admin/policy.rs
@@ -12,8 +12,9 @@ use crate::output::Formatter;
 use rc_core::Error;
 use rc_core::admin::{
     AdminApi, CapabilityApi, CapabilityAvailability, GroupPolicyEntities,
-    IAM_POLICY_ENTITIES_CAPABILITY, IamReadApi, PolicyEntitiesQuery, PolicyEntitiesResult,
-    PolicyEntity, UserPolicyEntities,
+    IAM_POLICY_DETACH_CAPABILITY, IAM_POLICY_ENTITIES_CAPABILITY, IamMutationApi, IamReadApi,
+    PolicyDetachEntity, PolicyDetachRequest, PolicyDetachResult, PolicyEntitiesQuery,
+    PolicyEntitiesResult, PolicyEntity, UserPolicyEntities,
 };
 
 /// Policy management subcommands
@@ -35,6 +36,9 @@ pub enum PolicyCommands {
 
     /// Attach policy to a user or group
     Attach(AttachArgs),
+
+    /// Detach one or more policies from exactly one user or group
+    Detach(DetachArgs),
 
     /// Inspect policy mappings for users, groups, or policies
     Entities(EntitiesArgs),
@@ -90,6 +94,24 @@ pub struct AttachArgs {
 
     /// Target group name
     #[arg(long, conflicts_with = "user")]
+    pub group: Option<String>,
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct DetachArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Policy name to detach; accepts repeated values or comma-separated names
+    #[arg(required = true, num_args = 1.., value_delimiter = ',')]
+    pub policies: Vec<String>,
+
+    /// Target user access key
+    #[arg(long, required_unless_present = "group", conflicts_with = "group")]
+    pub user: Option<String>,
+
+    /// Target group name
+    #[arg(long, required_unless_present = "user", conflicts_with = "user")]
     pub group: Option<String>,
 }
 
@@ -191,6 +213,55 @@ struct PolicyEntitiesErrorBody {
     suggestion: Option<&'static str>,
 }
 
+#[derive(Debug, Serialize)]
+struct PolicyDetachSuccessOutput<'a> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: PolicyDetachOutput<'a>,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyDetachOutput<'a> {
+    operation: &'static str,
+    entity: PolicyDetachEntityOutput<'a>,
+    changed: bool,
+    attached: &'a [String],
+    detached: &'a [String],
+    unchanged: &'a [String],
+    updated_at: jiff::Timestamp,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyDetachEntityOutput<'a> {
+    #[serde(rename = "type")]
+    entity_type: PolicyDetachEntity,
+    name: &'a str,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyDetachErrorOutput {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: PolicyDetachErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyDetachErrorBody {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: String,
+    retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    capability: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    server: Option<&'static str>,
+    suggestion: Option<&'static str>,
+}
+
 /// Execute a policy subcommand
 pub async fn execute(cmd: PolicyCommands, formatter: &Formatter) -> ExitCode {
     match cmd {
@@ -199,7 +270,188 @@ pub async fn execute(cmd: PolicyCommands, formatter: &Formatter) -> ExitCode {
         PolicyCommands::Info(args) => execute_info(args, formatter).await,
         PolicyCommands::Remove(args) => execute_remove(args, formatter).await,
         PolicyCommands::Attach(args) => execute_attach(args, formatter).await,
+        PolicyCommands::Detach(args) => execute_detach(args, formatter).await,
         PolicyCommands::Entities(args) => execute_entities(args, formatter).await,
+    }
+}
+
+async fn execute_detach(args: DetachArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_detach_with_api(args, &client, &client, formatter).await
+}
+
+async fn execute_detach_with_api(
+    args: DetachArgs,
+    capabilities: &dyn CapabilityApi,
+    iam: &dyn IamMutationApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    let (entity, entity_name) = match (args.user, args.group) {
+        (Some(user), None) => (PolicyDetachEntity::User, user),
+        (None, Some(group)) => (PolicyDetachEntity::Group, group),
+        _ => {
+            return emit_policy_detach_error(
+                "Invalid policy detach target",
+                &Error::InvalidPath(
+                    "Specify exactly one target with --user or --group".to_string(),
+                ),
+                formatter,
+            );
+        }
+    };
+    let request = match PolicyDetachRequest::new(args.policies, entity, entity_name) {
+        Ok(request) => request,
+        Err(error) => {
+            return emit_policy_detach_error("Invalid policy detach selectors", &error, formatter);
+        }
+    };
+
+    let report = match capabilities.discover_capabilities(false).await {
+        Ok(report) => report,
+        Err(error) => {
+            let error = sanitize_capability_discovery_error(&error);
+            return emit_policy_detach_error(
+                "Failed to discover IAM capabilities",
+                &error,
+                formatter,
+            );
+        }
+    };
+    match report.capability(IAM_POLICY_DETACH_CAPABILITY) {
+        Some(capability) if capability.availability == CapabilityAvailability::Available => {}
+        Some(capability) if capability.availability == CapabilityAvailability::PermissionDenied => {
+            return emit_policy_detach_error(
+                "IAM policy detach capability is unavailable",
+                &Error::Auth(format!(
+                    "{IAM_POLICY_DETACH_CAPABILITY} is permission-denied"
+                )),
+                formatter,
+            );
+        }
+        Some(capability) => {
+            return emit_policy_detach_error(
+                "IAM policy detach capability is unavailable",
+                &Error::UnsupportedFeature(format!(
+                    "{} is {}{}",
+                    IAM_POLICY_DETACH_CAPABILITY,
+                    capability.availability,
+                    capability
+                        .reason
+                        .as_deref()
+                        .map(|reason| format!(": {reason}"))
+                        .unwrap_or_default()
+                )),
+                formatter,
+            );
+        }
+        None => {
+            return emit_policy_detach_error(
+                "IAM policy detach capability is unavailable",
+                &Error::UnsupportedFeature(format!(
+                    "{IAM_POLICY_DETACH_CAPABILITY} was not advertised by the server"
+                )),
+                formatter,
+            );
+        }
+    }
+
+    match iam.detach_policies(&request).await {
+        Ok(result) => output_policy_detach(&result, formatter),
+        Err(error) => emit_policy_detach_error("Failed to detach IAM policies", &error, formatter),
+    }
+}
+
+fn output_policy_detach(result: &PolicyDetachResult, formatter: &Formatter) -> ExitCode {
+    if formatter.is_json() {
+        formatter.json(&policy_detach_success(result));
+    } else {
+        formatter.println(&format!(
+            "Entity: {} {}",
+            result.entity,
+            formatter.style_name(&result.entity_name)
+        ));
+        formatter.println(&format!(
+            "Detached: {}",
+            display_names(&result.detached, formatter)
+        ));
+        formatter.println(&format!(
+            "Unchanged: {}",
+            display_names(&result.unchanged, formatter)
+        ));
+        formatter.println(&format!(
+            "Attached: {}",
+            display_names(&result.attached, formatter)
+        ));
+        formatter.println(&format!("Updated: {}", result.updated_at));
+    }
+    ExitCode::Success
+}
+
+fn policy_detach_success(result: &PolicyDetachResult) -> PolicyDetachSuccessOutput<'_> {
+    PolicyDetachSuccessOutput {
+        schema_version: 3,
+        output_type: "iam_policy_detach",
+        status: "success",
+        data: PolicyDetachOutput {
+            operation: "detach",
+            entity: PolicyDetachEntityOutput {
+                entity_type: result.entity,
+                name: &result.entity_name,
+            },
+            changed: !result.detached.is_empty(),
+            attached: &result.attached,
+            detached: &result.detached,
+            unchanged: &result.unchanged,
+            updated_at: result.updated_at,
+        },
+    }
+}
+
+fn emit_policy_detach_error(context: &str, error: &Error, formatter: &Formatter) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    let message = format!("{context}: {error}");
+    if formatter.is_json() {
+        let unsupported = code == ExitCode::UnsupportedFeature;
+        formatter.json_error(&PolicyDetachErrorOutput {
+            schema_version: 3,
+            output_type: "iam_policy_detach",
+            status: "error",
+            error: PolicyDetachErrorBody {
+                error_type: policy_entities_error_type(code),
+                message,
+                retryable: code == ExitCode::NetworkError,
+                capability: unsupported.then_some(IAM_POLICY_DETACH_CAPABILITY),
+                server: unsupported.then_some("rustfs"),
+                suggestion: policy_detach_error_suggestion(code),
+            },
+        });
+    } else {
+        formatter.error_with_code(code, &message);
+    }
+    code
+}
+
+const fn policy_detach_error_suggestion(code: ExitCode) -> Option<&'static str> {
+    match code {
+        ExitCode::UsageError => Some("Review the policy names and target selector, then retry."),
+        ExitCode::NetworkError => {
+            Some("The detach is idempotent; verify connectivity and retry the same request safely.")
+        }
+        ExitCode::AuthError => {
+            Some("Verify credentials and the attach-policy admin permission, then retry.")
+        }
+        ExitCode::NotFound => Some("Verify that the selected user or group still exists."),
+        ExitCode::Conflict => Some("Refresh the entity mapping and retry the detach."),
+        ExitCode::UnsupportedFeature => {
+            Some("Use a RustFS version that advertises builtin IAM policy detach.")
+        }
+        ExitCode::Interrupted => {
+            Some("Retry the same detach request; the operation is idempotent.")
+        }
+        ExitCode::Success | ExitCode::GeneralError => None,
     }
 }
 
@@ -716,6 +968,87 @@ mod tests {
         read_calls: AtomicUsize,
     }
 
+    #[derive(Clone, Copy)]
+    enum DetachResult {
+        Changed,
+        NoOp,
+        Auth,
+        Missing,
+    }
+
+    struct StubMutationApi {
+        availability: Option<CapabilityAvailability>,
+        result: DetachResult,
+        discovery_calls: AtomicUsize,
+        mutation_calls: AtomicUsize,
+    }
+
+    impl StubMutationApi {
+        fn report(&self) -> CapabilityReport {
+            CapabilityReport {
+                server_version: Some("1.0.0-beta.10".to_string()),
+                runtime_path: "/rustfs/admin/v4/runtime/capabilities".to_string(),
+                extensions_path: "/rustfs/admin/v4/extensions/catalog".to_string(),
+                cluster_snapshot_path: "/rustfs/admin/v4/cluster/snapshot".to_string(),
+                capabilities: self
+                    .availability
+                    .map(|availability| CapabilityEntry {
+                        name: IAM_POLICY_DETACH_CAPABILITY.to_string(),
+                        availability,
+                        reason: None,
+                    })
+                    .into_iter()
+                    .collect(),
+                extensions: Vec::new(),
+                cluster: ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                },
+            }
+        }
+    }
+
+    #[async_trait]
+    impl CapabilityApi for StubMutationApi {
+        async fn discover_capabilities(&self, _refresh: bool) -> Result<CapabilityReport> {
+            self.discovery_calls.fetch_add(1, Ordering::Relaxed);
+            Ok(self.report())
+        }
+    }
+
+    #[async_trait]
+    impl IamMutationApi for StubMutationApi {
+        async fn detach_policies(
+            &self,
+            request: &PolicyDetachRequest,
+        ) -> Result<PolicyDetachResult> {
+            self.mutation_calls.fetch_add(1, Ordering::Relaxed);
+            match self.result {
+                DetachResult::Changed => Ok(PolicyDetachResult {
+                    entity: request.entity,
+                    entity_name: request.entity_name.clone(),
+                    attached: Vec::new(),
+                    detached: vec!["diagnostics".to_string(), "readonly".to_string()],
+                    unchanged: vec!["writeonly".to_string()],
+                    updated_at: "2026-07-24T08:00:00Z".parse().expect("valid timestamp"),
+                }),
+                DetachResult::NoOp => Ok(PolicyDetachResult {
+                    entity: request.entity,
+                    entity_name: request.entity_name.clone(),
+                    attached: Vec::new(),
+                    detached: Vec::new(),
+                    unchanged: request.policies.clone(),
+                    updated_at: "2026-07-24T08:00:00Z".parse().expect("valid timestamp"),
+                }),
+                DetachResult::Auth => Err(Error::Auth("permission denied".to_string())),
+                DetachResult::Missing => {
+                    Err(Error::NotFound("IAM entity does not exist".to_string()))
+                }
+            }
+        }
+    }
+
     impl StubIamApi {
         fn report(&self) -> CapabilityReport {
             CapabilityReport {
@@ -798,6 +1131,19 @@ mod tests {
         }
     }
 
+    fn detach_args() -> DetachArgs {
+        DetachArgs {
+            alias: "local".to_string(),
+            policies: vec![
+                "readonly".to_string(),
+                "diagnostics".to_string(),
+                "writeonly".to_string(),
+            ],
+            user: Some("alice".to_string()),
+            group: None,
+        }
+    }
+
     fn quiet_formatter() -> Formatter {
         Formatter::new(crate::output::OutputConfig {
             quiet: true,
@@ -858,6 +1204,89 @@ mod tests {
         let value =
             serde_json::to_value(policy_entities_success(&result)).expect("serialize empty output");
         assert_valid(&value);
+    }
+
+    #[test]
+    fn policy_detach_multi_policy_and_noop_outputs_match_v3_schema() {
+        let changed = PolicyDetachResult {
+            entity: PolicyDetachEntity::User,
+            entity_name: "alice".to_string(),
+            attached: Vec::new(),
+            detached: vec!["diagnostics".to_string(), "readonly".to_string()],
+            unchanged: vec!["writeonly".to_string()],
+            updated_at: "2026-07-24T08:00:00Z".parse().expect("valid timestamp"),
+        };
+        let value = serde_json::to_value(policy_detach_success(&changed))
+            .expect("serialize changed output");
+        assert_valid(&value);
+        assert_eq!(value["data"]["changed"], true);
+        assert_eq!(value["data"]["detached"].as_array().map(Vec::len), Some(2));
+
+        let no_op = PolicyDetachResult {
+            detached: Vec::new(),
+            unchanged: vec!["readonly".to_string()],
+            ..changed
+        };
+        let value =
+            serde_json::to_value(policy_detach_success(&no_op)).expect("serialize no-op output");
+        assert_valid(&value);
+        assert_eq!(value["data"]["changed"], false);
+        assert_eq!(value["data"]["unchanged"][0], "readonly");
+    }
+
+    #[tokio::test]
+    async fn policy_detach_fails_closed_without_sending_mutation() {
+        let api = StubMutationApi {
+            availability: None,
+            result: DetachResult::Changed,
+            discovery_calls: AtomicUsize::new(0),
+            mutation_calls: AtomicUsize::new(0),
+        };
+        assert_eq!(
+            execute_detach_with_api(detach_args(), &api, &api, &quiet_formatter()).await,
+            ExitCode::UnsupportedFeature
+        );
+        assert_eq!(api.discovery_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(api.mutation_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn policy_detach_rejects_selectors_before_capability_discovery() {
+        let api = StubMutationApi {
+            availability: Some(CapabilityAvailability::Available),
+            result: DetachResult::Changed,
+            discovery_calls: AtomicUsize::new(0),
+            mutation_calls: AtomicUsize::new(0),
+        };
+        let mut invalid = detach_args();
+        invalid.policies = vec![" readonly ".to_string()];
+        assert_eq!(
+            execute_detach_with_api(invalid, &api, &api, &quiet_formatter()).await,
+            ExitCode::UsageError
+        );
+        assert_eq!(api.discovery_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(api.mutation_calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn policy_detach_preserves_auth_and_missing_entity_exit_codes() {
+        for (result, expected) in [
+            (DetachResult::Auth, ExitCode::AuthError),
+            (DetachResult::Missing, ExitCode::NotFound),
+            (DetachResult::NoOp, ExitCode::Success),
+        ] {
+            let api = StubMutationApi {
+                availability: Some(CapabilityAvailability::Available),
+                result,
+                discovery_calls: AtomicUsize::new(0),
+                mutation_calls: AtomicUsize::new(0),
+            };
+            assert_eq!(
+                execute_detach_with_api(detach_args(), &api, &api, &quiet_formatter()).await,
+                expected
+            );
+            assert_eq!(api.mutation_calls.load(Ordering::Relaxed), 1);
+        }
     }
 
     #[tokio::test]

--- a/crates/cli/tests/admin_policy_detach.rs
+++ b/crates/cli/tests/admin_policy_detach.rs
@@ -1,0 +1,83 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_sequence_test_server};
+
+const INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const RUNTIME_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+const DETACH_RESPONSE: &str = r#"{"policiesAttached":[],"policiesDetached":["readonly"],"updatedAt":"2026-07-24T08:00:00Z","secretKey":"must-not-leak"}"#;
+
+#[test]
+fn policy_detach_dispatches_typed_multi_policy_request_and_emits_v3_result() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", DETACH_RESPONSE),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "policy",
+            "detach",
+            "myalias",
+            "writeonly,readonly",
+            "--user",
+            "alice",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "iam_policy_detach");
+    assert_eq!(value["data"]["entity"]["type"], "user");
+    assert_eq!(value["data"]["entity"]["name"], "alice");
+    assert_eq!(value["data"]["detached"], serde_json::json!(["readonly"]));
+    assert_eq!(value["data"]["unchanged"], serde_json::json!(["writeonly"]));
+    assert!(!String::from_utf8_lossy(&output.stdout).contains("must-not-leak"));
+
+    for expected in [
+        ("GET", "/rustfs/admin/v3/info"),
+        ("GET", "/rustfs/admin/v4/runtime/capabilities"),
+        ("GET", "/rustfs/admin/v4/extensions/catalog"),
+        ("GET", "/rustfs/admin/v4/cluster/snapshot"),
+    ] {
+        let request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured capability request");
+        assert_eq!((request.method.as_str(), request.target.as_str()), expected);
+    }
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured detach request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(request.target, "/rustfs/admin/v3/idp/builtin/policy/detach");
+    let body: serde_json::Value =
+        serde_json::from_slice(&request.body).expect("detach body should be JSON");
+    assert_eq!(
+        body["policies"],
+        serde_json::json!(["readonly", "writeonly"])
+    );
+    assert_eq!(body["user"], "alice");
+    assert!(body.get("group").is_none());
+    handle.join().expect("admin test server finished");
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_policy_detach/empty.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_policy_detach/empty.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 3,
+  "type": "iam_policy_detach",
+  "status": "success",
+  "data": {
+    "operation": "detach",
+    "entity": {
+      "type": "group",
+      "name": "ops"
+    },
+    "changed": false,
+    "attached": [],
+    "detached": [],
+    "unchanged": ["readonly"],
+    "updated_at": "2026-07-24T08:00:00Z"
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_policy_detach/error.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_policy_detach/error.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 3,
+  "type": "iam_policy_detach",
+  "status": "error",
+  "error": {
+    "type": "auth_error",
+    "message": "Failed to detach IAM policies: permission denied",
+    "retryable": false,
+    "suggestion": "Verify credentials and the attach-policy admin permission, then retry."
+  }
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_policy_detach/success.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_policy_detach/success.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 3,
+  "type": "iam_policy_detach",
+  "status": "success",
+  "data": {
+    "operation": "detach",
+    "entity": {
+      "type": "user",
+      "name": "alice"
+    },
+    "changed": true,
+    "attached": [],
+    "detached": ["diagnostics", "readonly"],
+    "unchanged": ["writeonly"],
+    "updated_at": "2026-07-24T08:00:00Z"
+  }
+}

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -1036,6 +1036,11 @@ fn nested_subcommand_help_contract() {
             expected_tokens: &["--user", "--group"],
         },
         HelpCase {
+            args: &["admin", "policy", "detach"],
+            usage: "Usage: rc admin policy detach [OPTIONS] <ALIAS> <POLICIES>...",
+            expected_tokens: &["--user", "--group", "<POLICIES>..."],
+        },
+        HelpCase {
             args: &["admin", "policy", "entities"],
             usage: "Usage: rc admin policy entities [OPTIONS] <ALIAS>",
             expected_tokens: &["--user", "--group", "--policy"],

--- a/crates/cli/tests/output_schema_v3.rs
+++ b/crates/cli/tests/output_schema_v3.rs
@@ -26,6 +26,7 @@ const V3_FAMILIES: &[&str] = &[
     "replication_operations",
     "bucket_operations",
     "iam_policy_entities",
+    "iam_policy_detach",
 ];
 
 fn repository_root() -> PathBuf {

--- a/crates/core/src/admin/iam.rs
+++ b/crates/core/src/admin/iam.rs
@@ -1,4 +1,4 @@
-//! Typed contracts for read-only IAM policy-entity inspection.
+//! Typed contracts for IAM policy inspection and mutation.
 
 use async_trait::async_trait;
 use jiff::Timestamp;
@@ -9,14 +9,122 @@ use crate::{Error, Result};
 /// Capability name used to guard policy-entity inspection.
 pub const IAM_POLICY_ENTITIES_CAPABILITY: &str = "admin.iam.policy-entities";
 
+/// Capability name used to guard builtin policy detach mutations.
+pub const IAM_POLICY_DETACH_CAPABILITY: &str = "admin.iam.policy-detach";
+
 /// Maximum encoded size accepted for one policy-entity response.
 pub const MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+
+/// Maximum encoded size accepted for one policy detach response.
+pub const MAX_IAM_POLICY_DETACH_RESPONSE_BYTES: usize = 1024 * 1024;
+
+/// Maximum encoded size sent for one policy detach request.
+pub const MAX_IAM_POLICY_DETACH_REQUEST_BYTES: usize = 512 * 1024;
 
 /// Maximum number of selectors accepted in a single request.
 pub const MAX_IAM_POLICY_ENTITY_SELECTORS: usize = 1_000;
 
 /// Maximum UTF-8 byte length accepted for one selector.
 pub const MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES: usize = 1_024;
+
+/// Maximum number of policies accepted by one detach request.
+pub const MAX_IAM_POLICY_DETACH_POLICIES: usize = 1_000;
+
+/// Maximum UTF-8 byte length accepted for a detach selector.
+pub const MAX_IAM_POLICY_DETACH_SELECTOR_BYTES: usize = 1_024;
+
+/// A builtin IAM entity affected by a policy mutation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PolicyDetachEntity {
+    User,
+    Group,
+}
+
+impl std::fmt::Display for PolicyDetachEntity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::User => formatter.write_str("user"),
+            Self::Group => formatter.write_str("group"),
+        }
+    }
+}
+
+/// A validated, retry-safe builtin policy detach request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyDetachRequest {
+    pub policies: Vec<String>,
+    pub entity: PolicyDetachEntity,
+    pub entity_name: String,
+}
+
+impl PolicyDetachRequest {
+    /// Validate and normalize selectors before any network request is made.
+    pub fn new(
+        mut policies: Vec<String>,
+        entity: PolicyDetachEntity,
+        entity_name: String,
+    ) -> Result<Self> {
+        validate_detach_selector("entity", &entity_name)?;
+        if policies.is_empty() {
+            return Err(Error::InvalidPath(
+                "At least one policy name is required".to_string(),
+            ));
+        }
+        if policies.len() > MAX_IAM_POLICY_DETACH_POLICIES {
+            return Err(Error::InvalidPath(format!(
+                "Policy detach accepts at most {MAX_IAM_POLICY_DETACH_POLICIES} policies"
+            )));
+        }
+        for policy in &policies {
+            validate_detach_selector("policy", policy)?;
+        }
+        policies.sort();
+        policies.dedup();
+        Ok(Self {
+            policies,
+            entity,
+            entity_name,
+        })
+    }
+}
+
+fn validate_detach_selector(kind: &str, selector: &str) -> Result<()> {
+    if selector.is_empty() || selector.trim() != selector {
+        return Err(Error::InvalidPath(format!(
+            "Policy detach {kind} selector cannot be empty or contain surrounding whitespace"
+        )));
+    }
+    if selector.len() > MAX_IAM_POLICY_DETACH_SELECTOR_BYTES {
+        return Err(Error::InvalidPath(format!(
+            "Policy detach {kind} selector exceeds {MAX_IAM_POLICY_DETACH_SELECTOR_BYTES} bytes"
+        )));
+    }
+    if selector.chars().any(char::is_control) {
+        return Err(Error::InvalidPath(format!(
+            "Policy detach {kind} selector cannot contain control characters"
+        )));
+    }
+    Ok(())
+}
+
+/// Normalized outcome for an idempotent builtin policy detach.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyDetachResult {
+    pub entity: PolicyDetachEntity,
+    pub entity_name: String,
+    pub attached: Vec<String>,
+    pub detached: Vec<String>,
+    pub unchanged: Vec<String>,
+    pub updated_at: Timestamp,
+}
+
+/// Typed builtin IAM mutation operations.
+#[async_trait]
+pub trait IamMutationApi: Send + Sync {
+    /// Detach only the requested policies from exactly one user or group.
+    async fn detach_policies(&self, request: &PolicyDetachRequest) -> Result<PolicyDetachResult>;
+}
 
 /// Filters for a policy-entity inspection request.
 ///
@@ -283,5 +391,33 @@ mod tests {
         )
         .expect("decode invalid response");
         assert!(matches!(invalid.normalize(), Err(Error::General(_))));
+    }
+
+    #[test]
+    fn detach_request_normalizes_policies_and_rejects_ambiguous_selectors() {
+        let request = PolicyDetachRequest::new(
+            vec!["write".to_string(), "read".to_string(), "write".to_string()],
+            PolicyDetachEntity::User,
+            "alice".to_string(),
+        )
+        .expect("valid detach request");
+        assert_eq!(request.policies, ["read", "write"]);
+
+        assert!(matches!(
+            PolicyDetachRequest::new(
+                vec!["read".to_string()],
+                PolicyDetachEntity::Group,
+                " ops ".to_string(),
+            ),
+            Err(Error::InvalidPath(_))
+        ));
+        assert!(matches!(
+            PolicyDetachRequest::new(
+                vec!["".to_string()],
+                PolicyDetachEntity::User,
+                "alice".to_string(),
+            ),
+            Err(Error::InvalidPath(_))
+        ));
     }
 }

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -48,10 +48,13 @@ pub use diagnostics::{
     MAX_DIAGNOSTIC_RESPONSE_BYTES,
 };
 pub use iam::{
-    GroupPolicyEntities, IAM_POLICY_ENTITIES_CAPABILITY, IamReadApi,
-    MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES, MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES,
-    MAX_IAM_POLICY_ENTITY_SELECTORS, PolicyEntities, PolicyEntitiesQuery, PolicyEntitiesResult,
-    UserPolicyEntities,
+    GroupPolicyEntities, IAM_POLICY_DETACH_CAPABILITY, IAM_POLICY_ENTITIES_CAPABILITY,
+    IamMutationApi, IamReadApi, MAX_IAM_POLICY_DETACH_POLICIES,
+    MAX_IAM_POLICY_DETACH_REQUEST_BYTES, MAX_IAM_POLICY_DETACH_RESPONSE_BYTES,
+    MAX_IAM_POLICY_DETACH_SELECTOR_BYTES, MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES,
+    MAX_IAM_POLICY_ENTITY_SELECTOR_BYTES, MAX_IAM_POLICY_ENTITY_SELECTORS, PolicyDetachEntity,
+    PolicyDetachRequest, PolicyDetachResult, PolicyEntities, PolicyEntitiesQuery,
+    PolicyEntitiesResult, UserPolicyEntities,
 };
 pub use kms::{
     KmsApi, KmsBackendKind, KmsCacheSummary, KmsCancelKeyDeletionResult, KmsConfigSummary,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -20,19 +20,22 @@ use rc_core::admin::{
     ConfigMutationResult, CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus,
     DetailedHealthSnapshot, DiagnosticCapability, DiagnosticReadApi, ExtensionsCatalog, Group,
     GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus, HealTaskRequest,
-    IAM_POLICY_ENTITIES_CAPABILITY, IamReadApi, KmsApi, KmsBackendKind, KmsCacheSummary,
-    KmsCancelKeyDeletionResult, KmsConfigSummary, KmsConfigureRequest, KmsCreateKeyRequest,
-    KmsCreateKeyResult, KmsDeleteKeyRequest, KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState,
-    KmsKeyUsage, KmsServiceState, KmsStatus, MAX_DIAGNOSTIC_RESPONSE_BYTES,
-    MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
-    MAX_METRICS_SAMPLES, MAX_OIDC_RESPONSE_BYTES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
+    IAM_POLICY_DETACH_CAPABILITY, IAM_POLICY_ENTITIES_CAPABILITY, IamMutationApi, IamReadApi,
+    KmsApi, KmsBackendKind, KmsCacheSummary, KmsCancelKeyDeletionResult, KmsConfigSummary,
+    KmsConfigureRequest, KmsCreateKeyRequest, KmsCreateKeyResult, KmsDeleteKeyRequest,
+    KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState, KmsKeyUsage, KmsServiceState, KmsStatus,
+    MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_IAM_POLICY_DETACH_REQUEST_BYTES,
+    MAX_IAM_POLICY_DETACH_RESPONSE_BYTES, MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES,
+    MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES, MAX_METRICS_SAMPLES,
+    MAX_OIDC_RESPONSE_BYTES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REQUEST_BYTES,
     MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES, ManualTransitionRunRequest,
     ManualTransitionRunResponse, MetricsBatch, MetricsQuery, ModuleSwitches, ObservabilityApi,
     OidcMutationApi, OidcMutationRequest, OidcMutationResult, OidcProvider, OidcProviderList,
     OidcReadApi, OidcValidationRequest, OidcValidationResult, PeerSiteSpec, Policy,
-    PolicyEntitiesQuery, PolicyEntitiesResult, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
-    RealtimeMetrics, RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
+    PolicyDetachEntity, PolicyDetachRequest, PolicyDetachResult, PolicyEntitiesQuery,
+    PolicyEntitiesResult, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RealtimeMetrics,
+    RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
     ReplicationDiffApi, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
     ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
     SiteReplicationInfo, SiteReplicationPeer, SiteReplicationResyncOperation,
@@ -55,6 +58,25 @@ struct BoundedJsonResponse {
     max_bytes: usize,
     name: &'static str,
     error_mapper: fn(&AdminClient, StatusCode, &str) -> Error,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyDetachWireRequest<'a> {
+    policies: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    user: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    group: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct PolicyDetachWireResponse {
+    #[serde(default)]
+    policies_attached: Vec<String>,
+    #[serde(default)]
+    policies_detached: Vec<String>,
+    updated_at: jiff::Timestamp,
 }
 
 impl AsRef<[u8]> for SensitiveRequestBody {
@@ -1048,6 +1070,58 @@ impl AdminClient {
             )),
         }
     }
+
+    fn map_iam_policy_detach_error(&self, status: StatusCode, body: &str) -> Error {
+        let structured = parse_admin_error(body);
+        let is_missing_entity = structured.as_ref().is_some_and(|error| {
+            let code = error
+                .code
+                .as_deref()
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            let message = error
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .to_ascii_lowercase();
+            code.contains("nosuchuser")
+                || code.contains("nosuchgroup")
+                || message.contains("user not exist")
+                || message.contains("group not exist")
+                || message.contains("no such user")
+                || message.contains("no such group")
+        });
+        if is_missing_entity {
+            return Error::NotFound("The requested IAM entity does not exist".to_string());
+        }
+
+        match status {
+            StatusCode::METHOD_NOT_ALLOWED | StatusCode::NOT_IMPLEMENTED => {
+                Error::UnsupportedFeature(
+                    "Builtin IAM policy detach is not supported by this RustFS server".to_string(),
+                )
+            }
+            StatusCode::NOT_FOUND if structured.is_none() => Error::UnsupportedFeature(
+                "Builtin IAM policy detach is not supported by this RustFS server".to_string(),
+            ),
+            StatusCode::NOT_FOUND => {
+                Error::NotFound("The requested IAM entity was not found".to_string())
+            }
+            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                Error::Auth("Permission denied for IAM policy detach".to_string())
+            }
+            StatusCode::BAD_REQUEST => {
+                Error::InvalidPath("RustFS rejected the policy detach selectors".to_string())
+            }
+            StatusCode::CONFLICT => {
+                Error::Conflict("IAM policy mappings changed concurrently".to_string())
+            }
+            _ => Error::Network(format!(
+                "IAM policy detach failed with HTTP {}",
+                status.as_u16()
+            )),
+        }
+    }
 }
 
 fn site_replication_response_rejected(
@@ -1913,6 +1987,11 @@ fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<C
     });
     capabilities.push(CapabilityEntry {
         name: IAM_POLICY_ENTITIES_CAPABILITY.to_string(),
+        availability: CapabilityAvailability::Available,
+        reason: None,
+    });
+    capabilities.push(CapabilityEntry {
+        name: IAM_POLICY_DETACH_CAPABILITY.to_string(),
         availability: CapabilityAvailability::Available,
         reason: None,
     });
@@ -2823,6 +2902,97 @@ impl OidcMutationApi for AdminClient {
 }
 
 #[async_trait]
+impl IamMutationApi for AdminClient {
+    async fn detach_policies(&self, request: &PolicyDetachRequest) -> Result<PolicyDetachResult> {
+        let request = PolicyDetachRequest::new(
+            request.policies.clone(),
+            request.entity,
+            request.entity_name.clone(),
+        )?;
+        let wire = PolicyDetachWireRequest {
+            policies: &request.policies,
+            user: (request.entity == PolicyDetachEntity::User)
+                .then_some(request.entity_name.as_str()),
+            group: (request.entity == PolicyDetachEntity::Group)
+                .then_some(request.entity_name.as_str()),
+        };
+        let body = serde_json::to_vec(&wire).map_err(Error::Json)?;
+        if body.len() > MAX_IAM_POLICY_DETACH_REQUEST_BYTES {
+            return Err(Error::InvalidPath(format!(
+                "Policy detach request exceeds the {MAX_IAM_POLICY_DETACH_REQUEST_BYTES}-byte limit"
+            )));
+        }
+        let response: PolicyDetachWireResponse = self
+            .request_bounded_json(
+                Method::POST,
+                "/idp/builtin/policy/detach",
+                None,
+                Some(&body),
+                BoundedJsonResponse {
+                    max_bytes: MAX_IAM_POLICY_DETACH_RESPONSE_BYTES,
+                    name: "IAM policy detach response",
+                    error_mapper: Self::map_iam_policy_detach_error,
+                },
+            )
+            .await
+            .map_err(|error| match error {
+                Error::Json(_) => {
+                    Error::General("RustFS returned a malformed policy detach response".to_string())
+                }
+                other => other,
+            })?;
+
+        let mut attached = response.policies_attached;
+        let mut detached = response.policies_detached;
+        normalize_policy_detach_response_names("attached", &mut attached)?;
+        normalize_policy_detach_response_names("detached", &mut detached)?;
+        if attached
+            .iter()
+            .any(|policy| !request.policies.contains(policy))
+            || detached
+                .iter()
+                .any(|policy| !request.policies.contains(policy))
+        {
+            return Err(Error::General(
+                "RustFS policy detach response contains an unrequested policy".to_string(),
+            ));
+        }
+        if attached.iter().any(|policy| detached.contains(policy)) {
+            return Err(Error::General(
+                "RustFS policy detach response reports a policy as both attached and detached"
+                    .to_string(),
+            ));
+        }
+
+        let unchanged = request
+            .policies
+            .iter()
+            .filter(|policy| !detached.contains(policy))
+            .cloned()
+            .collect();
+        Ok(PolicyDetachResult {
+            entity: request.entity,
+            entity_name: request.entity_name,
+            attached,
+            detached,
+            unchanged,
+            updated_at: response.updated_at,
+        })
+    }
+}
+
+fn normalize_policy_detach_response_names(kind: &str, names: &mut Vec<String>) -> Result<()> {
+    if names.iter().any(|name| name.trim().is_empty()) {
+        return Err(Error::General(format!(
+            "RustFS policy detach response contains an empty {kind} policy"
+        )));
+    }
+    names.sort();
+    names.dedup();
+    Ok(())
+}
+
+#[async_trait]
 impl DiagnosticReadApi for AdminClient {
     async fn health_snapshot(&self) -> Result<DetailedHealthSnapshot> {
         self.request_bounded_json_url(Method::GET, self.admin_url("/healthinfo"))
@@ -3449,14 +3619,15 @@ impl AdminApi for AdminClient {
         entity_type: PolicyEntity,
         entity_name: &str,
     ) -> Result<()> {
-        // Detach by setting empty policy
-        // RustFS replaces the previous policy association when a new one is set.
-        // For detach, we need to get current policies and remove the specified ones
-        let _ = (policy_names, entity_type, entity_name);
-        Err(Error::UnsupportedFeature(
-            "Policy detach not directly supported. Use attach with remaining policies instead."
-                .to_string(),
-        ))
+        let entity = match entity_type {
+            PolicyEntity::User => PolicyDetachEntity::User,
+            PolicyEntity::Group => PolicyDetachEntity::Group,
+        };
+        let request =
+            PolicyDetachRequest::new(policy_names.to_vec(), entity, entity_name.to_string())?;
+        IamMutationApi::detach_policies(self, &request)
+            .await
+            .map(|_| ())
     }
 
     // ==================== Group Operations ====================
@@ -4326,6 +4497,10 @@ mod tests {
         assert!(report.cluster.summary.is_some());
         assert!(report.capabilities.iter().any(|capability| {
             capability.name == IAM_POLICY_ENTITIES_CAPABILITY
+                && capability.availability == CapabilityAvailability::Available
+        }));
+        assert!(report.capabilities.iter().any(|capability| {
+            capability.name == IAM_POLICY_DETACH_CAPABILITY
                 && capability.availability == CapabilityAvailability::Available
         }));
         assert!(report.capabilities.iter().any(|capability| {
@@ -5285,6 +5460,162 @@ mod tests {
             matches!(oversized, Error::General(message) if message.contains("IAM policy-entity response exceeded"))
         );
         handle.join().expect("join oversized response server");
+    }
+
+    #[tokio::test]
+    async fn iam_policy_detach_sends_one_typed_target_and_normalizes_multi_policy_result() {
+        let response = r#"{
+            "policiesAttached":[],
+            "policiesDetached":["readonly","diagnostics","readonly"],
+            "updatedAt":"2026-07-24T08:00:00Z"
+        }"#;
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = PolicyDetachRequest::new(
+            vec![
+                "writeonly".to_string(),
+                "readonly".to_string(),
+                "diagnostics".to_string(),
+            ],
+            PolicyDetachEntity::Group,
+            "ops".to_string(),
+        )
+        .expect("valid detach request");
+        let result = client
+            .detach_policies(&request)
+            .await
+            .expect("policy detach request");
+
+        let captured = receiver.recv().expect("captured request");
+        assert_eq!(captured.method, "POST");
+        assert_eq!(
+            captured.target,
+            "/rustfs/admin/v3/idp/builtin/policy/detach"
+        );
+        let body: serde_json::Value =
+            serde_json::from_slice(&captured.body).expect("typed JSON request");
+        assert_eq!(body["group"], "ops");
+        assert!(body.get("user").is_none());
+        assert_eq!(
+            body["policies"],
+            serde_json::json!(["diagnostics", "readonly", "writeonly"])
+        );
+        assert_eq!(result.detached, ["diagnostics", "readonly"]);
+        assert_eq!(result.unchanged, ["writeonly"]);
+        assert!(result.attached.is_empty());
+        assert_eq!(result.entity, PolicyDetachEntity::Group);
+        assert_eq!(result.entity_name, "ops");
+        handle.join().expect("join policy detach server");
+    }
+
+    #[tokio::test]
+    async fn iam_policy_detach_noop_retry_reports_every_requested_policy_unchanged() {
+        let response = r#"{"policiesDetached":[],"updatedAt":"2026-07-24T08:00:00Z"}"#;
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let request = PolicyDetachRequest::new(
+            vec!["readonly".to_string(), "diagnostics".to_string()],
+            PolicyDetachEntity::User,
+            "alice".to_string(),
+        )
+        .expect("valid detach request");
+        let result = client
+            .detach_policies(&request)
+            .await
+            .expect("idempotent no-op detach");
+
+        assert!(result.detached.is_empty());
+        assert_eq!(result.unchanged, ["diagnostics", "readonly"]);
+        handle.join().expect("join policy detach server");
+    }
+
+    #[tokio::test]
+    async fn iam_policy_detach_classifies_missing_entity_and_access_denial() {
+        for (status, body, expected) in [
+            (
+                "400 Bad Request",
+                r#"{"Code":"InvalidArgument","Message":"user not exist"}"#,
+                "missing",
+            ),
+            (
+                "403 Forbidden",
+                r#"{"Code":"AccessDenied","Message":"do not echo this"}"#,
+                "auth",
+            ),
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server(status, body);
+            let client = admin_client_for_endpoint(&endpoint);
+            let request = PolicyDetachRequest::new(
+                vec!["readonly".to_string()],
+                PolicyDetachEntity::User,
+                "missing".to_string(),
+            )
+            .expect("valid detach request");
+            let error = client
+                .detach_policies(&request)
+                .await
+                .expect_err("detach should fail");
+            match expected {
+                "missing" => assert!(matches!(error, Error::NotFound(_))),
+                "auth" => assert!(matches!(error, Error::Auth(_))),
+                _ => unreachable!(),
+            }
+            assert!(!error.to_string().contains("do not echo this"));
+            handle.join().expect("join policy detach error server");
+        }
+    }
+
+    #[tokio::test]
+    async fn iam_policy_detach_rejects_malformed_and_oversized_responses() {
+        let request = PolicyDetachRequest::new(
+            vec!["readonly".to_string()],
+            PolicyDetachEntity::User,
+            "alice".to_string(),
+        )
+        .expect("valid detach request");
+
+        let (endpoint, _receiver, handle) = start_admin_test_server("200 OK", "{");
+        let malformed = admin_client_for_endpoint(&endpoint)
+            .detach_policies(&request)
+            .await
+            .expect_err("malformed response must fail");
+        assert!(
+            matches!(malformed, Error::General(message) if message.contains("malformed policy detach response"))
+        );
+        handle.join().expect("join malformed detach server");
+
+        let (endpoint, _receiver, handle) =
+            start_admin_declared_length_server("200 OK", MAX_IAM_POLICY_DETACH_RESPONSE_BYTES + 1);
+        let oversized = admin_client_for_endpoint(&endpoint)
+            .detach_policies(&request)
+            .await
+            .expect_err("oversized response must fail");
+        assert!(
+            matches!(oversized, Error::General(message) if message.contains("IAM policy detach response exceeded"))
+        );
+        handle.join().expect("join oversized detach server");
+    }
+
+    #[tokio::test]
+    async fn iam_policy_detach_rejects_oversized_request_before_network_access() {
+        let policies = (0..rc_core::admin::MAX_IAM_POLICY_DETACH_POLICIES)
+            .map(|index| {
+                format!(
+                    "{index:04}-{}",
+                    "p".repeat(rc_core::admin::MAX_IAM_POLICY_DETACH_SELECTOR_BYTES - 5)
+                )
+            })
+            .collect();
+        let request =
+            PolicyDetachRequest::new(policies, PolicyDetachEntity::User, "alice".to_string())
+                .expect("individual selectors fit their limits");
+        let error = admin_client_for_endpoint("http://127.0.0.1:9")
+            .detach_policies(&request)
+            .await
+            .expect_err("oversized request must fail locally");
+        assert!(
+            matches!(error, Error::InvalidPath(message) if message.contains("request exceeds"))
+        );
     }
 
     #[test]

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -40,7 +40,8 @@ rc admin decommission <start|cancel|clear> <ALIAS> <POOL> [OPTIONS]
 rc admin decommission status <ALIAS> [POOL] [OPTIONS]
 rc admin rebalance <start|status|stop> <ALIAS>
 rc admin user <ls|add|info|rm|enable|disable> ...
-rc admin policy <ls|create|info|rm|attach|entities> ...
+rc admin policy <ls|create|info|rm|attach|detach|entities> ...
+rc admin policy detach <ALIAS> <POLICY>... (--user USER | --group GROUP)
 rc admin policy entities <ALIAS> [--user USER]... [--group GROUP]... [--policy POLICY]...
 rc admin group <ls|add|info|rm|enable|disable|add-members|rm-members> ...
 rc admin service-account <ls|create|info|rm> ...
@@ -192,6 +193,12 @@ Create a user and attach a policy:
 ```bash
 rc admin user add local analyst STRONG_PASSWORD
 rc admin policy attach local readonly --user analyst
+
+# Detach several policies from exactly one user.
+rc admin policy detach local readonly diagnostics --user analyst
+
+# A comma-separated policy list is accepted too.
+rc admin policy detach local readonly,diagnostics --group operations
 ```
 
 Inspect policy-to-entity mappings:
@@ -297,6 +304,25 @@ only the server timestamp, user mappings, inherited group mappings, group
 mappings, and policy mappings. Unknown response fields are discarded, and
 secret keys, session tokens, credentials, and raw server error bodies are never
 included in output.
+
+## IAM Policy Detach
+
+`rc admin policy detach` uses the native RustFS
+`POST /rustfs/admin/v3/idp/builtin/policy/detach` mutation. The target must be
+exactly one `--user` or `--group`; policy and entity selectors are validated
+before capability discovery or mutation traffic. The command fails closed
+unless the server advertises `admin.iam.policy-detach` as available.
+
+Detach is idempotent. JSON schema-v3 output uses the `iam_policy_detach` family
+and reports the affected entity, the server-reported `attached` and `detached`
+sets, and an `unchanged` set derived from requested policies that were already
+detached. A successful retry therefore returns `changed: false` instead of
+turning a prior success into an error. Requests are bounded to 512 KiB and
+responses to 1 MiB;
+malformed and oversized replies fail without displaying their contents.
+Authentication denial, missing entities, unsupported routes, validation
+failures, conflicts, and network failures retain distinct error classes and
+exit codes.
 
 ## KMS Key Lifecycle Workflow
 

--- a/docs/reference/rc/output.md
+++ b/docs/reference/rc/output.md
@@ -6,7 +6,7 @@
 | --- | --- | --- |
 | [`output_v1.json`](../../../schemas/output_v1.json) | Original S3 and alias command output | Preserved unchanged |
 | [`output_v2.json`](../../../schemas/output_v2.json) | Existing cluster and administrative output | Preserved unchanged |
-| [`output_v3.json`](../../../schemas/output_v3.json) | New capability, version, lock, multipart, watch, health, usage, metrics, diagnostic snapshot, scanner-status, storage-info, KMS, OIDC, admin-operation, replication, and bucket-operation families | Contract for new implementations |
+| [`output_v3.json`](../../../schemas/output_v3.json) | New capability, version, lock, multipart, watch, health, usage, metrics, diagnostic snapshot, scanner-status, storage-info, KMS, OIDC, IAM policy, admin-operation, replication, and bucket-operation families | Contract for new implementations |
 
 Adding v3 does not silently change the JSON emitted by existing commands. Each command implementation must document when it adopts v3. Consumers should choose a parser from the command's documented output version instead of inferring a version from the installed `rc` release.
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -43,7 +43,8 @@
         "cluster_snapshot",
         "extension_catalog",
         "oidc",
-        "iam_policy_entities"
+        "iam_policy_entities",
+        "iam_policy_detach"
       ]
     },
     "pagination": {
@@ -1060,6 +1061,39 @@
         }
       }
     },
+    "iamPolicyDetachData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "operation", "entity", "changed", "attached", "detached", "unchanged", "updated_at"
+      ],
+      "properties": {
+        "operation": { "const": "detach" },
+        "entity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "name"],
+          "properties": {
+            "type": { "enum": ["user", "group"] },
+            "name": { "type": "string", "minLength": 1 }
+          }
+        },
+        "changed": { "type": "boolean" },
+        "attached": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "detached": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "unchanged": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "updated_at": { "$ref": "#/definitions/timestamp" }
+      }
+    },
     "replicationDiffEntry": {
       "type": "object",
       "required": [
@@ -1346,6 +1380,17 @@
           "properties": {
             "type": { "const": "iam_policy_entities" },
             "data": { "$ref": "#/definitions/iamPolicyEntitiesData" }
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        { "$ref": "#/definitions/successEnvelope" },
+        {
+          "properties": {
+            "type": { "const": "iam_policy_detach" },
+            "data": { "$ref": "#/definitions/iamPolicyDetachData" }
           }
         }
       ]


### PR DESCRIPTION
## Summary

- add `rc admin policy detach` with exactly one user/group selector and deterministic multi-policy input
- use typed, bounded admin request/response handling and fail closed when the detach capability is absent
- report detached, still-attached, and unchanged policies with stable human and output-v3 results
- preserve idempotent retry behavior and distinguish auth, not-found, unsupported, validation, conflict, and network failures

## BREAKING contract update

The protected command reference is extended with the new detach subcommand and its selector rules. Existing commands and output schemas remain backward compatible.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

Closes rustfs/backlog#1492
Refs rustfs/backlog#1380