### PR TITLE
feat(admin): add manual transition job controls

### DIFF
--- a/crates/cli/src/commands/admin/ilm.rs
+++ b/crates/cli/src/commands/admin/ilm.rs
@@ -1,8 +1,12 @@
 //! ILM administration commands.
 
 use clap::{Args, Subcommand};
-use rc_core::admin::{AdminApi, ManualTransitionRunRequest, ManualTransitionRunResponse};
+use rc_core::Error;
+use rc_core::admin::{
+    AdminApi, ManualTransitionJobResponse, ManualTransitionRunRequest, ManualTransitionRunResponse,
+};
 use serde::Serialize;
+use tokio::time::{Duration, Instant, sleep};
 
 use super::{emit_observability_error, get_admin_client};
 use crate::exit_code::ExitCode;
@@ -22,6 +26,15 @@ pub enum IlmCommands {
 pub enum TransitionCommands {
     /// Run bounded lifecycle transition evaluation for existing objects
     Run(ManualTransitionRunArgs),
+
+    /// Show durable lifecycle transition job status
+    Status(ManualTransitionJobArgs),
+
+    /// Request cancellation for a durable lifecycle transition job
+    Cancel(ManualTransitionJobArgs),
+
+    /// Wait until a durable lifecycle transition job reaches a terminal state
+    Wait(ManualTransitionWaitArgs),
 }
 
 #[derive(Args, Debug)]
@@ -44,6 +57,10 @@ pub struct ManualTransitionRunArgs {
     #[arg(long)]
     pub dry_run: bool,
 
+    /// Start a durable background job and return its job endpoints
+    #[arg(long = "async")]
+    pub async_mode: bool,
+
     /// Maximum number of object versions to scan
     #[arg(long, default_value_t = 10_000, value_parser = clap::value_parser!(u64).range(1..=MAX_MANUAL_TRANSITION_OBJECTS))]
     pub max_objects: u64,
@@ -51,6 +68,32 @@ pub struct ManualTransitionRunArgs {
     /// Best-effort seconds budget checked between listed object versions
     #[arg(long, value_parser = clap::value_parser!(u64).range(1..=MAX_MANUAL_TRANSITION_DURATION_SECONDS))]
     pub max_duration_seconds: Option<u64>,
+}
+
+#[derive(Args, Debug)]
+pub struct ManualTransitionJobArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Durable manual transition job ID returned by `transition run --async`
+    pub job_id: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ManualTransitionWaitArgs {
+    /// Alias name of the server
+    pub alias: String,
+
+    /// Durable manual transition job ID returned by `transition run --async`
+    pub job_id: String,
+
+    /// Seconds between status polls
+    #[arg(long, default_value_t = 2, value_parser = clap::value_parser!(u64).range(1..=60))]
+    pub poll_interval_seconds: u64,
+
+    /// Maximum seconds to wait before returning an error
+    #[arg(long, value_parser = clap::value_parser!(u64).range(1..=86_400))]
+    pub timeout_seconds: Option<u64>,
 }
 
 #[derive(Debug, Serialize)]
@@ -62,10 +105,28 @@ struct ManualTransitionRunSuccessOutput<'a> {
     data: &'a ManualTransitionRunResponse,
 }
 
+#[derive(Debug, Serialize)]
+struct ManualTransitionJobSuccessOutput<'a> {
+    schema_version: u8,
+    #[serde(rename = "type")]
+    output_type: &'static str,
+    status: &'static str,
+    data: &'a ManualTransitionJobResponse,
+}
+
 pub async fn execute(command: IlmCommands, formatter: &Formatter) -> ExitCode {
     match command {
         IlmCommands::Transition(TransitionCommands::Run(args)) => {
             execute_manual_transition_run(args, formatter).await
+        }
+        IlmCommands::Transition(TransitionCommands::Status(args)) => {
+            execute_manual_transition_status(args, formatter).await
+        }
+        IlmCommands::Transition(TransitionCommands::Cancel(args)) => {
+            execute_manual_transition_cancel(args, formatter).await
+        }
+        IlmCommands::Transition(TransitionCommands::Wait(args)) => {
+            execute_manual_transition_wait(args, formatter).await
         }
     }
 }
@@ -88,7 +149,13 @@ async fn execute_manual_transition_run(
         max_duration_seconds: args.max_duration_seconds,
     };
 
-    match client.run_manual_transition(request).await {
+    let result = if args.async_mode {
+        client.run_manual_transition_async(request).await
+    } else {
+        client.run_manual_transition(request).await
+    };
+
+    match result {
         Ok(response) => {
             if formatter.is_json() {
                 formatter.json(&ManualTransitionRunSuccessOutput {
@@ -112,6 +179,101 @@ async fn execute_manual_transition_run(
     }
 }
 
+async fn execute_manual_transition_status(
+    args: ManualTransitionJobArgs,
+    formatter: &Formatter,
+) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    match client.manual_transition_job_status(&args.job_id).await {
+        Ok(response) => {
+            print_manual_transition_job("manual_transition_job_status", &response, formatter);
+            ExitCode::Success
+        }
+        Err(error) => emit_observability_error(
+            "manual_transition_job_status",
+            "admin.ilm-transition-job",
+            "Failed to get manual transition job status",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn execute_manual_transition_cancel(
+    args: ManualTransitionJobArgs,
+    formatter: &Formatter,
+) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    match client.cancel_manual_transition_job(&args.job_id).await {
+        Ok(response) => {
+            print_manual_transition_job("manual_transition_job_cancel", &response, formatter);
+            ExitCode::Success
+        }
+        Err(error) => emit_observability_error(
+            "manual_transition_job_cancel",
+            "admin.ilm-transition-job",
+            "Failed to cancel manual transition job",
+            &error,
+            formatter,
+        ),
+    }
+}
+
+async fn execute_manual_transition_wait(
+    args: ManualTransitionWaitArgs,
+    formatter: &Formatter,
+) -> ExitCode {
+    let client = match get_admin_client(&args.alias, formatter) {
+        Ok(client) => client,
+        Err(code) => return code,
+    };
+
+    let deadline = args
+        .timeout_seconds
+        .map(|seconds| Instant::now() + Duration::from_secs(seconds));
+    let poll_interval = Duration::from_secs(args.poll_interval_seconds);
+
+    loop {
+        match client.manual_transition_job_status(&args.job_id).await {
+            Ok(response) if is_terminal_job_status(&response.status) => {
+                print_manual_transition_job("manual_transition_job_wait", &response, formatter);
+                return wait_terminal_exit_code(&response.status);
+            }
+            Ok(_) if deadline.is_some_and(|deadline| Instant::now() >= deadline) => {
+                let error = Error::General(format!(
+                    "Timed out waiting for manual transition job '{}' to finish",
+                    args.job_id
+                ));
+                return emit_observability_error(
+                    "manual_transition_job_wait",
+                    "admin.ilm-transition-job",
+                    "Manual transition job wait timed out",
+                    &error,
+                    formatter,
+                );
+            }
+            Ok(_) => sleep(poll_interval).await,
+            Err(error) => {
+                return emit_observability_error(
+                    "manual_transition_job_wait",
+                    "admin.ilm-transition-job",
+                    "Failed while waiting for manual transition job",
+                    &error,
+                    formatter,
+                );
+            }
+        }
+    }
+}
+
 fn print_manual_transition_run(response: &ManualTransitionRunResponse, formatter: &Formatter) {
     let report = &response.report;
     formatter.println(&formatter.style_name("Manual Transition Run"));
@@ -124,6 +286,24 @@ fn print_manual_transition_run(response: &ManualTransitionRunResponse, formatter
         "Mode:           {}",
         formatter.sanitize_text(&response.mode)
     ));
+    if let Some(job_id) = &response.job_id {
+        formatter.println(&format!(
+            "Job ID:         {}",
+            formatter.sanitize_text(job_id)
+        ));
+    }
+    if let Some(status_endpoint) = &response.status_endpoint {
+        formatter.println(&format!(
+            "Status:         {}",
+            formatter.sanitize_text(status_endpoint)
+        ));
+    }
+    if let Some(cancel_endpoint) = &response.cancel_endpoint {
+        formatter.println(&format!(
+            "Cancel:         {}",
+            formatter.sanitize_text(cancel_endpoint)
+        ));
+    }
     formatter.println(&format!(
         "Bucket:         {}",
         formatter.sanitize_text(&report.bucket)
@@ -159,8 +339,119 @@ fn print_manual_transition_run(response: &ManualTransitionRunResponse, formatter
     ));
     formatter.println(&format!("Limit reached:  {}", report.truncated_by_limit));
     formatter.println(&format!("Duration hit:   {}", report.truncated_by_duration));
+    if let Some(continuation_token) = &report.continuation_token {
+        formatter.println(&format!(
+            "Continuation:   {}",
+            formatter.sanitize_text(continuation_token)
+        ));
+    }
 }
 
 fn value_or_all(value: &str) -> &str {
     if value.is_empty() { "all" } else { value }
+}
+
+fn print_manual_transition_job(
+    output_type: &'static str,
+    response: &ManualTransitionJobResponse,
+    formatter: &Formatter,
+) {
+    if formatter.is_json() {
+        formatter.json(&ManualTransitionJobSuccessOutput {
+            schema_version: 3,
+            output_type,
+            status: "success",
+            data: response,
+        });
+        return;
+    }
+
+    let report = &response.report;
+    let queue = &response.queue_snapshot;
+    formatter.println(&formatter.style_name("Manual Transition Job"));
+    formatter.println("");
+    formatter.println(&format!(
+        "Status:         {}",
+        formatter.sanitize_text(&response.status)
+    ));
+    formatter.println(&format!(
+        "Mode:           {}",
+        formatter.sanitize_text(&response.mode)
+    ));
+    formatter.println(&format!(
+        "Job ID:         {}",
+        formatter.sanitize_text(&response.job_id)
+    ));
+    formatter.println(&format!(
+        "Bucket:         {}",
+        formatter.sanitize_text(&response.bucket)
+    ));
+    formatter.println(&format!(
+        "Prefix:         {}",
+        formatter.sanitize_text(value_or_all(&response.prefix))
+    ));
+    formatter.println(&format!(
+        "Tier:           {}",
+        formatter.sanitize_text(response.tier.as_deref().map(value_or_all).unwrap_or("all"))
+    ));
+    formatter.println(&format!("Dry run:        {}", response.dry_run));
+    formatter.println(&format!("Cancel asked:   {}", response.cancel_requested));
+    formatter.println(&format!(
+        "Created ns:     {}",
+        response.created_at_unix_nanos
+    ));
+    formatter.println(&format!(
+        "Updated ns:     {}",
+        response.updated_at_unix_nanos
+    ));
+    if let Some(completed_at) = response.completed_at_unix_nanos {
+        formatter.println(&format!("Completed ns:   {completed_at}"));
+    }
+    if let Some(reason) = &response.failure_reason {
+        formatter.println(&format!(
+            "Failure:        {}",
+            formatter.sanitize_text(reason)
+        ));
+    }
+    formatter.println("");
+    formatter.println(&formatter.style_name("Report"));
+    formatter.println(&format!("Scanned:        {}", report.scanned));
+    formatter.println(&format!("Eligible:       {}", report.eligible));
+    formatter.println(&format!("Enqueued:       {}", report.enqueued));
+    formatter.println(&format!("Completed:      {}", report.transition_completed));
+    formatter.println(&format!("Failed:         {}", report.transition_failed));
+    formatter.println(&format!(
+        "Already moved:  {}",
+        report.skipped_already_transitioned
+    ));
+    formatter.println(&format!("Cancelled:      {}", report.cancelled));
+    formatter.println(&format!("Limit reached:  {}", report.truncated_by_limit));
+    formatter.println(&format!("Duration hit:   {}", report.truncated_by_duration));
+    if let Some(continuation_token) = &report.continuation_token {
+        formatter.println(&format!(
+            "Continuation:   {}",
+            formatter.sanitize_text(continuation_token)
+        ));
+    }
+    formatter.println("");
+    formatter.println(&formatter.style_name("Queue"));
+    formatter.println(&format!("Queued:         {}", queue.queued));
+    formatter.println(&format!("Active:         {}", queue.active));
+    formatter.println(&format!("Workers:        {}", queue.workers));
+    formatter.println(&format!("Capacity:       {}", queue.queue_capacity));
+}
+
+fn is_terminal_job_status(status: &str) -> bool {
+    matches!(
+        status,
+        "completed" | "partial" | "failed" | "cancelled" | "unknown"
+    )
+}
+
+fn wait_terminal_exit_code(status: &str) -> ExitCode {
+    if matches!(status, "completed" | "partial") {
+        ExitCode::Success
+    } else {
+        ExitCode::GeneralError
+    }
 }

--- a/crates/cli/src/commands/admin/mod.rs
+++ b/crates/cli/src/commands/admin/mod.rs
@@ -347,6 +347,7 @@ mod tests {
             "--tier",
             "COLDTIER",
             "--dry-run",
+            "--async",
             "--max-objects",
             "25",
             "--max-duration-seconds",
@@ -362,10 +363,74 @@ mod tests {
                 assert_eq!(args.prefix, "logs/");
                 assert_eq!(args.tier.as_deref(), Some("COLDTIER"));
                 assert!(args.dry_run);
+                assert!(args.async_mode);
                 assert_eq!(args.max_objects, 25);
                 assert_eq!(args.max_duration_seconds, Some(30));
             }
             _ => panic!("Unexpected ILM transition run command"),
+        }
+    }
+
+    #[test]
+    fn test_parse_admin_ilm_transition_job_commands() {
+        let status = TestCli::parse_from([
+            "rc",
+            "ilm",
+            "transition",
+            "status",
+            "local",
+            "11111111-1111-4111-8111-111111111111",
+        ]);
+        match status.command {
+            AdminCommands::Ilm(ilm::IlmCommands::Transition(ilm::TransitionCommands::Status(
+                args,
+            ))) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.job_id, "11111111-1111-4111-8111-111111111111");
+            }
+            _ => panic!("Unexpected ILM transition status command"),
+        }
+
+        let cancel = TestCli::parse_from([
+            "rc",
+            "ilm",
+            "transition",
+            "cancel",
+            "local",
+            "11111111-1111-4111-8111-111111111111",
+        ]);
+        match cancel.command {
+            AdminCommands::Ilm(ilm::IlmCommands::Transition(ilm::TransitionCommands::Cancel(
+                args,
+            ))) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.job_id, "11111111-1111-4111-8111-111111111111");
+            }
+            _ => panic!("Unexpected ILM transition cancel command"),
+        }
+
+        let wait = TestCli::parse_from([
+            "rc",
+            "ilm",
+            "transition",
+            "wait",
+            "local",
+            "11111111-1111-4111-8111-111111111111",
+            "--poll-interval-seconds",
+            "1",
+            "--timeout-seconds",
+            "30",
+        ]);
+        match wait.command {
+            AdminCommands::Ilm(ilm::IlmCommands::Transition(ilm::TransitionCommands::Wait(
+                args,
+            ))) => {
+                assert_eq!(args.alias, "local");
+                assert_eq!(args.job_id, "11111111-1111-4111-8111-111111111111");
+                assert_eq!(args.poll_interval_seconds, 1);
+                assert_eq!(args.timeout_seconds, Some(30));
+            }
+            _ => panic!("Unexpected ILM transition wait command"),
         }
     }
 

--- a/crates/cli/tests/admin_ilm.rs
+++ b/crates/cli/tests/admin_ilm.rs
@@ -5,7 +5,9 @@ mod admin_support;
 use std::process::Command;
 use std::time::Duration;
 
-use admin_support::{rc_binary, rc_host_alias, start_admin_response_test_server};
+use admin_support::{
+    rc_binary, rc_host_alias, start_admin_response_test_server, start_admin_sequence_test_server,
+};
 use serde_json::Value;
 
 const MANUAL_TRANSITION_RESPONSE: &str = r#"{
@@ -94,6 +96,195 @@ const MANUAL_TRANSITION_LEGACY_RESPONSE: &str = r#"{
     "skipped_queue_timeout":0,
     "truncated_by_limit":false
   }
+}"#;
+
+const MANUAL_TRANSITION_ASYNC_RESPONSE: &str = r#"{
+  "state":"accepted",
+  "mode":"durable_job",
+  "job_id":"11111111-1111-4111-8111-111111111111",
+  "status_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/",
+    "tier":"COLDTIER",
+    "dry_run":false,
+    "lifecycle_config_found":true,
+    "scanned":0,
+    "eligible":0,
+    "enqueued":0,
+    "dry_run_eligible":0,
+    "skipped_not_transition":0,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_transitioned":0,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "truncated_by_limit":false,
+    "truncated_by_duration":false
+  }
+}"#;
+
+const MANUAL_TRANSITION_JOB_RUNNING_RESPONSE: &str = r#"{
+  "status":"running",
+  "mode":"durable_job",
+  "job_id":"11111111-1111-4111-8111-111111111111",
+  "status_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_requested":false,
+  "bucket":"photos",
+  "prefix":"logs/",
+  "tier":"COLDTIER",
+  "dry_run":false,
+  "created_at_unix_nanos":100,
+  "updated_at_unix_nanos":200,
+  "completed_at_unix_nanos":null,
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/",
+    "tier":"COLDTIER",
+    "dry_run":false,
+    "lifecycle_config_found":true,
+    "scanned":3,
+    "eligible":2,
+    "enqueued":2,
+    "dry_run_eligible":0,
+    "skipped_not_transition":1,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_transitioned":0,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "transition_completed":1,
+    "transition_failed":0,
+    "truncated_by_limit":false,
+    "truncated_by_duration":false
+  },
+  "queue_snapshot":{
+    "queue_capacity":1000,
+    "queued":1,
+    "active":1,
+    "workers":4,
+    "queue_full":0,
+    "queue_send_timeout":0,
+    "compensation_pending":0,
+    "compensation_running":0
+  },
+  "failure_reason":null
+}"#;
+
+const MANUAL_TRANSITION_JOB_COMPLETED_RESPONSE: &str = r#"{
+  "status":"completed",
+  "mode":"durable_job",
+  "job_id":"11111111-1111-4111-8111-111111111111",
+  "status_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_requested":false,
+  "bucket":"photos",
+  "prefix":"logs/",
+  "tier":"COLDTIER",
+  "dry_run":false,
+  "created_at_unix_nanos":100,
+  "updated_at_unix_nanos":300,
+  "completed_at_unix_nanos":300,
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/",
+    "tier":"COLDTIER",
+    "dry_run":false,
+    "lifecycle_config_found":true,
+    "scanned":3,
+    "eligible":2,
+    "enqueued":2,
+    "dry_run_eligible":0,
+    "skipped_not_transition":1,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_transitioned":1,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "transition_completed":2,
+    "transition_failed":0,
+    "truncated_by_limit":false,
+    "truncated_by_duration":false,
+    "cancelled":false
+  },
+  "queue_snapshot":{
+    "queue_capacity":1000,
+    "queued":0,
+    "active":0,
+    "workers":4,
+    "queue_full":0,
+    "queue_send_timeout":0,
+    "compensation_pending":0,
+    "compensation_running":0
+  },
+  "failure_reason":null
+}"#;
+
+const MANUAL_TRANSITION_JOB_CANCELLED_RESPONSE: &str = r#"{
+  "status":"cancelled",
+  "mode":"durable_job",
+  "job_id":"11111111-1111-4111-8111-111111111111",
+  "status_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_endpoint":"/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111",
+  "cancel_requested":true,
+  "bucket":"photos",
+  "prefix":"logs/\nspoof",
+  "tier":"COLD\tTIER",
+  "dry_run":false,
+  "created_at_unix_nanos":100,
+  "updated_at_unix_nanos":400,
+  "completed_at_unix_nanos":400,
+  "report":{
+    "bucket":"photos",
+    "prefix":"logs/\nspoof",
+    "tier":"COLD\tTIER",
+    "dry_run":false,
+    "lifecycle_config_found":true,
+    "scanned":1,
+    "eligible":1,
+    "enqueued":0,
+    "dry_run_eligible":0,
+    "skipped_not_transition":0,
+    "skipped_tier":0,
+    "skipped_delete_marker":0,
+    "skipped_directory":0,
+    "skipped_replication":0,
+    "skipped_already_transitioned":0,
+    "skipped_already_in_flight":0,
+    "skipped_queue_full":0,
+    "skipped_queue_closed":0,
+    "skipped_queue_timeout":0,
+    "transition_completed":0,
+    "transition_failed":0,
+    "truncated_by_limit":false,
+    "truncated_by_duration":false,
+    "cancelled":true
+  },
+  "queue_snapshot":{
+    "queue_capacity":1000,
+    "queued":0,
+    "active":0,
+    "workers":4,
+    "queue_full":0,
+    "queue_send_timeout":0,
+    "compensation_pending":0,
+    "compensation_running":0
+  },
+  "failure_reason":"operator requested cancellation\nnext"
 }"#;
 
 #[test]
@@ -281,4 +472,255 @@ fn ilm_transition_run_accepts_legacy_response_without_duration_flag() {
     assert!(stdout.contains("Already moved:  0"), "stdout: {stdout}");
     assert!(stdout.contains("Duration hit:   false"), "stdout: {stdout}");
     handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_run_async_json_exposes_job_endpoints() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_response_test_server(
+        "202 Accepted",
+        "application/json",
+        MANUAL_TRANSITION_ASYNC_RESPONSE.to_string(),
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "ilm",
+            "transition",
+            "run",
+            "myalias",
+            "photos",
+            "--prefix",
+            "logs/",
+            "--tier",
+            "COLDTIER",
+            "--async",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["type"], "manual_transition_run");
+    assert_eq!(value["data"]["state"], "accepted");
+    assert_eq!(value["data"]["mode"], "durable_job");
+    assert_eq!(
+        value["data"]["job_id"],
+        "11111111-1111-4111-8111-111111111111"
+    );
+    assert_eq!(
+        value["data"]["cancel_endpoint"],
+        "/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111"
+    );
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "POST");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/ilm/transition/run?bucket=photos&prefix=logs%2F&dryRun=false&maxObjects=10000&tier=COLDTIER&async=true"
+    );
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_status_json_calls_job_endpoint() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_response_test_server(
+        "200 OK",
+        "application/json",
+        MANUAL_TRANSITION_JOB_RUNNING_RESPONSE.to_string(),
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "ilm",
+            "transition",
+            "status",
+            "myalias",
+            "11111111-1111-4111-8111-111111111111",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["schema_version"], 3);
+    assert_eq!(value["type"], "manual_transition_job_status");
+    assert_eq!(value["data"]["status"], "running");
+    assert_eq!(value["data"]["queue_snapshot"]["queued"], 1);
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "GET");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111"
+    );
+    assert!(request.body.is_empty());
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_cancel_human_sanitizes_job_text() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_response_test_server(
+        "200 OK",
+        "application/json",
+        MANUAL_TRANSITION_JOB_CANCELLED_RESPONSE.to_string(),
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "admin",
+            "ilm",
+            "transition",
+            "cancel",
+            "myalias",
+            "11111111-1111-4111-8111-111111111111",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be UTF-8");
+    assert!(
+        stdout.contains("Status:         cancelled"),
+        "stdout: {stdout}"
+    );
+    assert!(stdout.contains("Cancel asked:   true"), "stdout: {stdout}");
+    assert!(
+        stdout.contains("Prefix:         logs/\\nspoof"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Tier:           COLD\\tTIER"),
+        "stdout: {stdout}"
+    );
+    assert!(
+        stdout.contains("Failure:        operator requested cancellation\\nnext"),
+        "stdout: {stdout}"
+    );
+
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "DELETE");
+    assert_eq!(
+        request.target,
+        "/rustfs/admin/v3/ilm/transition/jobs/11111111-1111-4111-8111-111111111111"
+    );
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_wait_polls_until_terminal_state() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_sequence_test_server(vec![
+        ("200 OK", MANUAL_TRANSITION_JOB_RUNNING_RESPONSE),
+        ("200 OK", MANUAL_TRANSITION_JOB_COMPLETED_RESPONSE),
+    ]);
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "ilm",
+            "transition",
+            "wait",
+            "myalias",
+            "11111111-1111-4111-8111-111111111111",
+            "--poll-interval-seconds",
+            "1",
+            "--timeout-seconds",
+            "10",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: Value = serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(value["type"], "manual_transition_job_wait");
+    assert_eq!(value["data"]["status"], "completed");
+
+    let first = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured first status request");
+    let second = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured second status request");
+    assert_eq!(first.method, "GET");
+    assert_eq!(second.method, "GET");
+    assert_eq!(first.target, second.target);
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn ilm_transition_job_errors_preserve_exit_classes() {
+    for (status, expected_code) in [
+        ("403 Forbidden", 4),
+        ("404 Not Found", 5),
+        ("409 Conflict", 6),
+        ("501 Not Implemented", 7),
+    ] {
+        let config_dir = tempfile::tempdir().expect("create config dir");
+        let (endpoint, _receiver, handle) = start_admin_response_test_server(
+            status,
+            "application/xml",
+            "<Error><Code>NoSuchKey</Code><Message>job unavailable</Message></Error>".to_string(),
+        );
+
+        let output = Command::new(rc_binary())
+            .args([
+                "--json",
+                "admin",
+                "ilm",
+                "transition",
+                "status",
+                "myalias",
+                "11111111-1111-4111-8111-111111111111",
+            ])
+            .env("RC_CONFIG_DIR", config_dir.path())
+            .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+            .output()
+            .expect("run rc command");
+
+        assert_eq!(
+            output.status.code(),
+            Some(expected_code),
+            "status {status}, stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        handle.join().expect("admin test server finished");
+    }
 }

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -126,9 +126,10 @@ pub use site::{
     validate_site_replication_repair_token,
 };
 pub use tier::{
-    ManualTransitionRunReport, ManualTransitionRunRequest, ManualTransitionRunResponse, TierAliyun,
-    TierAzure, TierConfig, TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2, TierRustFS,
-    TierS3, TierTencent, TierType,
+    ManualTransitionJobResponse, ManualTransitionQueueSnapshot, ManualTransitionRunReport,
+    ManualTransitionRunRequest, ManualTransitionRunResponse, TierAliyun, TierAzure, TierConfig,
+    TierCreds, TierGCS, TierHuaweicloud, TierMinIO, TierR2, TierRustFS, TierS3, TierTencent,
+    TierType,
 };
 pub use types::{
     AccessKeyDetails, AccessKeyInfo, BucketQuota, CreateServiceAccountRequest, Group, GroupStatus,
@@ -325,6 +326,24 @@ pub trait AdminApi: Send + Sync {
         &self,
         request: ManualTransitionRunRequest,
     ) -> Result<ManualTransitionRunResponse>;
+
+    /// Start a durable manual lifecycle transition job for a bucket scope.
+    async fn run_manual_transition_async(
+        &self,
+        request: ManualTransitionRunRequest,
+    ) -> Result<ManualTransitionRunResponse>;
+
+    /// Inspect a durable manual lifecycle transition job.
+    async fn manual_transition_job_status(
+        &self,
+        job_id: &str,
+    ) -> Result<ManualTransitionJobResponse>;
+
+    /// Request cancellation for a durable manual lifecycle transition job.
+    async fn cancel_manual_transition_job(
+        &self,
+        job_id: &str,
+    ) -> Result<ManualTransitionJobResponse>;
 
     // ==================== Replication Target Operations ====================
 

--- a/crates/core/src/admin/tier.rs
+++ b/crates/core/src/admin/tier.rs
@@ -303,9 +303,56 @@ pub struct ManualTransitionRunRequest {
 pub struct ManualTransitionRunResponse {
     pub state: String,
     pub mode: String,
+    #[serde(default)]
     pub job_id: Option<String>,
+    #[serde(default)]
     pub status_endpoint: Option<String>,
+    #[serde(default)]
+    pub cancel_endpoint: Option<String>,
     pub report: ManualTransitionRunReport,
+}
+
+/// Response returned when inspecting or cancelling a durable manual transition job.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManualTransitionJobResponse {
+    pub status: String,
+    pub mode: String,
+    pub job_id: String,
+    pub status_endpoint: String,
+    pub cancel_endpoint: String,
+    pub cancel_requested: bool,
+    pub bucket: String,
+    pub prefix: String,
+    pub tier: Option<String>,
+    pub dry_run: bool,
+    pub created_at_unix_nanos: i128,
+    pub updated_at_unix_nanos: i128,
+    pub completed_at_unix_nanos: Option<i128>,
+    pub report: ManualTransitionRunReport,
+    #[serde(default)]
+    pub queue_snapshot: ManualTransitionQueueSnapshot,
+    pub failure_reason: Option<String>,
+}
+
+/// Snapshot of transition worker pressure reported with manual transition jobs.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManualTransitionQueueSnapshot {
+    #[serde(default)]
+    pub queue_capacity: u64,
+    #[serde(default)]
+    pub queued: u64,
+    #[serde(default)]
+    pub active: u64,
+    #[serde(default)]
+    pub workers: u64,
+    #[serde(default)]
+    pub queue_full: u64,
+    #[serde(default)]
+    pub queue_send_timeout: u64,
+    #[serde(default)]
+    pub compensation_pending: u64,
+    #[serde(default)]
+    pub compensation_running: u64,
 }
 
 /// Aggregate report for a manual lifecycle transition run.
@@ -331,9 +378,19 @@ pub struct ManualTransitionRunReport {
     pub skipped_queue_full: u64,
     pub skipped_queue_closed: u64,
     pub skipped_queue_timeout: u64,
+    #[serde(default)]
+    pub transition_completed: u64,
+    #[serde(default)]
+    pub transition_failed: u64,
+    #[serde(default)]
+    pub tier_failure: u64,
     pub truncated_by_limit: bool,
     #[serde(default)]
     pub truncated_by_duration: bool,
+    #[serde(default)]
+    pub cancelled: bool,
+    #[serde(default)]
+    pub continuation_token: Option<String>,
 }
 
 // ==================== Per-type sub-configs ====================

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -39,20 +39,21 @@ use rc_core::admin::{
     MAX_REPLICATION_DIFF_RESPONSE_BYTES, MAX_REPLICATION_INSPECTION_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_ERROR_RESPONSE_BYTES, MAX_SITE_REPLICATION_REPAIR_RESPONSE_BYTES,
     MAX_SITE_REPLICATION_REQUEST_BYTES, MAX_SITE_REPLICATION_SUCCESS_RESPONSE_BYTES,
-    ManualTransitionRunRequest, ManualTransitionRunResponse, MetricsBatch, MetricsQuery,
-    ModuleSwitches, ObservabilityApi, OidcMutationApi, OidcMutationRequest, OidcMutationResult,
-    OidcProvider, OidcProviderList, OidcReadApi, OidcValidationRequest, OidcValidationResult,
-    PeerSiteSpec, Policy, PolicyDetachEntity, PolicyDetachRequest, PolicyDetachResult,
-    PolicyEntitiesQuery, PolicyEntitiesResult, PolicyEntity, PolicyInfo, PoolStatus, PoolTarget,
-    RealtimeMetrics, RebalanceStartResult, RebalanceStatus, ReplicateEditStatus, ReplicationDiff,
-    ReplicationDiffApi, ReplicationInspectionApi, ReplicationMetricScope, ReplicationMetrics,
-    ReplicationMrf, RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus,
-    ServiceAccount, ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec,
-    SiteReplicationInfo, SiteReplicationPeer, SiteReplicationRepairApi,
-    SiteReplicationRepairCapabilityContract, SiteReplicationRepairOperationStatus,
-    SiteReplicationRepairPreflight, SiteReplicationRepairRequest, SiteReplicationResyncOperation,
-    SiteReplicationResyncStatus, SiteStatusOptions, StorageInfo, UpdateGroupMembersRequest,
-    UpdateServiceAccountRequest, User, UserStatus,
+    ManualTransitionJobResponse, ManualTransitionRunRequest, ManualTransitionRunResponse,
+    MetricsBatch, MetricsQuery, ModuleSwitches, ObservabilityApi, OidcMutationApi,
+    OidcMutationRequest, OidcMutationResult, OidcProvider, OidcProviderList, OidcReadApi,
+    OidcValidationRequest, OidcValidationResult, PeerSiteSpec, Policy, PolicyDetachEntity,
+    PolicyDetachRequest, PolicyDetachResult, PolicyEntitiesQuery, PolicyEntitiesResult,
+    PolicyEntity, PolicyInfo, PoolStatus, PoolTarget, RealtimeMetrics, RebalanceStartResult,
+    RebalanceStatus, ReplicateEditStatus, ReplicationDiff, ReplicationDiffApi,
+    ReplicationInspectionApi, ReplicationMetricScope, ReplicationMetrics, ReplicationMrf,
+    RuntimeCapabilitiesSnapshot, RuntimeCapabilityStatus, ScannerStatus, ServiceAccount,
+    ServiceAccountCreateResponse, ServiceActionResult, SiteRemoveSpec, SiteReplicationInfo,
+    SiteReplicationPeer, SiteReplicationRepairApi, SiteReplicationRepairCapabilityContract,
+    SiteReplicationRepairOperationStatus, SiteReplicationRepairPreflight,
+    SiteReplicationRepairRequest, SiteReplicationResyncOperation, SiteReplicationResyncStatus,
+    SiteStatusOptions, StorageInfo, UpdateGroupMembersRequest, UpdateServiceAccountRequest, User,
+    UserStatus,
 };
 use rc_core::{Alias, Error, Result};
 use reqwest::header::{CACHE_CONTROL, CONTENT_TYPE, HOST, HeaderMap, HeaderName, HeaderValue};
@@ -1653,6 +1654,37 @@ fn site_replication_server_invalid_state(code: Option<&str>, message: &str) -> b
         "site replication state changed" | "site replication refresh state changed"
     );
     state_changed && matches!(code, None | Some("InvalidRequest"))
+}
+
+fn manual_transition_run_query(
+    request: &ManualTransitionRunRequest,
+    async_mode: bool,
+) -> Vec<(&'static str, String)> {
+    let mut query = vec![
+        ("bucket", request.bucket.clone()),
+        ("prefix", request.prefix.clone()),
+        ("dryRun", request.dry_run.to_string()),
+        ("maxObjects", request.max_objects.to_string()),
+    ];
+    if let Some(duration) = request.max_duration_seconds {
+        query.push(("maxDurationSeconds", duration.to_string()));
+    }
+    if let Some(tier) = request.tier.as_deref() {
+        query.push(("tier", tier.to_string()));
+    }
+    if async_mode {
+        query.push(("async", "true".to_string()));
+    }
+    query
+}
+
+fn manual_transition_query_refs<'a>(
+    query: &'a [(&'static str, String)],
+) -> Vec<(&'a str, &'a str)> {
+    query
+        .iter()
+        .map(|(key, value)| (*key, value.as_str()))
+        .collect()
 }
 
 fn parse_admin_error(body: &str) -> Option<AdminErrorResponse> {
@@ -4971,26 +5003,38 @@ impl AdminApi for AdminClient {
         &self,
         request: ManualTransitionRunRequest,
     ) -> Result<ManualTransitionRunResponse> {
-        let dry_run = if request.dry_run { "true" } else { "false" };
-        let max_objects = request.max_objects.to_string();
-        let mut query = vec![
-            ("bucket", request.bucket.as_str()),
-            ("prefix", request.prefix.as_str()),
-            ("dryRun", dry_run),
-            ("maxObjects", max_objects.as_str()),
-        ];
-        let max_duration_seconds = request
-            .max_duration_seconds
-            .map(|duration| duration.to_string());
-        if let Some(max_duration_seconds) = max_duration_seconds.as_deref() {
-            query.push(("maxDurationSeconds", max_duration_seconds));
-        }
-        if let Some(tier) = request.tier.as_deref() {
-            query.push(("tier", tier));
-        }
+        let query = manual_transition_run_query(&request, false);
+        let query = manual_transition_query_refs(&query);
 
         self.request(Method::POST, "/ilm/transition/run", Some(&query), None)
             .await
+    }
+
+    async fn run_manual_transition_async(
+        &self,
+        request: ManualTransitionRunRequest,
+    ) -> Result<ManualTransitionRunResponse> {
+        let query = manual_transition_run_query(&request, true);
+        let query = manual_transition_query_refs(&query);
+
+        self.request(Method::POST, "/ilm/transition/run", Some(&query), None)
+            .await
+    }
+
+    async fn manual_transition_job_status(
+        &self,
+        job_id: &str,
+    ) -> Result<ManualTransitionJobResponse> {
+        let path = format!("/ilm/transition/jobs/{}", urlencoding::encode(job_id));
+        self.request(Method::GET, &path, None, None).await
+    }
+
+    async fn cancel_manual_transition_job(
+        &self,
+        job_id: &str,
+    ) -> Result<ManualTransitionJobResponse> {
+        let path = format!("/ilm/transition/jobs/{}", urlencoding::encode(job_id));
+        self.request(Method::DELETE, &path, None, None).await
     }
 
     // ==================== Replication Target Operations ====================


### PR DESCRIPTION
## Related Issues
rustfs/backlog#1480
rustfs/backlog#1481

## Background
RustFS manual transition durable jobs expose async run, status, wait, and cancel contracts. The CLI needs matching `rc admin ilm transition` controls while preserving the existing synchronous run behavior.

## Solution
Add `rc admin ilm transition run --async`, `status`, `wait`, and `cancel` commands. The implementation keeps the existing synchronous request shape compatible, adds optional parsing for durable job endpoints, and maps status/cancel error classes for 403, 404, 409, and 501 responses.

## Verification
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p rustfs-cli --test admin_ilm`
- `cargo test -p rustfs-cli test_parse_admin_ilm_transition`
- `cargo test -p rc-s3 manual_transition`
- `cargo check --workspace`
- `cargo test -p rustfs-cli --test output_schema_v3`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

## Compatibility
The existing synchronous run API remains unchanged and legacy responses without durable job fields still parse successfully.