### PR TITLE
feat(replication): render structured active checks

### DIFF
--- a/crates/cli/src/commands/replicate.rs
+++ b/crates/cli/src/commands/replicate.rs
@@ -7,14 +7,17 @@ use clap::{Args, Subcommand};
 use comfy_table::{Cell, Table};
 use rc_core::admin::{AdminApi, ReplicationDiff, ReplicationDiffApi, ReplicationDiffEntry};
 use rc_core::replication::{
-    BucketTarget, BucketTargetCredentials, ReplicationConfiguration, ReplicationDestination,
-    ReplicationResyncStartOptions, ReplicationResyncStartResult, ReplicationResyncStatus,
-    ReplicationResyncTargetStatus, ReplicationRule, ReplicationRuleStatus,
+    BucketTarget, BucketTargetCredentials, ReplicationCheckPhase, ReplicationCheckPhaseState,
+    ReplicationCheckPhases, ReplicationCheckResult, ReplicationCheckStatus, ReplicationCheckTarget,
+    ReplicationConfiguration, ReplicationDestination, ReplicationResyncStartOptions,
+    ReplicationResyncStartResult, ReplicationResyncStatus, ReplicationResyncTargetStatus,
+    ReplicationRule, ReplicationRuleStatus,
 };
 use rc_core::{AliasManager, Error, ObjectStore as _};
 use rc_s3::{AdminClient, S3Client};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::io::{BufRead as _, IsTerminal as _, Write as _};
 use std::path::{Path, PathBuf};
 
 use crate::exit_code::ExitCode;
@@ -350,6 +353,14 @@ struct ReplicationV3Data {
     bucket: String,
     valid: Option<bool>,
     targets: Vec<ReplicationV3Target>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    active_mutation: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mutation_description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    probe_namespace: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    legacy_empty_response: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]
@@ -367,6 +378,29 @@ struct ReplicationV3Target {
     failed_size: Option<u64>,
     current_bucket: Option<String>,
     current_object: Option<String>,
+    error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target_bucket: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    check_status: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    phases: Option<ReplicationV3CheckPhases>,
+}
+
+#[derive(Debug, Serialize)]
+struct ReplicationV3CheckPhases {
+    bucket: ReplicationV3CheckPhase,
+    versioning: ReplicationV3CheckPhase,
+    object_lock: ReplicationV3CheckPhase,
+    put: ReplicationV3CheckPhase,
+    delete_marker: ReplicationV3CheckPhase,
+    version_delete: ReplicationV3CheckPhase,
+    cleanup: ReplicationV3CheckPhase,
+}
+
+#[derive(Debug, Serialize)]
+struct ReplicationV3CheckPhase {
+    status: &'static str,
     error: Option<String>,
 }
 
@@ -1500,33 +1534,213 @@ async fn execute_check(args: CheckArgs, output_config: OutputConfig) -> ExitCode
         Ok(validated) => validated,
         Err(error) => return fail_replication(&formatter, &error, "check"),
     };
-    if !args.yes {
-        return fail_replication(
-            &formatter,
-            &Error::InvalidPath(
-                "Replication check performs a remote write/delete probe; pass --yes to confirm"
-                    .to_string(),
-            ),
-            "check",
-        );
+    if let Err(error) = confirm_replication_check(args.yes, &formatter) {
+        return fail_replication(&formatter, &error, "check");
     }
 
     let client = match setup_replication_operation_client(&alias, args.force).await {
         Ok(client) => client,
         Err(error) => return fail_replication(&formatter, &error, "check"),
     };
-    match client.check_bucket_replication(&bucket).await {
-        Ok(()) => {
-            output_replication_success(&formatter, "check", bucket.clone(), Some(true), Vec::new());
-            if !formatter.is_json() {
-                let display_path = formatter.sanitize_text(&format!("{alias}/{bucket}"));
-                formatter.success(&format!(
-                    "Replication targets for '{display_path}' passed the active validation probe."
-                ));
+    match client.check_bucket_replication_detailed(&bucket).await {
+        Ok(result) => {
+            let succeeded = result.succeeded();
+            output_replication_check(&formatter, &alias, &bucket, result);
+            if succeeded {
+                ExitCode::Success
+            } else {
+                ExitCode::Conflict
             }
-            ExitCode::Success
         }
         Err(error) => fail_replication(&formatter, &error, "check"),
+    }
+}
+
+fn confirm_replication_check(yes: bool, formatter: &Formatter) -> rc_core::Result<()> {
+    if yes {
+        return Ok(());
+    }
+    if formatter.is_json() || !std::io::stdin().is_terminal() {
+        return Err(Error::InvalidPath(
+            "Replication check performs temporary remote writes and deletes; pass --yes in non-interactive or JSON mode"
+                .to_string(),
+        ));
+    }
+
+    let mut stderr = std::io::stderr().lock();
+    write!(
+        stderr,
+        "Replication check writes and deletes a temporary object on every configured target. Continue? [y/N] "
+    )
+    .map_err(Error::Io)?;
+    stderr.flush().map_err(Error::Io)?;
+    let mut answer = String::new();
+    std::io::stdin()
+        .lock()
+        .read_line(&mut answer)
+        .map_err(Error::Io)?;
+    if matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes") {
+        Ok(())
+    } else {
+        Err(Error::Interrupted(
+            "Replication check was declined".to_string(),
+        ))
+    }
+}
+
+fn output_replication_check(
+    formatter: &Formatter,
+    alias: &str,
+    bucket: &str,
+    result: ReplicationCheckResult,
+) {
+    if formatter.is_json() {
+        let succeeded = result.succeeded();
+        let targets = result
+            .targets
+            .into_iter()
+            .map(replication_check_target_output)
+            .collect();
+        formatter.json(&ReplicationV3Output {
+            schema_version: 3,
+            output_type: "replication_operations",
+            status: "success",
+            data: ReplicationV3Data {
+                operation: "check",
+                bucket: bucket.to_string(),
+                valid: Some(succeeded),
+                targets,
+                active_mutation: Some(result.active_mutation),
+                mutation_description: Some(result.mutation_description),
+                probe_namespace: (!result.probe_namespace.is_empty())
+                    .then_some(result.probe_namespace),
+                legacy_empty_response: Some(result.legacy_empty_response),
+            },
+        });
+        return;
+    }
+
+    let display_path = formatter.sanitize_text(&format!("{alias}/{bucket}"));
+    if result.legacy_empty_response {
+        formatter.warning(
+            "The server returned the legacy empty response; no per-target or cleanup detail is available.",
+        );
+        formatter.success(&format!(
+            "Replication targets for '{display_path}' passed the legacy active validation probe."
+        ));
+        return;
+    }
+
+    formatter.warning(&formatter.sanitize_text(&result.mutation_description));
+    formatter.println(&format!(
+        "Replication target check for '{display_path}' (probe namespace '{}'):",
+        formatter.sanitize_text(&result.probe_namespace)
+    ));
+    for target in &result.targets {
+        output_replication_check_target(formatter, target);
+    }
+    if result.succeeded() {
+        formatter.success("Every configured replication target passed all active check phases.");
+    } else {
+        formatter.warning(
+            "One or more targets failed; inspect cleanup first because a temporary probe artifact may remain.",
+        );
+    }
+}
+
+fn replication_check_target_output(target: ReplicationCheckTarget) -> ReplicationV3Target {
+    ReplicationV3Target {
+        target_arn: target.target_arn,
+        reset_id: String::new(),
+        reset_before: None,
+        started_at: None,
+        last_updated_at: None,
+        state: None,
+        server_state: None,
+        replicated_count: None,
+        replicated_size: None,
+        failed_count: None,
+        failed_size: None,
+        current_bucket: None,
+        current_object: None,
+        error: target.error,
+        target_bucket: Some(target.bucket),
+        check_status: Some(replication_check_status_name(target.status)),
+        phases: Some(replication_check_phases_output(target.phases)),
+    }
+}
+
+fn replication_check_phases_output(phases: ReplicationCheckPhases) -> ReplicationV3CheckPhases {
+    ReplicationV3CheckPhases {
+        bucket: replication_check_phase_output(phases.bucket),
+        versioning: replication_check_phase_output(phases.versioning),
+        object_lock: replication_check_phase_output(phases.object_lock),
+        put: replication_check_phase_output(phases.put),
+        delete_marker: replication_check_phase_output(phases.delete_marker),
+        version_delete: replication_check_phase_output(phases.version_delete),
+        cleanup: replication_check_phase_output(phases.cleanup),
+    }
+}
+
+fn replication_check_phase_output(phase: ReplicationCheckPhase) -> ReplicationV3CheckPhase {
+    ReplicationV3CheckPhase {
+        status: replication_check_phase_name(phase.status),
+        error: phase.error,
+    }
+}
+
+const fn replication_check_status_name(status: ReplicationCheckStatus) -> &'static str {
+    match status {
+        ReplicationCheckStatus::Ok => "ok",
+        ReplicationCheckStatus::Failed => "failed",
+    }
+}
+
+const fn replication_check_phase_name(status: ReplicationCheckPhaseState) -> &'static str {
+    match status {
+        ReplicationCheckPhaseState::Ok => "ok",
+        ReplicationCheckPhaseState::Failed => "failed",
+        ReplicationCheckPhaseState::Skipped => "skipped",
+    }
+}
+
+fn output_replication_check_target(formatter: &Formatter, target: &ReplicationCheckTarget) {
+    formatter.println(&format!(
+        "  {} -> {} [{}]",
+        formatter.sanitize_text(&target.target_arn),
+        formatter.sanitize_text(&target.bucket),
+        replication_check_status_name(target.status)
+    ));
+    let phases = [
+        ("bucket", &target.phases.bucket),
+        ("versioning", &target.phases.versioning),
+        ("object lock", &target.phases.object_lock),
+        ("put", &target.phases.put),
+        ("delete marker", &target.phases.delete_marker),
+        ("version delete", &target.phases.version_delete),
+        ("cleanup", &target.phases.cleanup),
+    ];
+    for (name, phase) in phases {
+        let detail = phase
+            .error
+            .as_deref()
+            .map(|error| format!(": {}", formatter.sanitize_text(error)))
+            .unwrap_or_default();
+        let line = format!(
+            "    {name}: {}{detail}",
+            replication_check_phase_name(phase.status)
+        );
+        if phase.status == ReplicationCheckPhaseState::Failed {
+            formatter.warning(&line);
+        } else {
+            formatter.println(&line);
+        }
+    }
+    if let Some(error) = target.error.as_deref() {
+        formatter.warning(&format!(
+            "    target error: {}",
+            formatter.sanitize_text(error)
+        ));
     }
 }
 
@@ -1738,6 +1952,10 @@ fn output_replication_success(
                 bucket,
                 valid,
                 targets,
+                active_mutation: None,
+                mutation_description: None,
+                probe_namespace: None,
+                legacy_empty_response: None,
             },
         });
     }
@@ -1759,6 +1977,9 @@ fn start_target_output(result: &ReplicationResyncStartResult) -> ReplicationV3Ta
         current_bucket: None,
         current_object: None,
         error: None,
+        target_bucket: None,
+        check_status: None,
+        phases: None,
     }
 }
 
@@ -1778,6 +1999,9 @@ fn status_target_output(target: ReplicationResyncTargetStatus) -> ReplicationV3T
         current_bucket: target.current_bucket,
         current_object: target.current_object,
         error: target.error,
+        target_bucket: None,
+        check_status: None,
+        phases: None,
     }
 }
 
@@ -2920,6 +3144,10 @@ mod tests {
                 bucket: "source-bucket".to_string(),
                 valid: None,
                 targets: vec![target],
+                active_mutation: None,
+                mutation_description: None,
+                probe_namespace: None,
+                legacy_empty_response: None,
             },
         })
         .expect("serialize replication v3 output");
@@ -2928,6 +3156,70 @@ mod tests {
         assert_eq!(value["type"], "replication_operations");
         assert_eq!(value["data"]["targets"][0]["state"], "unknown");
         assert_eq!(value["data"]["targets"][0]["server_state"], "FutureState");
+    }
+
+    #[test]
+    fn replication_check_output_preserves_partial_and_cleanup_detail() {
+        let ok = || ReplicationCheckPhase {
+            status: ReplicationCheckPhaseState::Ok,
+            error: None,
+        };
+        let target = replication_check_target_output(ReplicationCheckTarget {
+            target_arn: "arn:rustfs:replication::id:backup".to_string(),
+            bucket: "replica".to_string(),
+            status: ReplicationCheckStatus::Failed,
+            error: Some("probe cleanup failed".to_string()),
+            phases: ReplicationCheckPhases {
+                bucket: ok(),
+                versioning: ok(),
+                object_lock: ok(),
+                put: ok(),
+                delete_marker: ok(),
+                version_delete: ok(),
+                cleanup: ReplicationCheckPhase {
+                    status: ReplicationCheckPhaseState::Failed,
+                    error: Some("cleanup denied".to_string()),
+                },
+            },
+        });
+        let value = serde_json::to_value(ReplicationV3Output {
+            schema_version: 3,
+            output_type: "replication_operations",
+            status: "success",
+            data: ReplicationV3Data {
+                operation: "check",
+                bucket: "source-bucket".to_string(),
+                valid: Some(false),
+                targets: vec![target],
+                active_mutation: Some(true),
+                mutation_description: Some("temporary probe".to_string()),
+                probe_namespace: Some(".rustfs.sys/replication-check/".to_string()),
+                legacy_empty_response: Some(false),
+            },
+        })
+        .expect("serialize structured check output");
+
+        assert_eq!(value["data"]["valid"], false);
+        assert_eq!(value["data"]["active_mutation"], true);
+        assert_eq!(value["data"]["targets"][0]["check_status"], "failed");
+        assert_eq!(
+            value["data"]["targets"][0]["phases"]["cleanup"]["status"],
+            "failed"
+        );
+        assert_eq!(
+            value["data"]["targets"][0]["phases"]["cleanup"]["error"],
+            "cleanup denied"
+        );
+    }
+
+    #[test]
+    fn legacy_check_result_is_explicit_without_target_fabrication() {
+        let result = ReplicationCheckResult::legacy_success();
+
+        assert!(result.succeeded());
+        assert!(result.legacy_empty_response);
+        assert!(result.targets.is_empty());
+        assert!(result.probe_namespace.is_empty());
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -57,9 +57,11 @@ pub use ops::{
 };
 pub use path::{ParsedPath, RemotePath, parse_object_path, parse_path};
 pub use replication::{
-    BucketTarget, BucketTargetCredentials, ReplicationConfiguration, ReplicationDestination,
-    ReplicationResyncStartOptions, ReplicationResyncStartResult, ReplicationResyncState,
-    ReplicationResyncStatus, ReplicationResyncTargetStatus, ReplicationRule, ReplicationRuleStatus,
+    BucketTarget, BucketTargetCredentials, ReplicationCheckPhase, ReplicationCheckPhaseState,
+    ReplicationCheckPhases, ReplicationCheckResult, ReplicationCheckStatus, ReplicationCheckTarget,
+    ReplicationConfiguration, ReplicationDestination, ReplicationResyncStartOptions,
+    ReplicationResyncStartResult, ReplicationResyncState, ReplicationResyncStatus,
+    ReplicationResyncTargetStatus, ReplicationRule, ReplicationRuleStatus,
 };
 pub use retry::{RetryBuilder, is_retryable_error, retry_with_backoff};
 pub use select::{

--- a/crates/core/src/replication.rs
+++ b/crates/core/src/replication.rs
@@ -7,6 +7,109 @@ use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::time::Duration;
 
+/// Overall or per-target outcome of an active replication check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReplicationCheckStatus {
+    #[serde(rename = "OK")]
+    Ok,
+    #[serde(rename = "FAILED")]
+    Failed,
+}
+
+/// Outcome of one phase in an active replication check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReplicationCheckPhaseState {
+    #[serde(rename = "OK")]
+    Ok,
+    #[serde(rename = "FAILED")]
+    Failed,
+    #[serde(rename = "SKIPPED")]
+    Skipped,
+}
+
+/// One phase of the server's active target validation state machine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicationCheckPhase {
+    #[serde(rename = "Status")]
+    pub status: ReplicationCheckPhaseState,
+    #[serde(rename = "Error", default)]
+    pub error: Option<String>,
+}
+
+/// All phases reported for one configured replication target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicationCheckPhases {
+    #[serde(rename = "Bucket")]
+    pub bucket: ReplicationCheckPhase,
+    #[serde(rename = "Versioning")]
+    pub versioning: ReplicationCheckPhase,
+    #[serde(rename = "ObjectLock")]
+    pub object_lock: ReplicationCheckPhase,
+    #[serde(rename = "Put")]
+    pub put: ReplicationCheckPhase,
+    #[serde(rename = "DeleteMarker")]
+    pub delete_marker: ReplicationCheckPhase,
+    #[serde(rename = "VersionDelete")]
+    pub version_delete: ReplicationCheckPhase,
+    #[serde(rename = "Cleanup")]
+    pub cleanup: ReplicationCheckPhase,
+}
+
+/// Structured outcome for one configured replication target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicationCheckTarget {
+    #[serde(rename = "Arn")]
+    pub target_arn: String,
+    #[serde(rename = "Bucket")]
+    pub bucket: String,
+    #[serde(rename = "Status")]
+    pub status: ReplicationCheckStatus,
+    #[serde(rename = "Error", default)]
+    pub error: Option<String>,
+    #[serde(rename = "Phases")]
+    pub phases: ReplicationCheckPhases,
+}
+
+/// Result of the active replication-target validation extension.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReplicationCheckResult {
+    /// Optional explicit contract version for forward-compatible servers.
+    #[serde(rename = "Version", default, skip_serializing_if = "Option::is_none")]
+    pub contract_version: Option<u32>,
+    #[serde(rename = "Status")]
+    pub status: ReplicationCheckStatus,
+    #[serde(rename = "ActiveMutation")]
+    pub active_mutation: bool,
+    #[serde(rename = "MutationDescription")]
+    pub mutation_description: String,
+    #[serde(rename = "ProbeNamespace")]
+    pub probe_namespace: String,
+    #[serde(rename = "Targets")]
+    pub targets: Vec<ReplicationCheckTarget>,
+    /// True only for the successful empty-body contract used by older servers.
+    #[serde(skip)]
+    pub legacy_empty_response: bool,
+}
+
+impl ReplicationCheckResult {
+    /// Represent the legacy server contract that returned no target detail.
+    pub fn legacy_success() -> Self {
+        Self {
+            contract_version: None,
+            status: ReplicationCheckStatus::Ok,
+            active_mutation: true,
+            mutation_description: "Legacy active write/delete replication probe".to_string(),
+            probe_namespace: String::new(),
+            targets: Vec::new(),
+            legacy_empty_response: true,
+        }
+    }
+
+    pub fn succeeded(&self) -> bool {
+        self.status == ReplicationCheckStatus::Ok
+    }
+}
+
 /// Options for starting a RustFS bucket replication resync.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct ReplicationResyncStartOptions {

--- a/crates/core/src/traits.rs
+++ b/crates/core/src/traits.rs
@@ -22,8 +22,8 @@ use crate::object_lock::{
 };
 use crate::path::RemotePath;
 use crate::replication::{
-    ReplicationConfiguration, ReplicationResyncStartOptions, ReplicationResyncStartResult,
-    ReplicationResyncStatus,
+    ReplicationCheckResult, ReplicationConfiguration, ReplicationResyncStartOptions,
+    ReplicationResyncStartResult, ReplicationResyncStatus,
 };
 use crate::select::SelectOptions;
 use crate::transfer_options::{
@@ -1053,8 +1053,19 @@ pub trait ObjectStore: Send + Sync {
     /// Delete bucket replication configuration.
     async fn delete_bucket_replication(&self, bucket: &str) -> Result<()>;
 
-    /// Actively validate configured replication targets.
+    /// Actively validate configured replication targets using the legacy
+    /// success/failure contract.
     async fn check_bucket_replication(&self, bucket: &str) -> Result<()>;
+
+    /// Actively validate configured replication targets and retain structured
+    /// per-target and cleanup outcomes when the server provides them.
+    async fn check_bucket_replication_detailed(
+        &self,
+        bucket: &str,
+    ) -> Result<ReplicationCheckResult> {
+        self.check_bucket_replication(bucket).await?;
+        Ok(ReplicationCheckResult::legacy_success())
+    }
 
     /// Start a server-side bucket replication resync.
     async fn start_bucket_replication_resync(

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -44,10 +44,12 @@ use rc_core::{
     ObjectEncryptionRequest, ObjectInfo, ObjectLockOptions, ObjectReadOptions, ObjectRetention,
     ObjectStore, ObjectTransferMetadata, ObjectVersion, ObjectVersionIdentifier,
     ObjectVersionListResult, ObjectWriteEncryption, ObjectWriteOptions, RemotePath,
-    ReplicationConfiguration, ReplicationResyncStartOptions, ReplicationResyncStartResult,
-    ReplicationResyncState, ReplicationResyncStatus, ReplicationResyncTargetStatus, RequestHeader,
-    Result, RetentionDuration, RetentionDurationUnit, RetentionMode, SelectOptions, SseCustomerKey,
-    TransferCopyOptions, TransferReadOptions, global_request_headers,
+    ReplicationCheckPhase, ReplicationCheckPhaseState, ReplicationCheckResult,
+    ReplicationCheckStatus, ReplicationConfiguration, ReplicationResyncStartOptions,
+    ReplicationResyncStartResult, ReplicationResyncState, ReplicationResyncStatus,
+    ReplicationResyncTargetStatus, RequestHeader, Result, RetentionDuration, RetentionDurationUnit,
+    RetentionMode, SelectOptions, SseCustomerKey, TransferCopyOptions, TransferReadOptions,
+    global_request_headers,
 };
 use reqwest::Method;
 use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
@@ -68,6 +70,70 @@ const S3_SERVICE_NAME: &str = "s3";
 const S3_REPLICATION_XML_NAMESPACE: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
 const RUSTFS_FORCE_DELETE_HEADER: &str = "x-rustfs-force-delete";
 const REPLICATION_EXTENSION_BODY_LIMIT: u64 = 1024 * 1024;
+const REPLICATION_CHECK_PROBE_NAMESPACE: &str = ".rustfs.sys/replication-check/";
+const REPLICATION_CHECK_ERROR_LIMIT: usize = 512;
+const REPLICATION_CHECK_DESCRIPTION_LIMIT: usize = 1024;
+
+fn contains_control_characters(value: &str) -> bool {
+    value.chars().any(char::is_control)
+}
+
+fn validate_replication_check_error(error: Option<&str>) -> Result<()> {
+    if error.is_some_and(|value| {
+        value.is_empty()
+            || value.len() > REPLICATION_CHECK_ERROR_LIMIT
+            || contains_control_characters(value)
+    }) {
+        return Err(Error::General(
+            "Malformed structured replication check response".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_replication_check_phase(phase: &ReplicationCheckPhase) -> Result<()> {
+    validate_replication_check_error(phase.error.as_deref())?;
+    let error_matches_status = match phase.status {
+        ReplicationCheckPhaseState::Failed => phase.error.is_some(),
+        ReplicationCheckPhaseState::Ok | ReplicationCheckPhaseState::Skipped => {
+            phase.error.is_none()
+        }
+    };
+    if !error_matches_status {
+        return Err(Error::General(
+            "Malformed structured replication check response".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn replication_check_phases(
+    phases: &rc_core::ReplicationCheckPhases,
+) -> [&ReplicationCheckPhase; 7] {
+    [
+        &phases.bucket,
+        &phases.versioning,
+        &phases.object_lock,
+        &phases.put,
+        &phases.delete_marker,
+        &phases.version_delete,
+        &phases.cleanup,
+    ]
+}
+
+fn replication_check_phases_mut(
+    phases: &mut rc_core::ReplicationCheckPhases,
+) -> [&mut ReplicationCheckPhase; 7] {
+    [
+        &mut phases.bucket,
+        &mut phases.versioning,
+        &mut phases.object_lock,
+        &mut phases.put,
+        &mut phases.delete_marker,
+        &mut phases.version_delete,
+        &mut phases.cleanup,
+    ]
+}
 
 #[derive(Debug, Clone, Copy)]
 enum ObjectWritePrecondition<'a> {
@@ -2908,6 +2974,102 @@ impl S3Client {
             Error::Network(message)
         } else {
             Error::General(message)
+        }
+    }
+
+    fn parse_replication_check_response(&self, body: &[u8]) -> Result<ReplicationCheckResult> {
+        if body.is_empty() {
+            return Ok(ReplicationCheckResult::legacy_success());
+        }
+
+        let mut result = serde_json::from_slice::<ReplicationCheckResult>(body).map_err(|_| {
+            Error::General("Malformed structured replication check response".to_string())
+        })?;
+        if result.contract_version.is_some_and(|version| version != 1)
+            || !result.active_mutation
+            || result.probe_namespace != REPLICATION_CHECK_PROBE_NAMESPACE
+            || result.mutation_description.is_empty()
+            || result.mutation_description.len() > REPLICATION_CHECK_DESCRIPTION_LIMIT
+            || contains_control_characters(&result.mutation_description)
+            || result.targets.is_empty()
+        {
+            return Err(Error::General(
+                "Malformed structured replication check response".to_string(),
+            ));
+        }
+
+        let expected_status = if result
+            .targets
+            .iter()
+            .all(|target| target.status == ReplicationCheckStatus::Ok)
+        {
+            ReplicationCheckStatus::Ok
+        } else {
+            ReplicationCheckStatus::Failed
+        };
+        if result.status != expected_status {
+            return Err(Error::General(
+                "Malformed structured replication check response".to_string(),
+            ));
+        }
+
+        for target in &mut result.targets {
+            if target.target_arn.is_empty()
+                || target.bucket.is_empty()
+                || contains_control_characters(&target.target_arn)
+                || contains_control_characters(&target.bucket)
+            {
+                return Err(Error::General(
+                    "Malformed structured replication check response".to_string(),
+                ));
+            }
+            target.target_arn = self.redact_sensitive_text(std::mem::take(&mut target.target_arn));
+            target.bucket = self.redact_sensitive_text(std::mem::take(&mut target.bucket));
+            validate_replication_check_error(target.error.as_deref())?;
+            if let Some(error) = target.error.take() {
+                target.error = Some(self.sanitize_replication_check_error(error));
+            }
+            for phase in replication_check_phases_mut(&mut target.phases) {
+                validate_replication_check_phase(phase)?;
+                if let Some(error) = phase.error.take() {
+                    phase.error = Some(self.sanitize_replication_check_error(error));
+                }
+            }
+
+            let any_failed = replication_check_phases(&target.phases)
+                .into_iter()
+                .any(|phase| phase.status == ReplicationCheckPhaseState::Failed);
+            if (target.status == ReplicationCheckStatus::Failed)
+                != (any_failed || target.error.is_some())
+            {
+                return Err(Error::General(
+                    "Malformed structured replication check response".to_string(),
+                ));
+            }
+        }
+
+        result.mutation_description = self.redact_sensitive_text(result.mutation_description);
+        Ok(result)
+    }
+
+    fn sanitize_replication_check_error(&self, error: String) -> String {
+        let redacted = self.redact_sensitive_text(error);
+        let lower = redacted.to_ascii_lowercase();
+        if [
+            "http://",
+            "https://",
+            "authorization",
+            "x-amz-credential",
+            "x-amz-signature",
+            "secret-key",
+            "access-key",
+        ]
+        .iter()
+        .any(|marker| lower.contains(marker))
+        {
+            "server reported a redacted replication check failure".to_string()
+        } else {
+            redacted
         }
     }
 
@@ -6409,16 +6571,25 @@ impl ObjectStore for S3Client {
     }
 
     async fn check_bucket_replication(&self, bucket: &str) -> Result<()> {
+        let result = self.check_bucket_replication_detailed(bucket).await?;
+        if result.succeeded() {
+            Ok(())
+        } else {
+            Err(Error::Conflict(
+                "One or more replication targets failed the active check".to_string(),
+            ))
+        }
+    }
+
+    async fn check_bucket_replication_detailed(
+        &self,
+        bucket: &str,
+    ) -> Result<ReplicationCheckResult> {
         let url = self.replication_extension_url(bucket, "replication-check", &[])?;
         let body = self
             .signed_replication_extension_request(Method::GET, url)
             .await?;
-        if !body.is_empty() {
-            return Err(Error::General(
-                "Malformed replication check response: expected an empty body".to_string(),
-            ));
-        }
-        Ok(())
+        self.parse_replication_check_response(&body)
     }
 
     async fn start_bucket_replication_resync(
@@ -8974,10 +9145,12 @@ mod tests {
         );
         let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
 
-        client
-            .check_bucket_replication("source-bucket")
+        let result = client
+            .check_bucket_replication_detailed("source-bucket")
             .await
             .expect("replication check should succeed");
+        assert!(result.legacy_empty_response);
+        assert!(result.succeeded());
 
         let request = receiver
             .recv_timeout(Duration::from_secs(5))
@@ -9315,7 +9488,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn replication_check_rejects_nonempty_success_body() {
+    async fn replication_check_rejects_malformed_nonempty_success_body() {
         let response =
             b"HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\nok".to_vec();
         let (endpoint, _receiver, handle) = start_replication_extension_test_server(response);
@@ -9328,6 +9501,97 @@ mod tests {
 
         assert!(matches!(error, Error::General(_)));
         handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn replication_check_retains_structured_partial_and_cleanup_outcomes() {
+        let body = br#"{"Status":"FAILED","ActiveMutation":true,"MutationDescription":"Writes and deletes a temporary probe.","ProbeNamespace":".rustfs.sys/replication-check/","Targets":[{"Arn":"arn:target","Bucket":"replica","Status":"FAILED","Error":"probe cleanup failed","Phases":{"Bucket":{"Status":"OK"},"Versioning":{"Status":"OK"},"ObjectLock":{"Status":"OK"},"Put":{"Status":"OK"},"DeleteMarker":{"Status":"OK"},"VersionDelete":{"Status":"OK"},"Cleanup":{"Status":"FAILED","Error":"cleanup denied"}}}]}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        )
+        .into_bytes()
+        .into_iter()
+        .chain(body.iter().copied())
+        .collect();
+        let (endpoint, _receiver, handle) = start_replication_extension_test_server(response);
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
+
+        let result = client
+            .check_bucket_replication_detailed("source-bucket")
+            .await
+            .expect("structured failure is a completed check");
+
+        assert!(!result.succeeded());
+        assert!(!result.legacy_empty_response);
+        assert_eq!(result.targets.len(), 1);
+        assert_eq!(
+            result.targets[0].phases.cleanup.status,
+            ReplicationCheckPhaseState::Failed
+        );
+        assert_eq!(
+            result.targets[0].phases.cleanup.error.as_deref(),
+            Some("cleanup denied")
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn legacy_replication_check_method_maps_structured_failure_to_conflict() {
+        let body = br#"{"Status":"FAILED","ActiveMutation":true,"MutationDescription":"probe","ProbeNamespace":".rustfs.sys/replication-check/","Targets":[{"Arn":"arn:target","Bucket":"replica","Status":"FAILED","Error":"bucket unavailable","Phases":{"Bucket":{"Status":"FAILED","Error":"bucket unavailable"},"Versioning":{"Status":"SKIPPED"},"ObjectLock":{"Status":"SKIPPED"},"Put":{"Status":"SKIPPED"},"DeleteMarker":{"Status":"SKIPPED"},"VersionDelete":{"Status":"SKIPPED"},"Cleanup":{"Status":"OK"}}}]}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        )
+        .into_bytes()
+        .into_iter()
+        .chain(body.iter().copied())
+        .collect();
+        let (endpoint, _receiver, handle) = start_replication_extension_test_server(response);
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
+
+        let error = client
+            .check_bucket_replication("source-bucket")
+            .await
+            .expect_err("legacy method must not discard structured failure");
+
+        assert!(matches!(error, Error::Conflict(_)));
+        handle.join().expect("server thread should finish");
+    }
+
+    #[test]
+    fn replication_check_rejects_inconsistent_or_unsafe_structured_results() {
+        let (client, _) = test_s3_client(None);
+        let inconsistent = br#"{"Status":"OK","ActiveMutation":true,"MutationDescription":"probe","ProbeNamespace":".rustfs.sys/replication-check/","Targets":[{"Arn":"arn:target","Bucket":"replica","Status":"FAILED","Error":"failed","Phases":{"Bucket":{"Status":"FAILED","Error":"failed"},"Versioning":{"Status":"SKIPPED"},"ObjectLock":{"Status":"SKIPPED"},"Put":{"Status":"SKIPPED"},"DeleteMarker":{"Status":"SKIPPED"},"VersionDelete":{"Status":"SKIPPED"},"Cleanup":{"Status":"OK"}}}]}"#;
+        let control_character = br#"{"Status":"FAILED","ActiveMutation":true,"MutationDescription":"probe","ProbeNamespace":".rustfs.sys/replication-check/","Targets":[{"Arn":"arn:target","Bucket":"replica","Status":"FAILED","Error":"unsafe\nline","Phases":{"Bucket":{"Status":"FAILED","Error":"failed"},"Versioning":{"Status":"SKIPPED"},"ObjectLock":{"Status":"SKIPPED"},"Put":{"Status":"SKIPPED"},"DeleteMarker":{"Status":"SKIPPED"},"VersionDelete":{"Status":"SKIPPED"},"Cleanup":{"Status":"OK"}}}]}"#;
+        let unsupported_version = br#"{"Version":2,"Status":"OK","ActiveMutation":true,"MutationDescription":"probe","ProbeNamespace":".rustfs.sys/replication-check/","Targets":[{"Arn":"arn:target","Bucket":"replica","Status":"OK","Phases":{"Bucket":{"Status":"OK"},"Versioning":{"Status":"OK"},"ObjectLock":{"Status":"OK"},"Put":{"Status":"OK"},"DeleteMarker":{"Status":"OK"},"VersionDelete":{"Status":"OK"},"Cleanup":{"Status":"OK"}}}]}"#;
+
+        for body in [
+            inconsistent.as_slice(),
+            control_character.as_slice(),
+            unsupported_version.as_slice(),
+        ] {
+            assert!(matches!(
+                client.parse_replication_check_response(body),
+                Err(Error::General(_))
+            ));
+        }
+    }
+
+    #[test]
+    fn replication_check_redacts_endpoint_and_signature_details() {
+        let (client, _) = test_s3_client(None);
+        let body = br#"{"Status":"FAILED","ActiveMutation":true,"MutationDescription":"probe","ProbeNamespace":".rustfs.sys/replication-check/","Targets":[{"Arn":"arn:target","Bucket":"replica","Status":"FAILED","Error":"request https://user:pass@example.test?X-Amz-Signature=secret failed","Phases":{"Bucket":{"Status":"FAILED","Error":"request https://example.test failed"},"Versioning":{"Status":"SKIPPED"},"ObjectLock":{"Status":"SKIPPED"},"Put":{"Status":"SKIPPED"},"DeleteMarker":{"Status":"SKIPPED"},"VersionDelete":{"Status":"SKIPPED"},"Cleanup":{"Status":"OK"}}}]}"#;
+
+        let result = client
+            .parse_replication_check_response(body)
+            .expect("unsafe remote details should be replaced");
+        let serialized = serde_json::to_string(&result).expect("serialize redacted result");
+
+        assert!(serialized.contains("redacted replication check failure"));
+        assert!(!serialized.contains("example.test"));
+        assert!(!serialized.contains("X-Amz-Signature"));
+        assert!(!serialized.contains("user:pass"));
     }
 
     #[test]

--- a/docs/replication-check.md
+++ b/docs/replication-check.md
@@ -1,0 +1,32 @@
+# Active replication target checks
+
+`rc replicate check ALIAS/BUCKET` validates every replication target referenced
+by the source bucket configuration. Despite using an HTTP GET extension, the
+operation is active: RustFS writes a temporary probe object, creates a delete
+marker, deletes the probe version, and attempts final cleanup on each target.
+
+Interactive use asks for confirmation. Automation and JSON mode must pass
+`--yes` explicitly:
+
+```console
+rc replicate check local/source --yes
+rc --json replicate check local/source --yes
+```
+
+Current RustFS servers return the outcome of every target and each bucket,
+versioning, object-lock, put, delete-marker, version-delete, and cleanup phase.
+A failed cleanup is highlighted because a probe artifact may remain. The
+command exits successfully only when the overall result is successful; a
+completed check with failed targets still prints its structured JSON result and
+returns a conflict exit status.
+
+Older compatible servers return an empty success body. `rc` accepts that
+response but reports it as a legacy result with no per-target or cleanup
+evidence. Malformed structured responses are rejected instead of being treated
+as legacy success.
+
+Probe keys are allocated by the server below
+`.rustfs.sys/replication-check/`. Output sanitizes control characters, and the
+client rejects unbounded or structurally inconsistent error details. Do not
+grant the invoking source credential more permissions than the replication
+administration operation requires.


### PR DESCRIPTION
## Summary

- consume RustFS's structured active replication-check response while retaining
  compatibility with the legacy successful empty body
- add typed core contracts for overall, per-target, and per-phase outcomes and
  a default detailed trait method so other object-store implementations remain
  source compatible
- render all target and bucket/versioning/object-lock/put/delete-marker/
  version-delete/cleanup results in stable human and output-v3 JSON
- return a conflict exit status for a completed structured check containing
  failed targets while still emitting the complete result
- require an interactive confirmation or explicit `--yes` in non-interactive
  and JSON modes, with the active temporary mutation described before execution
- validate aggregate/target/phase consistency, the reserved probe namespace,
  bounded single-line errors, and optional contract version
- reject malformed/future unsupported responses, redact credentials, signed
  URLs and endpoint details, and sanitize server-controlled terminal text
- preserve the old `check_bucket_replication()` failure semantics instead of
  discarding a structured failed result
- document active mutation, cleanup risk, legacy limitations, and automation
  behavior

## Compatibility

Existing output-v1 and protected command references are unchanged. The
output-v3 `replication_operations` family already allows additive target/data
fields, so existing resync fixtures remain byte-for-byte unchanged.

Older servers returning an empty HTTP 200 body continue to succeed, but the
client explicitly reports that no per-target or cleanup evidence is available.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p rc-s3 replication_check` (6 passed)
- `cargo test --workspace` (all unit, integration, schema, golden, and doc tests
  passed on the final source)
- the one unrelated transient local fixture disconnect observed on the first
  workspace run passed when rerun alone and on the complete second workspace
  run
- `git diff --check`

Adversarial review:

- Security/redaction: PASS
- Contract correctness: PASS
- Failure/exit semantics: PASS
- Compatibility: PASS
- Resource bounds: PASS
- Test quality: PASS
- Operator documentation: PASS

## Dependency

The structured service response is implemented by rustfs/rustfs#5208 and
rustfs/backlog#1417. Merge this PR after that dependency.

Closes rustfs/backlog#1496

Related: rustfs/backlog#1410, rustfs/backlog#1381, rustfs/backlog#1361
