### PR TITLE
feat(admin): add bulk access-key inspection

### DIFF
--- a/crates/cli/src/commands/admin/access_key.rs
+++ b/crates/cli/src/commands/admin/access_key.rs
@@ -2,18 +2,32 @@
 //!
 //! Commands for resolving an access key to its IAM identity type and metadata.
 
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
+use serde::Serialize;
 
 use super::get_admin_client;
 use crate::exit_code::ExitCode;
 use crate::output::Formatter;
-use rc_core::admin::{AccessKeyDetails, AccessKeyInfo, AdminApi, OpenIdAccessKeyInfo};
+use rc_core::Error;
+use rc_core::admin::{
+    AccessKeyDetails, AccessKeyInfo, AccessKeyListType, AccessKeyProvider, AccessKeyRecord,
+    AdminApi, BulkAccessKeyApi, BulkAccessKeyQuery, CapabilityApi, CapabilityAvailability,
+    IAM_ACCESS_KEYS_BULK_CAPABILITY, MAX_IAM_ACCESS_KEY_RESULTS, MAX_IAM_ACCESS_KEY_SELECTORS,
+    OpenIdAccessKeyInfo,
+};
+
+const DEFAULT_PAGE_LIMIT: usize = 1_000;
+const DEFAULT_REQUEST_BATCH_SIZE: usize = 100;
 
 /// Access key inspection subcommands.
 #[derive(Subcommand, Debug)]
 pub enum AccessKeyCommands {
     /// Get access key information
     Info(InfoArgs),
+
+    /// List access keys across capability-advertised identity providers
+    #[command(name = "ls", alias = "list")]
+    List(ListArgs),
 }
 
 #[derive(clap::Args, Debug)]
@@ -25,10 +39,545 @@ pub struct InfoArgs {
     pub access_key: String,
 }
 
+#[derive(clap::Args, Debug, Clone)]
+pub struct ListArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Provider scope; repeat to inspect multiple providers
+    #[arg(long, value_enum, value_delimiter = ',', default_value = "builtin")]
+    pub provider: Vec<ProviderArg>,
+
+    /// Parent identity to inspect; may be repeated
+    #[arg(long, conflicts_with = "all")]
+    pub user: Vec<String>,
+
+    /// Inspect all parent identities visible to the caller
+    #[arg(long)]
+    pub all: bool,
+
+    /// Access-key class to include
+    #[arg(long, value_enum, default_value = "all")]
+    pub key_type: KeyTypeArg,
+
+    /// Zero-based offset into the deterministic aggregate result
+    #[arg(long, default_value_t = 0)]
+    pub offset: usize,
+
+    /// Maximum records emitted in this output page
+    #[arg(long, default_value_t = DEFAULT_PAGE_LIMIT)]
+    pub limit: usize,
+
+    /// Maximum user selectors sent in one bounded server request
+    #[arg(long, default_value_t = DEFAULT_REQUEST_BATCH_SIZE)]
+    pub request_batch_size: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProviderArg {
+    Builtin,
+    Ldap,
+    Openid,
+}
+
+impl From<ProviderArg> for AccessKeyProvider {
+    fn from(value: ProviderArg) -> Self {
+        match value {
+            ProviderArg::Builtin => Self::Builtin,
+            ProviderArg::Ldap => Self::Ldap,
+            ProviderArg::Openid => Self::Openid,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum KeyTypeArg {
+    All,
+    #[value(name = "users-only")]
+    UsersOnly,
+    Sts,
+    #[value(name = "service-account")]
+    ServiceAccount,
+}
+
+impl From<KeyTypeArg> for AccessKeyListType {
+    fn from(value: KeyTypeArg) -> Self {
+        match value {
+            KeyTypeArg::All => Self::All,
+            KeyTypeArg::UsersOnly => Self::UsersOnly,
+            KeyTypeArg::Sts => Self::StsOnly,
+            KeyTypeArg::ServiceAccount => Self::ServiceAccountsOnly,
+        }
+    }
+}
+
 /// Execute an access key subcommand.
 pub async fn execute(cmd: AccessKeyCommands, formatter: &Formatter) -> ExitCode {
     match cmd {
         AccessKeyCommands::Info(args) => execute_info(args, formatter).await,
+        AccessKeyCommands::List(args) => execute_list(args, formatter).await,
+    }
+}
+
+async fn execute_list(args: ListArgs, formatter: &Formatter) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+    execute_list_with_apis(args, &client, &client, formatter).await
+}
+
+async fn execute_list_with_apis(
+    args: ListArgs,
+    capabilities: &dyn CapabilityApi,
+    api: &dyn BulkAccessKeyApi,
+    formatter: &Formatter,
+) -> ExitCode {
+    if let Err(error) = validate_list_args(&args) {
+        return emit_list_error(&error, None, None, formatter);
+    }
+
+    let mut providers = args
+        .provider
+        .iter()
+        .copied()
+        .map(AccessKeyProvider::from)
+        .collect::<Vec<_>>();
+    providers.sort();
+    providers.dedup();
+
+    let report = match capabilities.discover_capabilities(false).await {
+        Ok(report) => report,
+        Err(error) => {
+            let error = sanitized_access_key_error(&error);
+            return emit_list_error(
+                &error,
+                Some("Failed to discover bulk access-key capabilities"),
+                None,
+                formatter,
+            );
+        }
+    };
+
+    let mut records = Vec::new();
+    let mut failures = Vec::new();
+    for provider in providers {
+        let capability = provider.capability();
+        match report.capability(capability) {
+            Some(entry) if entry.availability == CapabilityAvailability::Available => {}
+            Some(entry) if entry.availability == CapabilityAvailability::PermissionDenied => {
+                failures.push(AccessKeyFailure::new(
+                    provider,
+                    "capability",
+                    &Error::Auth("Provider capability is permission-denied".to_string()),
+                ));
+                continue;
+            }
+            _ => {
+                failures.push(AccessKeyFailure::new(
+                    provider,
+                    "capability",
+                    &Error::UnsupportedFeature(
+                        "Provider bulk access-key route was not advertised as available"
+                            .to_string(),
+                    ),
+                ));
+                continue;
+            }
+        }
+
+        let batches = selector_batches(&args.user, args.request_batch_size);
+        for users in batches {
+            let query = BulkAccessKeyQuery {
+                provider,
+                users: users.to_vec(),
+                all: args.all,
+                list_type: args.key_type.into(),
+            };
+            match api.list_access_keys_bulk(&query).await {
+                Ok(mut batch_records) => records.append(&mut batch_records),
+                Err(error) => {
+                    let targets = if users.is_empty() {
+                        vec![if args.all { "all" } else { "self" }]
+                    } else {
+                        users.iter().map(String::as_str).collect()
+                    };
+                    failures.extend(
+                        targets
+                            .into_iter()
+                            .map(|target| AccessKeyFailure::new(provider, target, &error)),
+                    );
+                }
+            }
+        }
+    }
+
+    if records.len() > MAX_IAM_ACCESS_KEY_RESULTS {
+        return emit_list_error(
+            &Error::General(format!(
+                "aggregate bulk access-key result exceeds {MAX_IAM_ACCESS_KEY_RESULTS} records"
+            )),
+            Some("RustFS returned too many aggregate access-key records"),
+            None,
+            formatter,
+        );
+    }
+
+    records.sort_by(|left, right| {
+        (
+            left.provider,
+            left.parent_user.as_str(),
+            left.kind,
+            left.access_key.as_str(),
+        )
+            .cmp(&(
+                right.provider,
+                right.parent_user.as_str(),
+                right.kind,
+                right.access_key.as_str(),
+            ))
+    });
+    records.dedup_by(|left, right| {
+        left.provider == right.provider
+            && left.parent_user == right.parent_user
+            && left.kind == right.kind
+            && left.access_key == right.access_key
+    });
+    failures.sort_by(|left, right| {
+        (
+            left.provider,
+            left.target.as_str(),
+            left.error_type,
+            left.message,
+        )
+            .cmp(&(
+                right.provider,
+                right.target.as_str(),
+                right.error_type,
+                right.message,
+            ))
+    });
+
+    let total = records.len();
+    let page = records
+        .iter()
+        .skip(args.offset)
+        .take(args.limit)
+        .cloned()
+        .collect::<Vec<_>>();
+    let consumed = args.offset.saturating_add(page.len());
+    let truncated = consumed < total;
+    let data = AccessKeyListData {
+        operation: "list",
+        keys: page,
+        failures,
+        pagination: AccessKeyPagination {
+            offset: args.offset,
+            limit: args.limit,
+            total,
+            truncated,
+            next_offset: truncated.then_some(consumed),
+        },
+    };
+
+    if data.failures.is_empty() {
+        output_list_success(&data, formatter);
+        return ExitCode::Success;
+    }
+
+    let code = aggregate_failure_code(&data);
+    output_list_failure(code, &data, formatter);
+    code
+}
+
+fn validate_list_args(args: &ListArgs) -> Result<(), Error> {
+    if args.provider.is_empty() {
+        return Err(Error::InvalidPath(
+            "at least one access-key provider is required".to_string(),
+        ));
+    }
+    if args.all && !args.user.is_empty() {
+        return Err(Error::InvalidPath(
+            "bulk access-key inspection accepts either --all or --user, not both".to_string(),
+        ));
+    }
+    let query = BulkAccessKeyQuery {
+        users: args.user.clone(),
+        all: args.all,
+        ..Default::default()
+    };
+    query.validate()?;
+    if args.limit == 0 || args.limit > MAX_IAM_ACCESS_KEY_RESULTS {
+        return Err(Error::InvalidPath(format!(
+            "--limit must be between 1 and {MAX_IAM_ACCESS_KEY_RESULTS}"
+        )));
+    }
+    if args.offset > MAX_IAM_ACCESS_KEY_RESULTS {
+        return Err(Error::InvalidPath(format!(
+            "--offset must not exceed {MAX_IAM_ACCESS_KEY_RESULTS}"
+        )));
+    }
+    if args.request_batch_size == 0 || args.request_batch_size > MAX_IAM_ACCESS_KEY_SELECTORS {
+        return Err(Error::InvalidPath(format!(
+            "--request-batch-size must be between 1 and {MAX_IAM_ACCESS_KEY_SELECTORS}"
+        )));
+    }
+    Ok(())
+}
+
+fn selector_batches(users: &[String], batch_size: usize) -> Vec<&[String]> {
+    if users.is_empty() {
+        vec![&[]]
+    } else {
+        users.chunks(batch_size).collect()
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct AccessKeySuccessOutput<'a> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: &'a AccessKeyListData,
+}
+
+#[derive(Debug, Serialize)]
+struct AccessKeyErrorOutput<'a> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    error: AccessKeyAggregateError,
+    data: &'a AccessKeyListData,
+}
+
+#[derive(Debug, Serialize)]
+struct AccessKeyAggregateError {
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: &'static str,
+    retryable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    capability: Option<&'static str>,
+    server: Option<String>,
+    suggestion: Option<&'static str>,
+}
+
+#[derive(Debug, Serialize)]
+struct AccessKeyListData {
+    operation: &'static str,
+    keys: Vec<AccessKeyRecord>,
+    failures: Vec<AccessKeyFailure>,
+    pagination: AccessKeyPagination,
+}
+
+#[derive(Debug, Serialize)]
+struct AccessKeyPagination {
+    offset: usize,
+    limit: usize,
+    total: usize,
+    truncated: bool,
+    next_offset: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+struct AccessKeyFailure {
+    provider: AccessKeyProvider,
+    target: String,
+    #[serde(rename = "type")]
+    error_type: &'static str,
+    message: &'static str,
+    retryable: bool,
+}
+
+impl AccessKeyFailure {
+    fn new(provider: AccessKeyProvider, target: &str, error: &Error) -> Self {
+        Self {
+            provider,
+            target: bounded_target(target),
+            error_type: access_key_error_type(error),
+            message: safe_access_key_error_message(error),
+            retryable: matches!(error, Error::Network(_)),
+        }
+    }
+}
+
+fn bounded_target(target: &str) -> String {
+    target.chars().take(1_024).collect()
+}
+
+fn access_key_error_type(error: &Error) -> &'static str {
+    match error {
+        Error::InvalidPath(_) | Error::Config(_) => "usage_error",
+        Error::Network(_) => "network_error",
+        Error::Auth(_) => "auth_error",
+        Error::NotFound(_) | Error::AliasNotFound(_) => "not_found",
+        Error::Conflict(_) | Error::AliasExists(_) => "conflict",
+        Error::UnsupportedFeature(_) => "unsupported_feature",
+        Error::Interrupted(_) => "interrupted",
+        _ => "general_error",
+    }
+}
+
+fn safe_access_key_error_message(error: &Error) -> &'static str {
+    match error {
+        Error::InvalidPath(_) | Error::Config(_) => "The access-key request was invalid",
+        Error::Network(_) => "The access-key request could not reach RustFS",
+        Error::Auth(_) => "RustFS denied the access-key request",
+        Error::NotFound(_) | Error::AliasNotFound(_) => {
+            "The requested access-key scope was not found"
+        }
+        Error::Conflict(_) | Error::AliasExists(_) => {
+            "The access-key request encountered a conflict"
+        }
+        Error::UnsupportedFeature(_) => "The access-key route is not supported",
+        Error::Interrupted(_) => "The access-key request was interrupted",
+        _ => "RustFS returned an invalid access-key response",
+    }
+}
+
+fn sanitized_access_key_error(error: &Error) -> Error {
+    match error.exit_code() {
+        2 => Error::Config("Bulk access-key capability discovery was not configured".to_string()),
+        3 => Error::Network("Bulk access-key capability discovery failed".to_string()),
+        4 => Error::Auth("Bulk access-key capability discovery was denied".to_string()),
+        5 => Error::NotFound("Bulk access-key capability endpoint was not found".to_string()),
+        6 => Error::Conflict("Bulk access-key capability discovery conflicted".to_string()),
+        7 => Error::UnsupportedFeature(
+            "Bulk access-key capability discovery is unavailable".to_string(),
+        ),
+        130 => {
+            Error::Interrupted("Bulk access-key capability discovery was interrupted".to_string())
+        }
+        _ => Error::General("Bulk access-key capability discovery failed".to_string()),
+    }
+}
+
+fn aggregate_failure_code(data: &AccessKeyListData) -> ExitCode {
+    if !data.keys.is_empty() {
+        return ExitCode::GeneralError;
+    }
+    let error_types = data
+        .failures
+        .iter()
+        .map(|failure| failure.error_type)
+        .collect::<std::collections::BTreeSet<_>>();
+    if error_types.len() != 1 {
+        return ExitCode::GeneralError;
+    }
+    match error_types.first().copied() {
+        Some("usage_error") => ExitCode::UsageError,
+        Some("network_error") => ExitCode::NetworkError,
+        Some("auth_error") => ExitCode::AuthError,
+        Some("not_found") => ExitCode::NotFound,
+        Some("conflict") => ExitCode::Conflict,
+        Some("unsupported_feature") => ExitCode::UnsupportedFeature,
+        Some("interrupted") => ExitCode::Interrupted,
+        _ => ExitCode::GeneralError,
+    }
+}
+
+fn output_list_success(data: &AccessKeyListData, formatter: &Formatter) {
+    if formatter.is_json() {
+        formatter.json(&AccessKeySuccessOutput {
+            schema_version: 3,
+            output_type: "iam_access_keys",
+            status: "success",
+            data,
+        });
+    } else {
+        print_access_key_list(data, formatter);
+    }
+}
+
+fn output_list_failure(code: ExitCode, data: &AccessKeyListData, formatter: &Formatter) {
+    if formatter.is_json() {
+        let unsupported = code == ExitCode::UnsupportedFeature;
+        formatter.json_error(&AccessKeyErrorOutput {
+            schema_version: 3,
+            output_type: "iam_access_keys",
+            status: "error",
+            error: AccessKeyAggregateError {
+                error_type: if unsupported {
+                    "unsupported_feature"
+                } else if code == ExitCode::GeneralError {
+                    "general_error"
+                } else {
+                    data.failures
+                        .first()
+                        .map(|failure| failure.error_type)
+                        .unwrap_or("general_error")
+                },
+                message: "One or more bulk access-key scopes failed",
+                retryable: code == ExitCode::NetworkError,
+                capability: if unsupported {
+                    data.failures
+                        .first()
+                        .map(|failure| failure.provider.capability())
+                } else {
+                    None
+                },
+                server: None,
+                suggestion: unsupported
+                    .then_some("Use only provider routes advertised by RustFS capabilities."),
+            },
+            data,
+        });
+    } else {
+        print_access_key_list(data, formatter);
+        formatter.error_with_code(code, "One or more bulk access-key scopes failed");
+    }
+}
+
+fn emit_list_error(
+    error: &Error,
+    context: Option<&str>,
+    capability: Option<&'static str>,
+    formatter: &Formatter,
+) -> ExitCode {
+    let code = ExitCode::from_i32(error.exit_code()).unwrap_or(ExitCode::GeneralError);
+    let safe_message = context.unwrap_or_else(|| safe_access_key_error_message(error));
+    if formatter.is_json() {
+        let unsupported = code == ExitCode::UnsupportedFeature;
+        formatter.json_error(&serde_json::json!({
+            "schema_version": 3,
+            "type": "iam_access_keys",
+            "status": "error",
+            "error": {
+                "type": if unsupported { "unsupported_feature" } else { access_key_error_type(error) },
+                "message": safe_message,
+                "retryable": code == ExitCode::NetworkError,
+                "capability": capability.or(unsupported.then_some(IAM_ACCESS_KEYS_BULK_CAPABILITY)),
+                "server": serde_json::Value::Null,
+                "suggestion": serde_json::Value::Null
+            }
+        }));
+    } else {
+        formatter.error_with_code(code, safe_message);
+    }
+    code
+}
+
+fn print_access_key_list(data: &AccessKeyListData, formatter: &Formatter) {
+    for key in &data.keys {
+        formatter.println(&format!(
+            "{}\t{}\t{}\t{}\t{}\t{}",
+            formatter.sanitize_text(&key.access_key),
+            key.kind,
+            key.provider,
+            formatter.sanitize_text(&key.parent_user),
+            formatter.sanitize_text(key.account_status.as_deref().unwrap_or("-")),
+            formatter.sanitize_text(key.expiration.as_deref().unwrap_or("-")),
+        ));
+    }
+    for failure in &data.failures {
+        formatter.error(&format!(
+            "{} {}: {}",
+            failure.provider,
+            formatter.sanitize_text(&failure.target),
+            failure.message
+        ));
     }
 }
 
@@ -138,7 +687,16 @@ fn print_openid_info(info: &OpenIdAccessKeyInfo, formatter: &Formatter) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rc_core::admin::{AccessKeyDetails, LdapAccessKeyInfo, OpenIdAccessKeyInfo};
+    use async_trait::async_trait;
+    use jsonschema::Validator;
+    use rc_core::Result;
+    use rc_core::admin::{
+        AccessKeyDetails, AccessKeyKind, CapabilityEntry, CapabilityReport,
+        ClusterSnapshotMetadata, LdapAccessKeyInfo, OpenIdAccessKeyInfo,
+    };
+    use serde_json::Value;
+    use std::path::Path;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[test]
     fn test_access_key_info_serializes_server_shape() {
@@ -178,5 +736,319 @@ mod tests {
         let error = rc_core::Error::General("Bad request: access key not exist".to_string());
 
         assert!(is_access_key_not_found_error(&error));
+    }
+
+    struct StubBulkApi {
+        capabilities: Vec<CapabilityEntry>,
+        builtin: Result<Vec<AccessKeyRecord>>,
+        ldap: Result<Vec<AccessKeyRecord>>,
+        openid: Result<Vec<AccessKeyRecord>>,
+        calls: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl CapabilityApi for StubBulkApi {
+        async fn discover_capabilities(&self, _refresh: bool) -> Result<CapabilityReport> {
+            Ok(CapabilityReport {
+                server_version: Some("1.0.0-beta.10".to_string()),
+                runtime_path: "/runtime".to_string(),
+                extensions_path: "/extensions".to_string(),
+                cluster_snapshot_path: "/snapshot".to_string(),
+                capabilities: self.capabilities.clone(),
+                extensions: Vec::new(),
+                cluster: ClusterSnapshotMetadata {
+                    summary: None,
+                    runtime_capabilities_path: None,
+                    extensions_catalog_path: None,
+                },
+            })
+        }
+    }
+
+    #[async_trait]
+    impl BulkAccessKeyApi for StubBulkApi {
+        async fn list_access_keys_bulk(
+            &self,
+            query: &BulkAccessKeyQuery,
+        ) -> Result<Vec<AccessKeyRecord>> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            match query.provider {
+                AccessKeyProvider::Builtin => clone_result(&self.builtin),
+                AccessKeyProvider::Ldap => clone_result(&self.ldap),
+                AccessKeyProvider::Openid => clone_result(&self.openid),
+            }
+        }
+    }
+
+    fn clone_result(result: &Result<Vec<AccessKeyRecord>>) -> Result<Vec<AccessKeyRecord>> {
+        match result {
+            Ok(records) => Ok(records.clone()),
+            Err(error) => Err(match error.exit_code() {
+                3 => Error::Network("stub".to_string()),
+                4 => Error::Auth("stub".to_string()),
+                7 => Error::UnsupportedFeature("stub".to_string()),
+                _ => Error::General("stub".to_string()),
+            }),
+        }
+    }
+
+    fn capability(provider: AccessKeyProvider) -> CapabilityEntry {
+        CapabilityEntry {
+            name: provider.capability().to_string(),
+            availability: CapabilityAvailability::Available,
+            reason: None,
+        }
+    }
+
+    fn record(
+        provider: AccessKeyProvider,
+        parent: &str,
+        key: &str,
+        kind: AccessKeyKind,
+    ) -> AccessKeyRecord {
+        AccessKeyRecord {
+            access_key: key.to_string(),
+            kind,
+            provider,
+            parent_user: parent.to_string(),
+            account_status: Some("on".to_string()),
+            expiration: None,
+            name: None,
+            description: None,
+            implied_policy: None,
+        }
+    }
+
+    fn list_args(providers: Vec<ProviderArg>) -> ListArgs {
+        ListArgs {
+            alias: "local".to_string(),
+            provider: providers,
+            user: vec!["alice".to_string()],
+            all: false,
+            key_type: KeyTypeArg::All,
+            offset: 0,
+            limit: DEFAULT_PAGE_LIMIT,
+            request_batch_size: DEFAULT_REQUEST_BATCH_SIZE,
+        }
+    }
+
+    fn quiet_formatter() -> Formatter {
+        Formatter::new(crate::output::OutputConfig {
+            quiet: true,
+            ..Default::default()
+        })
+    }
+
+    fn output_v3_validator() -> Validator {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("schemas/output_v3.json");
+        let schema: Value = serde_json::from_str(
+            &std::fs::read_to_string(path).expect("output schema should be readable"),
+        )
+        .expect("output schema should parse");
+        jsonschema::validator_for(&schema).expect("output schema should compile")
+    }
+
+    #[test]
+    fn access_key_success_matches_v3_schema_and_golden_fixture() {
+        let data = AccessKeyListData {
+            operation: "list",
+            keys: vec![record(
+                AccessKeyProvider::Builtin,
+                "alice",
+                "svc-a",
+                AccessKeyKind::ServiceAccount,
+            )],
+            failures: Vec::new(),
+            pagination: AccessKeyPagination {
+                offset: 0,
+                limit: 100,
+                total: 1,
+                truncated: false,
+                next_offset: None,
+            },
+        };
+        let value = serde_json::to_value(AccessKeySuccessOutput {
+            schema_version: 3,
+            output_type: "iam_access_keys",
+            status: "success",
+            data: &data,
+        })
+        .expect("serialize bulk access-key output");
+        let errors = output_v3_validator()
+            .iter_errors(&value)
+            .map(|error| error.to_string())
+            .collect::<Vec<_>>();
+        assert!(errors.is_empty(), "invalid output: {}", errors.join("\n"));
+
+        let golden: Value = serde_json::from_str(include_str!(
+            "../../../tests/fixtures/output_v3/iam_access_keys/success.json"
+        ))
+        .expect("golden fixture should parse");
+        assert_eq!(value, golden);
+    }
+
+    #[test]
+    fn access_key_empty_and_partial_outputs_match_v3_schema() {
+        let empty = AccessKeyListData {
+            operation: "list",
+            keys: Vec::new(),
+            failures: Vec::new(),
+            pagination: AccessKeyPagination {
+                offset: 0,
+                limit: 100,
+                total: 0,
+                truncated: false,
+                next_offset: None,
+            },
+        };
+        let empty_value = serde_json::to_value(AccessKeySuccessOutput {
+            schema_version: 3,
+            output_type: "iam_access_keys",
+            status: "success",
+            data: &empty,
+        })
+        .expect("serialize empty output");
+        assert!(output_v3_validator().is_valid(&empty_value));
+
+        let partial = AccessKeyListData {
+            operation: "list",
+            keys: vec![record(
+                AccessKeyProvider::Builtin,
+                "alice",
+                "svc-a",
+                AccessKeyKind::ServiceAccount,
+            )],
+            failures: vec![AccessKeyFailure::new(
+                AccessKeyProvider::Ldap,
+                "alice",
+                &Error::Auth("secret canary".to_string()),
+            )],
+            pagination: AccessKeyPagination {
+                offset: 0,
+                limit: 100,
+                total: 1,
+                truncated: false,
+                next_offset: None,
+            },
+        };
+        let partial_value = serde_json::to_value(AccessKeyErrorOutput {
+            schema_version: 3,
+            output_type: "iam_access_keys",
+            status: "error",
+            error: AccessKeyAggregateError {
+                error_type: "general_error",
+                message: "One or more bulk access-key scopes failed",
+                retryable: false,
+                capability: None,
+                server: None,
+                suggestion: None,
+            },
+            data: &partial,
+        })
+        .expect("serialize partial output");
+        assert!(output_v3_validator().is_valid(&partial_value));
+        assert!(!partial_value.to_string().contains("secret canary"));
+    }
+
+    #[tokio::test]
+    async fn access_key_partial_results_return_general_error_deterministically() {
+        let api = StubBulkApi {
+            capabilities: vec![
+                capability(AccessKeyProvider::Builtin),
+                capability(AccessKeyProvider::Ldap),
+            ],
+            builtin: Ok(vec![
+                record(
+                    AccessKeyProvider::Builtin,
+                    "bob",
+                    "sts-z",
+                    AccessKeyKind::Sts,
+                ),
+                record(
+                    AccessKeyProvider::Builtin,
+                    "alice",
+                    "svc-a",
+                    AccessKeyKind::ServiceAccount,
+                ),
+            ]),
+            ldap: Err(Error::Auth("secret server body".to_string())),
+            openid: Ok(Vec::new()),
+            calls: AtomicUsize::new(0),
+        };
+
+        let code = execute_list_with_apis(
+            list_args(vec![ProviderArg::Ldap, ProviderArg::Builtin]),
+            &api,
+            &api,
+            &quiet_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::GeneralError);
+        assert_eq!(api.calls.load(Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn access_key_missing_capability_fails_closed_before_route_call() {
+        let api = StubBulkApi {
+            capabilities: Vec::new(),
+            builtin: Ok(Vec::new()),
+            ldap: Ok(Vec::new()),
+            openid: Ok(Vec::new()),
+            calls: AtomicUsize::new(0),
+        };
+
+        let code = execute_list_with_apis(
+            list_args(vec![ProviderArg::Openid]),
+            &api,
+            &api,
+            &quiet_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::UnsupportedFeature);
+        assert_eq!(api.calls.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn access_key_uniform_permission_failure_preserves_auth_exit_code() {
+        let api = StubBulkApi {
+            capabilities: vec![capability(AccessKeyProvider::Builtin)],
+            builtin: Err(Error::Auth("secret server body".to_string())),
+            ldap: Ok(Vec::new()),
+            openid: Ok(Vec::new()),
+            calls: AtomicUsize::new(0),
+        };
+
+        let code = execute_list_with_apis(
+            list_args(vec![ProviderArg::Builtin]),
+            &api,
+            &api,
+            &quiet_formatter(),
+        )
+        .await;
+
+        assert_eq!(code, ExitCode::AuthError);
+        assert_eq!(api.calls.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn access_key_invalid_limit_is_rejected_before_discovery() {
+        let api = StubBulkApi {
+            capabilities: vec![capability(AccessKeyProvider::Builtin)],
+            builtin: Ok(Vec::new()),
+            ldap: Ok(Vec::new()),
+            openid: Ok(Vec::new()),
+            calls: AtomicUsize::new(0),
+        };
+        let mut args = list_args(vec![ProviderArg::Builtin]);
+        args.limit = MAX_IAM_ACCESS_KEY_RESULTS + 1;
+
+        let code = execute_list_with_apis(args, &api, &api, &quiet_formatter()).await;
+
+        assert_eq!(code, ExitCode::UsageError);
+        assert_eq!(api.calls.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -583,6 +583,43 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_admin_access_key_bulk_list() {
+        let cli = TestCli::parse_from([
+            "rc",
+            "access-key",
+            "ls",
+            "local",
+            "--provider",
+            "builtin,ldap",
+            "--user",
+            "alice",
+            "--key-type",
+            "service-account",
+            "--offset",
+            "10",
+            "--limit",
+            "20",
+        ]);
+
+        match cli.command {
+            AdminCommands::AccessKey(access_key::AccessKeyCommands::List(args)) => {
+                assert_eq!(
+                    args.provider,
+                    vec![
+                        access_key::ProviderArg::Builtin,
+                        access_key::ProviderArg::Ldap
+                    ]
+                );
+                assert_eq!(args.user, vec!["alice"]);
+                assert_eq!(args.key_type, access_key::KeyTypeArg::ServiceAccount);
+                assert_eq!(args.offset, 10);
+                assert_eq!(args.limit, 20);
+            }
+            _ => panic!("Unexpected command parsing result"),
+        }
+    }
+
+    #[test]
     fn test_parse_admin_heal_start_options() {
         let cli = TestCli::parse_from([
             "rc",

--- a/crates/cli/tests/admin_access_key_bulk.rs
+++ b/crates/cli/tests/admin_access_key_bulk.rs
@@ -1,0 +1,124 @@
+#![cfg(not(windows))]
+
+mod admin_support;
+
+use std::process::Command;
+use std::time::Duration;
+
+use admin_support::{rc_binary, rc_host_alias, start_admin_sequence_test_server};
+
+const INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
+const RUNTIME_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
+const SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
+
+#[test]
+fn bulk_access_keys_dispatches_advertised_mixed_providers_with_bounded_v3_output() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let builtin = r#"{"alice":{"serviceAccounts":[{"accessKey":"svc-builtin","parentUser":"alice","accountStatus":"on","secretKey":"secret-canary"}],"stsKeys":[]}}"#;
+    let openid = r#"{"alice":{"serviceAccounts":[],"stsKeys":[{"accessKey":"sts-openid","parentUser":"alice","expiration":"2027-01-01T00:00:00Z","sessionToken":"token-canary"}]}}"#;
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", builtin),
+        ("200 OK", openid),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "access-key",
+            "ls",
+            "myalias",
+            "--provider",
+            "openid,builtin",
+            "--user",
+            "alice",
+            "--limit",
+            "1",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "iam_access_keys");
+    assert_eq!(value["data"]["keys"][0]["provider"], "builtin");
+    assert_eq!(value["data"]["keys"][0]["kind"], "service_account");
+    assert_eq!(value["data"]["pagination"]["total"], 2);
+    assert_eq!(value["data"]["pagination"]["truncated"], true);
+    assert_eq!(value["data"]["pagination"]["next_offset"], 1);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(!stdout.contains("secret-canary"));
+    assert!(!stdout.contains("token-canary"));
+    assert!(output.stderr.is_empty());
+
+    for expected in [
+        "/rustfs/admin/v3/info",
+        "/rustfs/admin/v4/runtime/capabilities",
+        "/rustfs/admin/v4/extensions/catalog",
+        "/rustfs/admin/v4/cluster/snapshot",
+        "/rustfs/admin/v3/list-access-keys-bulk?users=alice&listType=all",
+        "/rustfs/admin/v3/idp/openid/list-access-keys-bulk?users=alice&listType=all",
+    ] {
+        let request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("captured admin request");
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.target, expected);
+    }
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn bulk_access_keys_retains_partial_failure_and_returns_non_success() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let builtin = r#"{"alice":{"serviceAccounts":[{"accessKey":"svc-builtin","parentUser":"alice"}],"stsKeys":[]}}"#;
+    let (endpoint, _receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", INFO_RESPONSE),
+        ("200 OK", RUNTIME_RESPONSE),
+        ("200 OK", EXTENSIONS_RESPONSE),
+        ("200 OK", SNAPSHOT_RESPONSE),
+        ("200 OK", builtin),
+        ("403 Forbidden", r#"{"message":"secret-canary"}"#),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "access-key",
+            "ls",
+            "myalias",
+            "--provider",
+            "builtin,ldap",
+            "--user",
+            "alice",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert_eq!(output.status.code(), Some(1));
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stderr).expect("stderr should be JSON");
+    assert_eq!(value["type"], "iam_access_keys");
+    assert_eq!(value["status"], "error");
+    assert_eq!(value["data"]["keys"][0]["access_key"], "svc-builtin");
+    assert_eq!(value["data"]["failures"][0]["provider"], "ldap");
+    assert_eq!(value["data"]["failures"][0]["type"], "auth_error");
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("secret-canary"));
+    handle.join().expect("admin test server finished");
+}

--- a/crates/cli/tests/fixtures/output_v3/iam_access_keys/success.json
+++ b/crates/cli/tests/fixtures/output_v3/iam_access_keys/success.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 3,
+  "type": "iam_access_keys",
+  "status": "success",
+  "data": {
+    "operation": "list",
+    "keys": [
+      {
+        "access_key": "svc-a",
+        "kind": "service_account",
+        "provider": "builtin",
+        "parent_user": "alice",
+        "account_status": "on"
+      }
+    ],
+    "failures": [],
+    "pagination": {
+      "offset": 0,
+      "limit": 100,
+      "total": 1,
+      "truncated": false,
+      "next_offset": null
+    }
+  }
+}

--- a/crates/core/src/admin/access_keys.rs
+++ b/crates/core/src/admin/access_keys.rs
@@ -1,0 +1,200 @@
+//! Typed, secret-free contracts for bulk access-key inspection.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+use crate::{Error, Result};
+
+/// Capability for the builtin bulk access-key route.
+pub const IAM_ACCESS_KEYS_BULK_CAPABILITY: &str = "admin.iam.access-keys-bulk";
+/// Capability for the LDAP-scoped bulk access-key route.
+pub const IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY: &str = "admin.iam.access-keys-bulk.ldap";
+/// Capability for the OpenID-scoped bulk access-key route.
+pub const IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY: &str = "admin.iam.access-keys-bulk.openid";
+
+/// Maximum encoded response accepted from one bulk route.
+pub const MAX_IAM_ACCESS_KEYS_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+/// Maximum selectors accepted by one logical command.
+pub const MAX_IAM_ACCESS_KEY_SELECTORS: usize = 1_000;
+/// Maximum UTF-8 byte length of one parent selector.
+pub const MAX_IAM_ACCESS_KEY_SELECTOR_BYTES: usize = 1_024;
+/// Maximum number of decoded keys accepted from one server response.
+pub const MAX_IAM_ACCESS_KEY_RESULTS: usize = 10_000;
+
+/// Identity provider owning an access key.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AccessKeyProvider {
+    #[default]
+    Builtin,
+    Ldap,
+    Openid,
+}
+
+impl AccessKeyProvider {
+    /// Capability that must be available before this provider route is called.
+    pub const fn capability(self) -> &'static str {
+        match self {
+            Self::Builtin => IAM_ACCESS_KEYS_BULK_CAPABILITY,
+            Self::Ldap => IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
+            Self::Openid => IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY,
+        }
+    }
+}
+
+impl fmt::Display for AccessKeyProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Builtin => "builtin",
+            Self::Ldap => "ldap",
+            Self::Openid => "openid",
+        })
+    }
+}
+
+/// Access-key class represented by a RustFS bulk response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccessKeyKind {
+    ServiceAccount,
+    Sts,
+}
+
+impl fmt::Display for AccessKeyKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::ServiceAccount => "service-account",
+            Self::Sts => "sts",
+        })
+    }
+}
+
+/// Server-side access-key class filter.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum AccessKeyListType {
+    #[default]
+    All,
+    UsersOnly,
+    StsOnly,
+    ServiceAccountsOnly,
+}
+
+impl AccessKeyListType {
+    pub const fn wire_value(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::UsersOnly => "users-only",
+            Self::StsOnly => "sts-only",
+            Self::ServiceAccountsOnly => "svcacc-only",
+        }
+    }
+}
+
+/// One bounded bulk-list request.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BulkAccessKeyQuery {
+    pub provider: AccessKeyProvider,
+    pub users: Vec<String>,
+    pub all: bool,
+    pub list_type: AccessKeyListType,
+}
+
+impl BulkAccessKeyQuery {
+    pub fn validate(&self) -> Result<()> {
+        if self.all && !self.users.is_empty() {
+            return Err(Error::InvalidPath(
+                "bulk access-key inspection accepts either --all or --user, not both".to_string(),
+            ));
+        }
+        if self.users.len() > MAX_IAM_ACCESS_KEY_SELECTORS {
+            return Err(Error::InvalidPath(format!(
+                "bulk access-key inspection accepts at most {MAX_IAM_ACCESS_KEY_SELECTORS} user selectors"
+            )));
+        }
+        for user in &self.users {
+            if user.trim().is_empty() {
+                return Err(Error::InvalidPath(
+                    "bulk access-key user selector cannot be empty".to_string(),
+                ));
+            }
+            if user.len() > MAX_IAM_ACCESS_KEY_SELECTOR_BYTES {
+                return Err(Error::InvalidPath(format!(
+                    "bulk access-key user selector exceeds {MAX_IAM_ACCESS_KEY_SELECTOR_BYTES} bytes"
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A safe projection of one key returned by RustFS.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AccessKeyRecord {
+    pub access_key: String,
+    pub kind: AccessKeyKind,
+    pub provider: AccessKeyProvider,
+    pub parent_user: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_status: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub implied_policy: Option<bool>,
+}
+
+/// Typed access-key bulk operations.
+#[async_trait]
+pub trait BulkAccessKeyApi: Send + Sync {
+    async fn list_access_keys_bulk(
+        &self,
+        query: &BulkAccessKeyQuery,
+    ) -> Result<Vec<AccessKeyRecord>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_validation_rejects_conflicting_empty_and_oversized_selectors() {
+        let conflict = BulkAccessKeyQuery {
+            users: vec!["alice".to_string()],
+            all: true,
+            ..Default::default()
+        };
+        assert!(matches!(conflict.validate(), Err(Error::InvalidPath(_))));
+
+        let empty = BulkAccessKeyQuery {
+            users: vec![" ".to_string()],
+            ..Default::default()
+        };
+        assert!(matches!(empty.validate(), Err(Error::InvalidPath(_))));
+
+        let oversized = BulkAccessKeyQuery {
+            users: vec!["u".repeat(MAX_IAM_ACCESS_KEY_SELECTOR_BYTES + 1)],
+            ..Default::default()
+        };
+        assert!(matches!(oversized.validate(), Err(Error::InvalidPath(_))));
+    }
+
+    #[test]
+    fn provider_capability_mapping_is_stable() {
+        assert_eq!(
+            AccessKeyProvider::Builtin.capability(),
+            IAM_ACCESS_KEYS_BULK_CAPABILITY
+        );
+        assert_eq!(
+            AccessKeyProvider::Ldap.capability(),
+            IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY
+        );
+        assert_eq!(
+            AccessKeyProvider::Openid.capability(),
+            IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY
+        );
+    }
+}

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides the AdminApi trait and types for managing
 //! IAM users, policies, groups, service accounts, and cluster operations.
 
+mod access_keys;
 mod bucket_metadata;
 mod capabilities;
 mod cluster;
@@ -18,6 +19,13 @@ mod site;
 pub mod tier;
 mod types;
 
+pub use access_keys::{
+    AccessKeyKind, AccessKeyListType, AccessKeyProvider, AccessKeyRecord, BulkAccessKeyApi,
+    BulkAccessKeyQuery, IAM_ACCESS_KEYS_BULK_CAPABILITY, IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
+    IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY, MAX_IAM_ACCESS_KEY_RESULTS,
+    MAX_IAM_ACCESS_KEY_SELECTOR_BYTES, MAX_IAM_ACCESS_KEY_SELECTORS,
+    MAX_IAM_ACCESS_KEYS_RESPONSE_BYTES,
+};
 pub use bucket_metadata::{
     BUCKET_METADATA_CAPABILITY, BucketMetadataApi, BucketMetadataArchive,
     MAX_BUCKET_METADATA_ARCHIVE_BYTES,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -14,20 +14,23 @@ use aws_sigv4::sign::v4;
 use bytes::Bytes;
 use futures::StreamExt;
 use rc_core::admin::{
-    AccessKeyInfo, AdminApi, BucketMetadataApi, BucketMetadataArchive, BucketQuota, CapabilityApi,
+    AccessKeyInfo, AccessKeyKind, AccessKeyProvider, AccessKeyRecord, AdminApi, BucketMetadataApi,
+    BucketMetadataArchive, BucketQuota, BulkAccessKeyApi, BulkAccessKeyQuery, CapabilityApi,
     CapabilityAvailability, CapabilityEntry, CapabilityReport, ClusterInfo,
     ClusterSnapshotDocument, ClusterSnapshotMetadata, ClusterSnapshotSummary, ConfigApi,
     ConfigDocument, ConfigHelp, ConfigHistoryEntry, ConfigMutationResult,
     CreateServiceAccountRequest, DecommissionPoolStatus, DecommissionStatus,
     DetailedHealthSnapshot, DiagnosticCapability, DiagnosticReadApi, ExtensionsCatalog, Group,
     GroupStatus, HealRuntimeState, HealScanMode, HealStartRequest, HealStatus, HealTaskRequest,
-    IAM_POLICY_DETACH_CAPABILITY, IAM_POLICY_ENTITIES_CAPABILITY, IamArchiveApi,
-    IamArchiveImportResult, IamArchiveImportSection, IamArchiveInventory, IamArchiveResultEntities,
-    IamMutationApi, IamReadApi, KmsApi, KmsBackendKind, KmsCacheSummary,
-    KmsCancelKeyDeletionResult, KmsConfigSummary, KmsConfigureRequest, KmsCreateKeyRequest,
-    KmsCreateKeyResult, KmsDeleteKeyRequest, KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState,
-    KmsKeyUsage, KmsServiceState, KmsStatus, MAX_BUCKET_METADATA_ARCHIVE_BYTES,
-    MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_IAM_ARCHIVE_BYTES, MAX_IAM_IMPORT_RESPONSE_BYTES,
+    IAM_ACCESS_KEYS_BULK_CAPABILITY, IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
+    IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY, IAM_POLICY_DETACH_CAPABILITY,
+    IAM_POLICY_ENTITIES_CAPABILITY, IamArchiveApi, IamArchiveImportResult, IamArchiveImportSection,
+    IamArchiveInventory, IamArchiveResultEntities, IamMutationApi, IamReadApi, KmsApi,
+    KmsBackendKind, KmsCacheSummary, KmsCancelKeyDeletionResult, KmsConfigSummary,
+    KmsConfigureRequest, KmsCreateKeyRequest, KmsCreateKeyResult, KmsDeleteKeyRequest,
+    KmsDeleteKeyResult, KmsKey, KmsKeyPage, KmsKeyState, KmsKeyUsage, KmsServiceState, KmsStatus,
+    MAX_BUCKET_METADATA_ARCHIVE_BYTES, MAX_DIAGNOSTIC_RESPONSE_BYTES, MAX_IAM_ACCESS_KEY_RESULTS,
+    MAX_IAM_ACCESS_KEYS_RESPONSE_BYTES, MAX_IAM_ARCHIVE_BYTES, MAX_IAM_IMPORT_RESPONSE_BYTES,
     MAX_IAM_POLICY_DETACH_REQUEST_BYTES, MAX_IAM_POLICY_DETACH_RESPONSE_BYTES,
     MAX_IAM_POLICY_ENTITIES_RESPONSE_BYTES, MAX_METRICS_LINE_BYTES, MAX_METRICS_RESPONSE_BYTES,
     MAX_METRICS_SAMPLES, MAX_OIDC_RESPONSE_BYTES, MAX_REPLICATION_DIFF_RESPONSE_BYTES,
@@ -1247,6 +1250,26 @@ impl AdminClient {
             )),
         }
     }
+
+    fn map_iam_access_keys_error(&self, status: StatusCode, _body: &str) -> Error {
+        match status {
+            StatusCode::NOT_FOUND
+            | StatusCode::METHOD_NOT_ALLOWED
+            | StatusCode::NOT_IMPLEMENTED => Error::UnsupportedFeature(
+                "Bulk access-key inspection is not supported by this RustFS server".to_string(),
+            ),
+            StatusCode::FORBIDDEN | StatusCode::UNAUTHORIZED => {
+                Error::Auth("Permission denied for bulk access-key inspection".to_string())
+            }
+            StatusCode::BAD_REQUEST | StatusCode::UNPROCESSABLE_ENTITY => {
+                Error::InvalidPath("RustFS rejected the bulk access-key query".to_string())
+            }
+            _ => Error::Network(format!(
+                "Bulk access-key inspection failed with HTTP {}",
+                status.as_u16()
+            )),
+        }
+    }
 }
 
 fn site_replication_response_rejected(
@@ -2120,6 +2143,17 @@ fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<C
         availability: CapabilityAvailability::Available,
         reason: None,
     });
+    for name in [
+        IAM_ACCESS_KEYS_BULK_CAPABILITY,
+        IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
+        IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY,
+    ] {
+        capabilities.push(CapabilityEntry {
+            name: name.to_string(),
+            availability: CapabilityAvailability::Available,
+            reason: None,
+        });
+    }
 
     for (name, reason) in [
         (
@@ -3004,6 +3038,152 @@ impl IamReadApi for AdminClient {
             .await?;
         result.normalize()
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BulkAccessKeyWireEntry {
+    access_key: String,
+    #[serde(default)]
+    parent_user: String,
+    #[serde(default)]
+    account_status: Option<String>,
+    #[serde(default)]
+    expiration: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    implied_policy: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct BulkAccessKeyWireGroup {
+    #[serde(default)]
+    service_accounts: Vec<BulkAccessKeyWireEntry>,
+    #[serde(default)]
+    sts_keys: Vec<BulkAccessKeyWireEntry>,
+}
+
+#[async_trait]
+impl BulkAccessKeyApi for AdminClient {
+    async fn list_access_keys_bulk(
+        &self,
+        query: &BulkAccessKeyQuery,
+    ) -> Result<Vec<AccessKeyRecord>> {
+        query.validate()?;
+
+        let mut parameters = Vec::with_capacity(query.users.len() + 2);
+        parameters.extend(query.users.iter().map(|user| ("users", user.as_str())));
+        if query.all {
+            parameters.push(("all", "true"));
+        }
+        parameters.push(("listType", query.list_type.wire_value()));
+
+        let path = match query.provider {
+            AccessKeyProvider::Builtin => "/list-access-keys-bulk",
+            AccessKeyProvider::Ldap => "/idp/ldap/list-access-keys-bulk",
+            AccessKeyProvider::Openid => "/idp/openid/list-access-keys-bulk",
+        };
+        let response: BTreeMap<String, BulkAccessKeyWireGroup> = self
+            .request_bounded_json(
+                Method::GET,
+                path,
+                Some(parameters.as_slice()),
+                None,
+                BoundedJsonResponse {
+                    max_bytes: MAX_IAM_ACCESS_KEYS_RESPONSE_BYTES,
+                    name: "bulk access-key response",
+                    error_mapper: Self::map_iam_access_keys_error,
+                },
+            )
+            .await
+            .map_err(|error| match error {
+                Error::Json(_) => Error::General(
+                    "RustFS returned a malformed bulk access-key response".to_string(),
+                ),
+                other => other,
+            })?;
+
+        normalize_access_key_response(response, query.provider)
+    }
+}
+
+fn normalize_access_key_response(
+    response: BTreeMap<String, BulkAccessKeyWireGroup>,
+    provider: AccessKeyProvider,
+) -> Result<Vec<AccessKeyRecord>> {
+    let count = response.values().fold(0_usize, |count, group| {
+        count
+            .saturating_add(group.service_accounts.len())
+            .saturating_add(group.sts_keys.len())
+    });
+    if count > MAX_IAM_ACCESS_KEY_RESULTS {
+        return Err(Error::General(format!(
+            "RustFS bulk access-key response exceeds the {MAX_IAM_ACCESS_KEY_RESULTS} item limit"
+        )));
+    }
+
+    let mut records = Vec::with_capacity(count);
+    for (parent, group) in response {
+        for (kind, entries) in [
+            (AccessKeyKind::ServiceAccount, group.service_accounts),
+            (AccessKeyKind::Sts, group.sts_keys),
+        ] {
+            for entry in entries {
+                if entry.access_key.trim().is_empty() {
+                    return Err(Error::General(
+                        "RustFS bulk access-key response contains an empty access key".to_string(),
+                    ));
+                }
+                let parent_user = if entry.parent_user.trim().is_empty() {
+                    parent.clone()
+                } else {
+                    entry.parent_user
+                };
+                if parent_user.trim().is_empty() {
+                    return Err(Error::General(
+                        "RustFS bulk access-key response contains an empty parent identity"
+                            .to_string(),
+                    ));
+                }
+                records.push(AccessKeyRecord {
+                    access_key: entry.access_key,
+                    kind,
+                    provider,
+                    parent_user,
+                    account_status: entry.account_status,
+                    expiration: entry.expiration,
+                    name: entry.name,
+                    description: entry.description,
+                    implied_policy: entry.implied_policy,
+                });
+            }
+        }
+    }
+    records.sort_by(|left, right| {
+        (
+            left.provider,
+            left.parent_user.as_str(),
+            left.kind,
+            left.access_key.as_str(),
+        )
+            .cmp(&(
+                right.provider,
+                right.parent_user.as_str(),
+                right.kind,
+                right.access_key.as_str(),
+            ))
+    });
+    records.dedup_by(|left, right| {
+        left.provider == right.provider
+            && left.parent_user == right.parent_user
+            && left.kind == right.kind
+            && left.access_key == right.access_key
+    });
+    Ok(records)
 }
 
 #[async_trait]
@@ -5987,6 +6167,89 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn bulk_access_keys_classifies_mixed_types_and_drops_secret_canaries() {
+        let response = r#"{
+            "alice":{
+                "serviceAccounts":[{
+                    "accessKey":"svc-b",
+                    "parentUser":"alice",
+                    "accountStatus":"on",
+                    "expiration":"2027-01-01T00:00:00Z",
+                    "impliedPolicy":true,
+                    "secretKey":"must-not-survive"
+                }],
+                "stsKeys":[{
+                    "accessKey":"sts-a",
+                    "parentUser":"alice",
+                    "sessionToken":"must-not-survive"
+                }]
+            }
+        }"#;
+        let (endpoint, receiver, handle) = start_admin_test_server("200 OK", response);
+        let client = admin_client_for_endpoint(&endpoint);
+        let result = client
+            .list_access_keys_bulk(&BulkAccessKeyQuery {
+                provider: AccessKeyProvider::Builtin,
+                users: vec!["alice@example.com".to_string(), "bob".to_string()],
+                all: false,
+                list_type: rc_core::admin::AccessKeyListType::All,
+            })
+            .await
+            .expect("bulk access-key request");
+
+        let request = receiver.recv().expect("captured request");
+        assert_eq!(
+            request.target,
+            "/rustfs/admin/v3/list-access-keys-bulk?users=alice%40example.com&users=bob&listType=all"
+        );
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].kind, AccessKeyKind::ServiceAccount);
+        assert_eq!(result[1].kind, AccessKeyKind::Sts);
+        assert!(result.iter().all(|record| {
+            record.provider == AccessKeyProvider::Builtin && record.parent_user == "alice"
+        }));
+        let encoded = serde_json::to_string(&result).expect("serialize safe records");
+        assert!(!encoded.contains("must-not-survive"));
+        assert!(!encoded.contains("secretKey"));
+        assert!(!encoded.contains("sessionToken"));
+        handle.join().expect("join bulk access-key server");
+    }
+
+    #[tokio::test]
+    async fn bulk_access_keys_uses_advertised_federated_routes() {
+        for (provider, expected_path) in [
+            (
+                AccessKeyProvider::Ldap,
+                "/rustfs/admin/v3/idp/ldap/list-access-keys-bulk?all=true&listType=svcacc-only",
+            ),
+            (
+                AccessKeyProvider::Openid,
+                "/rustfs/admin/v3/idp/openid/list-access-keys-bulk?all=true&listType=svcacc-only",
+            ),
+        ] {
+            let (endpoint, receiver, handle) =
+                start_admin_test_server("200 OK", r#"{"parent":{"serviceAccounts":[]}}"#);
+            let client = admin_client_for_endpoint(&endpoint);
+            let result = client
+                .list_access_keys_bulk(&BulkAccessKeyQuery {
+                    provider,
+                    users: Vec::new(),
+                    all: true,
+                    list_type: rc_core::admin::AccessKeyListType::ServiceAccountsOnly,
+                })
+                .await
+                .expect("federated bulk request");
+
+            assert!(result.is_empty());
+            assert_eq!(
+                receiver.recv().expect("captured request").target,
+                expected_path
+            );
+            handle.join().expect("join federated route server");
+        }
+    }
+
+    #[tokio::test]
     async fn iam_policy_detach_rejects_malformed_and_oversized_responses() {
         let request = PolicyDetachRequest::new(
             vec!["readonly".to_string()],
@@ -6037,6 +6300,42 @@ mod tests {
         assert!(
             matches!(error, Error::InvalidPath(message) if message.contains("request exceeds"))
         );
+    }
+
+    #[tokio::test]
+    async fn bulk_access_keys_distinguishes_malformed_denied_unsupported_and_oversized() {
+        for (status, body, expected) in [
+            ("200 OK", "{", "malformed"),
+            ("403 Forbidden", "secret server body", "denied"),
+            ("501 Not Implemented", "secret server body", "unsupported"),
+        ] {
+            let (endpoint, _receiver, handle) = start_admin_test_server(status, body);
+            let client = admin_client_for_endpoint(&endpoint);
+            let error = client
+                .list_access_keys_bulk(&BulkAccessKeyQuery::default())
+                .await
+                .expect_err("bulk request should fail");
+            match expected {
+                "malformed" => assert!(matches!(error, Error::General(_))),
+                "denied" => assert!(matches!(error, Error::Auth(_))),
+                "unsupported" => assert!(matches!(error, Error::UnsupportedFeature(_))),
+                _ => unreachable!(),
+            }
+            assert!(!error.to_string().contains("secret server body"));
+            handle.join().expect("join bulk error server");
+        }
+
+        let (endpoint, _receiver, handle) =
+            start_admin_declared_length_server("200 OK", MAX_IAM_ACCESS_KEYS_RESPONSE_BYTES + 1);
+        let client = admin_client_for_endpoint(&endpoint);
+        let oversized = client
+            .list_access_keys_bulk(&BulkAccessKeyQuery::default())
+            .await
+            .expect_err("oversized bulk response must fail");
+        assert!(
+            matches!(oversized, Error::General(message) if message.contains("bulk access-key response exceeded"))
+        );
+        handle.join().expect("join oversized bulk response server");
     }
 
     #[test]

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -43,6 +43,8 @@ rc admin user <ls|add|info|rm|enable|disable> ...
 rc admin policy <ls|create|info|rm|attach|detach|entities> ...
 rc admin policy detach <ALIAS> <POLICY>... (--user USER | --group GROUP)
 rc admin policy entities <ALIAS> [--user USER]... [--group GROUP]... [--policy POLICY]...
+rc admin access-key info <ALIAS> <ACCESS_KEY>
+rc admin access-key ls <ALIAS> [--provider builtin|ldap|openid]... [--user USER]... [--all] [OPTIONS]
 rc admin group <ls|add|info|rm|enable|disable|add-members|rm-members> ...
 rc admin service-account <ls|create|info|rm> ...
 rc admin service <restart|stop|freeze|unfreeze> <ALIAS>
@@ -75,6 +77,7 @@ rc admin replicate remove <ALIAS> <--all|--site <NAME>>
 | `rebalance` | Manage post-expansion rebalancing. |
 | `user` | Manage IAM users. |
 | `policy` | Manage IAM policies and attachments. |
+| `access-key` | Inspect individual or bounded pages of secret-free access-key metadata. |
 | `group` | Manage IAM groups and group membership. |
 | `service-account` | Manage service accounts. |
 | `iam` | Export or import bounded, versioned IAM archives. |
@@ -358,6 +361,42 @@ malformed and oversized replies fail without displaying their contents.
 Authentication denial, missing entities, unsupported routes, validation
 failures, conflicts, and network failures retain distinct error classes and
 exit codes.
+
+## Bulk Access-Key Inspection
+
+`rc admin access-key ls` reads RustFS's bulk access-key routes through a typed
+response model. The default provider is `builtin`; repeat `--provider` (or use
+a comma-separated value) to combine `builtin`, `ldap`, and `openid` scopes.
+LDAP and OpenID requests are sent only when capability discovery marks their
+exact provider route available. Missing, disabled, stubbed, unknown, and
+permission-denied capability states fail closed without probing the route.
+
+Use repeated `--user` selectors for specific parent identities, no selector
+for the caller's own identity, or `--all` for every identity visible to the
+caller. `--all` conflicts with `--user`. `--key-type` accepts `all`,
+`users-only`, `sts`, or `service-account`. At most 1,000 user selectors are
+accepted; `--request-batch-size` bounds each request and defaults to 100.
+
+Results are sorted by provider, parent, key type, and access key. `--offset`
+and `--limit` select a deterministic output page; the default limit is 1,000
+and the hard limit is 10,000. JSON uses the `iam_access_keys` output-v3 family
+and includes `total`, `truncated`, and `next_offset`. Each record contains only
+the access-key identifier, key type, provider, parent, status, expiration,
+name, description, and implied-policy flag when RustFS supplied them. Secret
+keys, session tokens, and unknown server fields are never retained in the
+public response model.
+
+Provider or selector failures are retained in `data.failures`. A page with any
+failure exits non-zero; partial data uses exit code 1, while a uniform
+all-failed result preserves the specific usage (2), network (3),
+authorization (4), not-found (5), conflict (6), unsupported (7), or
+interrupted (130) class.
+
+```bash
+rc admin access-key ls local --user alice --user bob
+rc admin access-key ls local --provider builtin,ldap --all --key-type service-account
+rc --json admin access-key ls local --provider openid --all --offset 100 --limit 100
+```
 
 ## KMS Key Lifecycle Workflow
 

--- a/schemas/output_v3.json
+++ b/schemas/output_v3.json
@@ -45,7 +45,8 @@
         "oidc",
         "iam_policy_entities",
         "iam_policy_detach",
-        "admin_iam_archive"
+        "admin_iam_archive",
+        "iam_access_keys"
       ]
     },
     "pagination": {
@@ -1163,6 +1164,71 @@
         "updated_at": { "$ref": "#/definitions/timestamp" }
       }
     },
+    "iamAccessKey": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["access_key", "kind", "provider", "parent_user"],
+      "properties": {
+        "access_key": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "enum": ["service_account", "sts"] },
+        "provider": { "type": "string", "enum": ["builtin", "ldap", "openid"] },
+        "parent_user": { "type": "string", "minLength": 1 },
+        "account_status": { "type": "string" },
+        "expiration": { "type": "string" },
+        "name": { "type": "string" },
+        "description": { "type": "string" },
+        "implied_policy": { "type": "boolean" }
+      }
+    },
+    "iamAccessKeyFailure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["provider", "target", "type", "message", "retryable"],
+      "properties": {
+        "provider": { "type": "string", "enum": ["builtin", "ldap", "openid"] },
+        "target": { "type": "string", "minLength": 1 },
+        "type": {
+          "type": "string",
+          "enum": [
+            "general_error", "usage_error", "network_error", "auth_error",
+            "not_found", "conflict", "unsupported_feature", "interrupted"
+          ]
+        },
+        "message": { "type": "string", "minLength": 1 },
+        "retryable": { "type": "boolean" }
+      }
+    },
+    "iamAccessKeyPagination": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["offset", "limit", "total", "truncated", "next_offset"],
+      "properties": {
+        "offset": { "type": "integer", "minimum": 0 },
+        "limit": { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "total": { "type": "integer", "minimum": 0, "maximum": 10000 },
+        "truncated": { "type": "boolean" },
+        "next_offset": { "type": ["integer", "null"], "minimum": 0 }
+      }
+    },
+    "iamAccessKeysData": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["operation", "keys", "failures", "pagination"],
+      "properties": {
+        "operation": { "const": "list" },
+        "keys": {
+          "type": "array",
+          "maxItems": 10000,
+          "items": { "$ref": "#/definitions/iamAccessKey" }
+        },
+        "failures": {
+          "type": "array",
+          "maxItems": 3000,
+          "items": { "$ref": "#/definitions/iamAccessKeyFailure" }
+        },
+        "pagination": { "$ref": "#/definitions/iamAccessKeyPagination" }
+      }
+    },
     "replicationDiffEntry": {
       "type": "object",
       "required": [
@@ -1472,6 +1538,17 @@
           "properties": {
             "type": { "const": "iam_policy_detach" },
             "data": { "$ref": "#/definitions/iamPolicyDetachData" }
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        { "$ref": "#/definitions/successEnvelope" },
+        {
+          "properties": {
+            "type": { "const": "iam_access_keys" },
+            "data": { "$ref": "#/definitions/iamAccessKeysData" }
           }
         }
       ]


### PR DESCRIPTION
## Summary

- add `rc admin access-key ls` for bounded, typed bulk inspection across builtin, LDAP, and OpenID identities
- require exact per-provider capability advertisement and fail closed for missing, disabled, stubbed, unknown, or denied capabilities
- batch up to 1,000 selectors, bound responses to 8 MiB / 10,000 records, and provide deterministic offset/limit pagination
- classify service-account and STS keys without retaining secret keys, session tokens, unknown fields, or raw server errors
- preserve per-provider and per-selector failures with stable aggregate exit-code semantics

## BREAKING contract update

The protected command reference and output-v3 schema are extended with the new `iam_access_keys` family. Existing command behavior and existing output families remain backward compatible.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- targeted access-key unit tests (11)
- `crates/cli/tests/admin_access_key_bulk.rs` E2E tests (2)
- `git diff --check`

## Known limits

Pagination is deterministic over each bounded server response but is not a cross-command transactional snapshot if IAM state changes between invocations. Future server versions without an explicit capability contract remain fail closed.

Closes rustfs/backlog#1495
Refs rustfs/backlog#1380