### PR TITLE
fix(admin): honor server-advertised capabilities and extend IAM pin to rc series

### DIFF
--- a/crates/core/src/admin/capabilities.rs
+++ b/crates/core/src/admin/capabilities.rs
@@ -86,10 +86,22 @@ pub struct RuntimeCapabilitiesSummary {
     pub cluster_snapshot: RuntimeCapabilityStatus,
 }
 
+/// One named admin capability advertised by the server itself
+/// (rustfs/backlog#1900). Servers after 1.0.0-rc.3 include this list in
+/// `/v4/runtime/capabilities`; older servers omit it, in which case the
+/// client falls back to its pinned per-version contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdvertisedAdminCapability {
+    pub name: String,
+    pub status: RuntimeCapabilityStatus,
+}
+
 /// Typed subset of the RustFS runtime capability response.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RuntimeCapabilitiesSnapshot {
     pub summary: RuntimeCapabilitiesSummary,
+    #[serde(default)]
+    pub advertised: Vec<AdvertisedAdminCapability>,
     #[serde(default)]
     pub inspect_archive: Option<super::InspectArchiveCapabilityContract>,
     #[serde(default)]

--- a/crates/core/src/admin/mod.rs
+++ b/crates/core/src/admin/mod.rs
@@ -32,10 +32,11 @@ pub use bucket_metadata::{
     MAX_BUCKET_METADATA_ARCHIVE_BYTES,
 };
 pub use capabilities::{
-    CapabilityAvailability, CapabilityEntry, CapabilityReport, ClusterSnapshotMetadata,
-    ClusterSnapshotSummary, DiagnosticCapability, DiagnosticCapabilityGuardError,
-    ExtensionMetadata, ExtensionsCatalog, RuntimeCapabilitiesSnapshot, RuntimeCapabilitiesSummary,
-    RuntimeCapabilityState, RuntimeCapabilityStatus,
+    AdvertisedAdminCapability, CapabilityAvailability, CapabilityEntry, CapabilityReport,
+    ClusterSnapshotMetadata, ClusterSnapshotSummary, DiagnosticCapability,
+    DiagnosticCapabilityGuardError, ExtensionMetadata, ExtensionsCatalog,
+    RuntimeCapabilitiesSnapshot, RuntimeCapabilitiesSummary, RuntimeCapabilityState,
+    RuntimeCapabilityStatus,
 };
 pub use cluster::{
     BackendInfo, BackendType, BucketsInfo, ClusterInfo, DecommissionPoolStatus, DecommissionStatus,

--- a/crates/s3/src/admin.rs
+++ b/crates/s3/src/admin.rs
@@ -2274,6 +2274,19 @@ impl AdminClient {
             Err(error) => return Err(error),
         };
 
+        // Merge after the direct endpoint probes so a probe result keeps
+        // precedence over a same-named advertisement, but before the pinned
+        // per-version fallbacks so the server's own advertisement wins there.
+        for advertised in &runtime.advertised {
+            push_capability_if_absent(
+                &mut capabilities,
+                CapabilityEntry {
+                    name: advertised.name.clone(),
+                    availability: advertised.status.availability(),
+                    reason: advertised.status.reason.clone(),
+                },
+            );
+        }
         add_known_server_capabilities(server_version.as_deref(), &mut capabilities);
         capabilities.sort_by(|left, right| left.name.cmp(&right.name));
 
@@ -2386,7 +2399,29 @@ fn stubbed_report(server_version: Option<String>, reason: String) -> CapabilityR
 }
 
 fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<CapabilityEntry>) {
-    if !version.is_some_and(is_rustfs_beta_10) {
+    let is_beta_10 = version.is_some_and(is_rustfs_beta_10);
+    if is_beta_10 || version.is_some_and(is_rustfs_rc_series) {
+        for name in [
+            "admin.data-usage",
+            "listen_notification",
+            IAM_POLICY_ENTITIES_CAPABILITY,
+            IAM_POLICY_DETACH_CAPABILITY,
+            IAM_ACCESS_KEYS_BULK_CAPABILITY,
+            IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
+            IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY,
+        ] {
+            push_capability_if_absent(
+                capabilities,
+                CapabilityEntry {
+                    name: name.to_string(),
+                    availability: CapabilityAvailability::Available,
+                    reason: None,
+                },
+            );
+        }
+    }
+
+    if !is_beta_10 {
         add_uniform_diagnostic_capabilities(
             capabilities,
             CapabilityAvailability::Unknown,
@@ -2394,38 +2429,6 @@ fn add_known_server_capabilities(version: Option<&str>, capabilities: &mut Vec<C
         );
         mirror_read_only_diagnostic_routes(capabilities);
         return;
-    }
-
-    capabilities.push(CapabilityEntry {
-        name: "admin.data-usage".to_string(),
-        availability: CapabilityAvailability::Available,
-        reason: None,
-    });
-    capabilities.push(CapabilityEntry {
-        name: "listen_notification".to_string(),
-        availability: CapabilityAvailability::Available,
-        reason: None,
-    });
-    capabilities.push(CapabilityEntry {
-        name: IAM_POLICY_ENTITIES_CAPABILITY.to_string(),
-        availability: CapabilityAvailability::Available,
-        reason: None,
-    });
-    capabilities.push(CapabilityEntry {
-        name: IAM_POLICY_DETACH_CAPABILITY.to_string(),
-        availability: CapabilityAvailability::Available,
-        reason: None,
-    });
-    for name in [
-        IAM_ACCESS_KEYS_BULK_CAPABILITY,
-        IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
-        IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY,
-    ] {
-        capabilities.push(CapabilityEntry {
-            name: name.to_string(),
-            availability: CapabilityAvailability::Available,
-            reason: None,
-        });
     }
 
     for (name, reason) in [
@@ -2589,6 +2592,35 @@ fn is_rustfs_beta_10(version: &str) -> bool {
         .split(|character: char| character.is_ascii_whitespace() || character == '/')
         .map(|component| component.trim_start_matches('v'))
         .any(|component| component.split('+').next() == Some("1.0.0-beta.10"))
+}
+
+/// The 1.0.0-rc series ships the same implemented IAM admin surface that was
+/// pinned for beta.10 (verified against 1.0.0-rc.3, rustfs/backlog#1900), but
+/// predates dynamic capability advertisement, so the pinned IAM contract must
+/// also apply to it.
+fn is_rustfs_rc_series(version: &str) -> bool {
+    version
+        .split(|character: char| character.is_ascii_whitespace() || character == '/')
+        .map(|component| component.trim_start_matches('v'))
+        .any(|component| {
+            component
+                .split('+')
+                .next()
+                .is_some_and(|core| core.starts_with("1.0.0-rc."))
+        })
+}
+
+/// Server-advertised entries are merged before any pinned per-version
+/// fallback, so a pinned fallback must never override an entry the server
+/// itself reported.
+fn push_capability_if_absent(capabilities: &mut Vec<CapabilityEntry>, entry: CapabilityEntry) {
+    if capabilities
+        .iter()
+        .any(|existing| existing.name == entry.name)
+    {
+        return;
+    }
+    capabilities.push(entry);
 }
 
 #[derive(Debug, Deserialize)]
@@ -5723,7 +5755,9 @@ mod tests {
 
     const CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.10","drives":[]}]}}"#;
     const UNKNOWN_CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-beta.11","drives":[]}]}}"#;
+    const RC3_CAPABILITY_INFO_RESPONSE: &str = r#"{"info":{"mode":"distributed","servers":[{"endpoint":"http://node1:9000","state":"online","version":"1.0.0-rc.3-preview.2","drives":[]}]}}"#;
     const RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
+    const ADVERTISED_RUNTIME_CAPABILITIES_RESPONSE: &str = r#"{"summary":{"observability":{"state":"supported"},"userspace_profiling":{"state":"disabled","reason":"disabled by configuration"},"memory_sampling":{"state":"unsupported","reason":"not available on this platform"},"platform":{"state":"supported"},"topology":{"state":"unknown","reason":"storage is initializing"},"cluster_snapshot":{"state":"supported"}},"advertised":[{"name":"admin.iam.policy-attach","status":{"state":"supported"}},{"name":"admin.iam.policy-detach","status":{"state":"supported"}},{"name":"admin.iam.policy-entities","status":{"state":"unsupported","reason":"route disabled by operator"}}],"cluster_snapshot_path":"/rustfs/admin/v4/cluster/snapshot","cluster_snapshot_summary":{"state":"supported"},"observability":{},"workload_admission":{},"topology":null,"topology_status":{"state":"unknown"}}"#;
     const EXTENSIONS_RESPONSE: &str = r#"{"extensions":[{"schema_version":"rustfs.extension-schema.v1","extension_id":"ops.diagnostics","display_name":"Operations Diagnostics","provider":"rustfs","version":"1","kind":"ops_diagnostics","runtime":{"api_version":"v1","boundary":"builtin"},"capabilities":[],"disabled_by_default":false}],"runtime_capabilities":{},"cluster_snapshot":{},"external_plugin_flow":{}}"#;
     const CLUSTER_SNAPSHOT_RESPONSE: &str = r#"{"snapshot":{"summary":{"runtime":{"state":"supported"},"topology":{"state":"supported"},"membership":{"state":"supported"},"peer_health":{"state":"supported"},"rpc_boundary":{"state":"supported"},"observability":{"state":"supported"},"workload_admission":{"state":"supported"},"actionable_pressure":{"state":"disabled"}},"runtime_capabilities_path":"/rustfs/admin/v4/runtime/capabilities","extensions_catalog_path":"/rustfs/admin/v4/extensions/catalog"}}"#;
     const CLIENT_DEVNULL_RESPONSE: &str = r#"{"kind":"client-devnull","measured":true,"aggregate_write_throughput_bytes_per_sec":2048.0,"rx_bytes":65536,"duration_secs":0.5}"#;
@@ -5894,6 +5928,117 @@ mod tests {
         assert!(is_rustfs_beta_10("rustfs/v1.0.0-beta.10+build.7"));
         assert!(!is_rustfs_beta_10("1.0.0-beta.100"));
         assert!(!is_rustfs_beta_10("1.0.0-beta.9"));
+    }
+
+    #[test]
+    fn rc_series_capability_gate_matches_only_the_rc_prerelease_family() {
+        assert!(is_rustfs_rc_series("1.0.0-rc.3"));
+        assert!(is_rustfs_rc_series("1.0.0-rc.3-preview.2"));
+        assert!(is_rustfs_rc_series("rustfs/v1.0.0-rc.1+build.2"));
+        assert!(!is_rustfs_rc_series("1.0.0-beta.10"));
+        assert!(!is_rustfs_rc_series("1.0.0"));
+        assert!(!is_rustfs_rc_series("1.0.1-rc.1"));
+        assert!(!is_rustfs_rc_series("1.0.0-rc"));
+    }
+
+    /// rustfs/backlog#1900: the rc.x series predates dynamic capability
+    /// advertisement but implements the beta.10 IAM admin surface, so the
+    /// pinned IAM contract must keep `rc admin policy detach` usable.
+    #[tokio::test]
+    async fn capability_discovery_applies_pinned_iam_contract_to_rc_series() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", RC3_CAPABILITY_INFO_RESPONSE),
+            ("200 OK", RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("capability discovery should succeed");
+
+        for name in [
+            IAM_POLICY_ENTITIES_CAPABILITY,
+            IAM_POLICY_DETACH_CAPABILITY,
+            IAM_ACCESS_KEYS_BULK_CAPABILITY,
+            IAM_ACCESS_KEYS_BULK_LDAP_CAPABILITY,
+            IAM_ACCESS_KEYS_BULK_OPENID_CAPABILITY,
+            "admin.data-usage",
+        ] {
+            assert!(
+                report.capabilities.iter().any(|capability| {
+                    capability.name == name
+                        && capability.availability == CapabilityAvailability::Available
+                }),
+                "{name} must be pinned available for the rc series"
+            );
+        }
+        assert!(
+            report.capabilities.iter().any(|capability| {
+                capability.name == "admin.diagnostics.health-snapshot"
+                    && capability.availability == CapabilityAvailability::Unknown
+            }),
+            "diagnostics must stay unknown because only beta.10 has a pinned diagnostic contract"
+        );
+        assert!(
+            !report
+                .capabilities
+                .iter()
+                .any(|capability| capability.name == "admin.batch"),
+            "beta.10 stub classifications must not be claimed for the rc series"
+        );
+        handle.join().expect("server thread should finish");
+    }
+
+    /// rustfs/backlog#1900: servers that advertise capabilities dynamically
+    /// are authoritative — advertised entries must be honored on unpinned
+    /// versions and must take precedence over pinned fallbacks.
+    #[tokio::test]
+    async fn capability_discovery_prefers_server_advertised_entries() {
+        let (endpoint, _receiver, handle) = start_admin_sequence_server(vec![
+            ("200 OK", RC3_CAPABILITY_INFO_RESPONSE),
+            ("200 OK", ADVERTISED_RUNTIME_CAPABILITIES_RESPONSE),
+            ("200 OK", EXTENSIONS_RESPONSE),
+            ("200 OK", CLUSTER_SNAPSHOT_RESPONSE),
+        ]);
+        let client = admin_client_for_endpoint(&endpoint);
+
+        let report = client
+            .discover_capabilities(false)
+            .await
+            .expect("capability discovery should succeed");
+
+        for name in ["admin.iam.policy-attach", IAM_POLICY_DETACH_CAPABILITY] {
+            assert!(
+                report.capabilities.iter().any(|capability| {
+                    capability.name == name
+                        && capability.availability == CapabilityAvailability::Available
+                }),
+                "{name} must be taken from the server advertisement"
+            );
+        }
+        let entities: Vec<_> = report
+            .capabilities
+            .iter()
+            .filter(|capability| capability.name == IAM_POLICY_ENTITIES_CAPABILITY)
+            .collect();
+        assert_eq!(
+            entities.len(),
+            1,
+            "advertised and pinned entries must not duplicate"
+        );
+        assert_eq!(
+            entities[0].availability,
+            CapabilityAvailability::Unsupported,
+            "the server-advertised state must override the pinned fallback"
+        );
+        assert_eq!(
+            entities[0].reason.as_deref(),
+            Some("route disabled by operator")
+        );
+        handle.join().expect("server thread should finish");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Related Issues

Fixes rustfs/backlog#1900 (client side). Companion server PR: rustfs/rustfs#6336.

## Summary of Changes

`rc admin policy detach` fails against RustFS `1.0.0-rc.3` servers with `Unsupported feature: admin.iam.policy-detach was not advertised by the server`, even though the server's detach endpoint is implemented and works. Root cause: the `admin.iam.*` entries in the capability report come only from a client-side contract pinned to the exact version `1.0.0-beta.10` (`add_known_server_capabilities`), so every newer server version silently loses the whole IAM capability family and the detach gate fails closed.

Two changes:

1. **Dynamic advertisement (forward-looking).** `RuntimeCapabilitiesSnapshot` gains an additive `advertised: Vec<AdvertisedAdminCapability { name, status }>` field (`#[serde(default)]`, so older servers that omit it are unaffected). Servers after rustfs/rustfs#6336 include their IAM capability list there. Merge precedence in `discover_capabilities_uncached`: direct endpoint probes > server advertisement > pinned per-version fallbacks, with `push_capability_if_absent` preventing duplicates.
2. **Pinned contract extension (works with already-deployed servers).** The pinned IAM/data-usage/listen_notification availability block now also applies to the `1.0.0-rc.*` family (`is_rustfs_rc_series`), which ships the same implemented IAM admin surface as beta.10 but predates dynamic advertisement — verified live against `1.0.0-rc.3` (detach REST endpoint returns 200 and takes effect, per the issue's reproduction). The beta.10 stub classifications (`admin.batch`, `admin.ldap-mutation`, …) and the beta.10 diagnostic contract stay beta.10-only; rc-series diagnostics remain Unknown/fail-closed as before.

The documented detach gate behavior is unchanged: the command still fails closed unless `admin.iam.policy-detach` is advertised as available — advertisement itself is what this PR fixes. The attach/detach gate asymmetry (attach has no gate) is intentionally left as is.

## Verification

- `cargo fmt --all` / `cargo clippy --workspace -- -D warnings` (zero warnings) / `cargo test --workspace` — all pass
- New tests:
  - `capability_discovery_applies_pinned_iam_contract_to_rc_series` — rc.3-preview.2 server without `advertised` gets the pinned IAM entries; diagnostics stay Unknown; beta.10 stub claims are not applied
  - `capability_discovery_prefers_server_advertised_entries` — advertised entries are honored, deduplicated against the pin, and the server-advertised state (including an Unsupported override with its reason) wins over the pinned fallback
  - `rc_series_capability_gate_matches_only_the_rc_prerelease_family` — version predicate boundaries (`1.0.0-rc.3-preview.2` matches; `1.0.0-beta.10`, `1.0.0`, `1.0.1-rc.1`, `1.0.0-rc` do not)
- Manual end-to-end against a locally built server carrying rustfs/rustfs#6336: `alias set` → `admin user add` → `policy attach readonly` → `policy detach readonly` succeeds, and `rc admin capabilities` lists all six `admin.iam.*` entries carrying the server's route-inventory reasons (pinned entries carry no reason, proving the dynamic path).

## Impact

- Existing `1.0.0-rc.*` deployments: `rc admin policy detach`, `policy entities`, and bulk access-key inspection become usable immediately after this release, no server upgrade required.
- Future servers: capability availability follows the server's own advertisement instead of requiring a new client pin per release.
- No output schema changes: the capability report shape is unchanged; only which entries appear.
