### PR TITLE
feat(admin): send targetUser when creating a service account

### DIFF
--- a/crates/cli/src/commands/admin/service_account.rs
+++ b/crates/cli/src/commands/admin/service_account.rs
@@ -76,6 +76,11 @@ pub struct CreateArgs {
     /// Optional expiration time (ISO 8601 format)
     #[arg(long)]
     pub expiry: Option<String>,
+
+    /// Parent IAM user. Owner credentials may create a service account for
+    /// another user; omitted requests stay parented to the alias identity.
+    #[arg(long)]
+    pub user: Option<String>,
 }
 
 #[derive(clap::Args, Debug)]
@@ -300,6 +305,11 @@ fn build_create_service_account_request(
         description: args.description.clone(),
         access_key: args.access_key.clone(),
         secret_key: args.secret_key.clone(),
+        target_user: args
+            .user
+            .as_ref()
+            .filter(|value| !value.is_empty())
+            .cloned(),
     }
 }
 
@@ -512,11 +522,13 @@ mod tests {
             policy: None,
             policy_json: None,
             expiry: None,
+            user: None,
         };
 
         let request = build_create_service_account_request(&args, None);
         assert_eq!(request.name.as_deref(), Some("AKIAIOSFODNN7EXAMPLE"));
         assert!(request.expiry.is_none());
+        assert!(request.target_user.is_none());
     }
 
     #[test]
@@ -530,6 +542,7 @@ mod tests {
             policy: None,
             policy_json: None,
             expiry: Some("2030-01-01T00:00:00Z".to_string()),
+            user: None,
         };
 
         let request = build_create_service_account_request(&args, Some("{\"x\":1}".to_string()));
@@ -537,6 +550,43 @@ mod tests {
         assert_eq!(request.description.as_deref(), Some("demo"));
         assert_eq!(request.expiry.as_deref(), Some("2030-01-01T00:00:00Z"));
         assert_eq!(request.policy.as_deref(), Some("{\"x\":1}"));
+        assert!(request.target_user.is_none());
+    }
+
+    #[test]
+    fn test_build_create_request_forwards_target_user() {
+        let args = CreateArgs {
+            alias: "local".to_string(),
+            access_key: "SA_ACCESS_KEY".to_string(),
+            secret_key: "SA_SECRET_KEY".to_string(),
+            name: None,
+            description: None,
+            policy: None,
+            policy_json: None,
+            expiry: None,
+            user: Some("test-user".to_string()),
+        };
+
+        let request = build_create_service_account_request(&args, None);
+        assert_eq!(request.target_user.as_deref(), Some("test-user"));
+    }
+
+    #[test]
+    fn test_build_create_request_omits_empty_target_user() {
+        let args = CreateArgs {
+            alias: "local".to_string(),
+            access_key: "SA_ACCESS_KEY".to_string(),
+            secret_key: "SA_SECRET_KEY".to_string(),
+            name: None,
+            description: None,
+            policy: None,
+            policy_json: None,
+            expiry: None,
+            user: Some(String::new()),
+        };
+
+        let request = build_create_service_account_request(&args, None);
+        assert!(request.target_user.is_none());
     }
 
     #[test]
@@ -617,6 +667,7 @@ mod tests {
             policy: None,
             policy_json: None,
             expiry: None,
+            user: None,
         };
         let error = rc_core::Error::InvalidPath("missing field `expiration`".to_string());
         assert!(should_retry_with_default_expiry(&args, &error));
@@ -633,6 +684,7 @@ mod tests {
             policy: None,
             policy_json: None,
             expiry: Some("2030-01-01T00:00:00Z".to_string()),
+            user: None,
         };
         let error = rc_core::Error::InvalidPath("missing field `expiration`".to_string());
         assert!(!should_retry_with_default_expiry(&args, &error));

--- a/crates/cli/tests/admin_service_account.rs
+++ b/crates/cli/tests/admin_service_account.rs
@@ -125,6 +125,44 @@ fn service_account_create_omits_target_user_when_parent_is_the_caller() {
 }
 
 #[test]
+fn service_account_create_omits_empty_user_flag_from_request_body() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(
+        r#"{"credentials":{"accessKey":"service-key","secretKey":"service-secret"}}"#,
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "service-account",
+            "create",
+            "myalias",
+            "service-key",
+            "service-secret",
+            "--user",
+            "",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    let body: serde_json::Value =
+        serde_json::from_slice(&request.body).expect("create body should be JSON");
+    assert!(body.get("targetUser").is_none());
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
 fn service_account_create_rejects_invalid_inline_policy_json() {
     let config_dir = tempfile::tempdir().expect("create config dir");
     let output = Command::new(rc_binary())

--- a/crates/cli/tests/admin_service_account.rs
+++ b/crates/cli/tests/admin_service_account.rs
@@ -47,6 +47,84 @@ fn service_account_create_accepts_inline_policy_json() {
 }
 
 #[test]
+fn service_account_create_sends_target_user_for_another_parent() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(
+        r#"{"credentials":{"accessKey":"service-key","secretKey":"service-secret"}}"#,
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "service-account",
+            "create",
+            "myalias",
+            "service-key",
+            "service-secret",
+            "--user",
+            "test-user",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    assert_eq!(request.method, "PUT");
+    assert_eq!(request.target, "/rustfs/admin/v3/add-service-accounts");
+    let body: serde_json::Value =
+        serde_json::from_slice(&request.body).expect("create body should be JSON");
+    assert_eq!(body["targetUser"], "test-user");
+    assert_eq!(body["accessKey"], "service-key");
+    assert!(body.get("secretKey").is_some());
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
+fn service_account_create_omits_target_user_when_parent_is_the_caller() {
+    let config_dir = tempfile::tempdir().expect("create config dir");
+    let (endpoint, receiver, handle) = start_admin_test_server(
+        r#"{"credentials":{"accessKey":"service-key","secretKey":"service-secret"}}"#,
+    );
+
+    let output = Command::new(rc_binary())
+        .args([
+            "--json",
+            "admin",
+            "service-account",
+            "create",
+            "myalias",
+            "service-key",
+            "service-secret",
+        ])
+        .env("RC_CONFIG_DIR", config_dir.path())
+        .env("RC_HOST_myalias", rc_host_alias(&endpoint))
+        .output()
+        .expect("run rc command");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let request = receiver
+        .recv_timeout(Duration::from_secs(5))
+        .expect("captured admin request");
+    let body: serde_json::Value =
+        serde_json::from_slice(&request.body).expect("create body should be JSON");
+    assert!(body.get("targetUser").is_none());
+    handle.join().expect("admin test server finished");
+}
+
+#[test]
 fn service_account_create_rejects_invalid_inline_policy_json() {
     let config_dir = tempfile::tempdir().expect("create config dir");
     let output = Command::new(rc_binary())

--- a/crates/cli/tests/help_contract.rs
+++ b/crates/cli/tests/help_contract.rs
@@ -1124,6 +1124,7 @@ fn nested_subcommand_help_contract() {
                 "--policy",
                 "--policy-json",
                 "--expiry",
+                "--user",
             ],
         },
         HelpCase {

--- a/crates/core/src/admin/types.rs
+++ b/crates/core/src/admin/types.rs
@@ -426,6 +426,11 @@ pub struct CreateServiceAccountRequest {
     /// Secret key (required)
     #[serde(rename = "secretKey")]
     pub secret_key: String,
+
+    /// Optional parent IAM user. Owner credentials may create a service
+    /// account for another user; omitted requests stay parented to the caller.
+    #[serde(rename = "targetUser", skip_serializing_if = "Option::is_none")]
+    pub target_user: Option<String>,
 }
 
 /// Request to update an existing service account
@@ -628,6 +633,7 @@ mod tests {
             description: None,
             access_key: "myaccesskey".to_string(),
             secret_key: "mysecretkey".to_string(),
+            target_user: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -640,6 +646,7 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
         assert!(parsed.get("expiration").is_some());
         assert!(parsed["expiration"].is_null());
+        assert!(parsed.get("targetUser").is_none());
     }
 
     #[test]
@@ -651,6 +658,7 @@ mod tests {
             description: None,
             access_key: "myaccesskey".to_string(),
             secret_key: "mysecretkey".to_string(),
+            target_user: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -659,6 +667,23 @@ mod tests {
             parsed.get("expiration").and_then(|v| v.as_str()),
             Some("2025-12-31T23:59:59Z")
         );
+    }
+
+    #[test]
+    fn test_create_service_account_request_serializes_target_user() {
+        let request = CreateServiceAccountRequest {
+            policy: None,
+            expiry: None,
+            name: None,
+            description: None,
+            access_key: "myaccesskey".to_string(),
+            secret_key: "mysecretkey".to_string(),
+            target_user: Some("test-user".to_string()),
+        };
+
+        let parsed: serde_json::Value = serde_json::to_value(&request).unwrap();
+        assert_eq!(parsed["targetUser"], "test-user");
+        assert_eq!(parsed["accessKey"], "myaccesskey");
     }
 
     #[test]

--- a/crates/core/src/admin/types.rs
+++ b/crates/core/src/admin/types.rs
@@ -687,6 +687,28 @@ mod tests {
     }
 
     #[test]
+    fn test_create_service_account_request_deserializes_target_user() {
+        let parsed: CreateServiceAccountRequest = serde_json::from_value(serde_json::json!({
+            "expiration": null,
+            "accessKey": "myaccesskey",
+            "secretKey": "mysecretkey",
+            "targetUser": "test-user"
+        }))
+        .expect("deserialize create request");
+
+        assert_eq!(parsed.target_user.as_deref(), Some("test-user"));
+
+        let omitted: CreateServiceAccountRequest = serde_json::from_value(serde_json::json!({
+            "expiration": null,
+            "accessKey": "myaccesskey",
+            "secretKey": "mysecretkey"
+        }))
+        .expect("deserialize create request without targetUser");
+
+        assert!(omitted.target_user.is_none());
+    }
+
+    #[test]
     fn test_update_service_account_request_serializes_provided_fields() {
         let request = UpdateServiceAccountRequest {
             new_policy: Some(r#"{"Version":"2012-10-17"}"#.to_string()),

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -261,6 +261,10 @@ rc admin service-account create local SA_ACCESS_KEY SA_SECRET_KEY --user test-us
 
 `--user` on create sends `targetUser` so an owner alias can parent the key to another IAM user. Omit it to keep the existing parent-is-the-caller behavior. `rc admin service-account ls --user` already lists another user's keys.
 
+### BREAKING service-account targetUser contract migration
+
+`--user` on `rc admin service-account create` is additive and omitted from the request body when unset or empty. Existing creates without `--user` serialize the same body as before. This PR must be marked `BREAKING` because `docs/reference/rc/admin.md` is a protected CLI behavior contract. No JSON schema or config `schema_version` bump applies.
+
 Link two sites for site replication and check the result:
 
 ```bash

--- a/docs/reference/rc/admin.md
+++ b/docs/reference/rc/admin.md
@@ -256,7 +256,10 @@ Create a service account with a policy file:
 
 ```bash
 rc admin service-account create local SA_ACCESS_KEY SA_SECRET_KEY --policy ./policy.json
+rc admin service-account create local SA_ACCESS_KEY SA_SECRET_KEY --user test-user
 ```
+
+`--user` on create sends `targetUser` so an owner alias can parent the key to another IAM user. Omit it to keep the existing parent-is-the-caller behavior. `rc admin service-account ls --user` already lists another user's keys.
 
 Link two sites for site replication and check the result:
 

--- a/scripts/regression/service-account-target-user.sh
+++ b/scripts/regression/service-account-target-user.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+#
+# Regression tests for service-account create --user / targetUser (#340).
+#
+# Usage:
+#   ./scripts/regression/service-account-target-user.sh
+#
+# These tests do not require a running RustFS backend. They cover:
+#   - CreateServiceAccountRequest serializing targetUser only when set
+#   - CLI --user forwarding into the admin create body
+#   - Existing create-without-user requests omitting targetUser
+#   - Help contract for admin service-account create --user
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $*"; }
+log_error() { echo -e "${RED}[FAIL]${NC} $*"; }
+
+run_tests() {
+    local description="$1"
+    shift
+    log_info "$description"
+    if "$@"; then
+        log_success "$description"
+    else
+        log_error "$description"
+        return 1
+    fi
+}
+
+log_info "Service-account targetUser regression suite"
+
+run_tests "core request serialization" \
+    cargo test -p rc-core --lib -- \
+    test_create_service_account_request_includes_expiration \
+    test_create_service_account_request_serializes_target_user
+
+run_tests "CLI request mapping" \
+    cargo test -p rustfs-cli --lib -- \
+    test_build_create_request_forwards_target_user \
+    test_build_create_request_omits_empty_target_user \
+    test_build_create_request_uses_access_key_as_default_name \
+    test_build_create_request_keeps_explicit_name
+
+run_tests "admin create integration" \
+    cargo test -p rustfs-cli --test admin_service_account -- \
+    service_account_create_sends_target_user_for_another_parent \
+    service_account_create_omits_target_user_when_parent_is_the_caller \
+    service_account_create_accepts_inline_policy_json
+
+run_tests "CLI help contract includes create --user" \
+    cargo test -p rustfs-cli --test help_contract -- nested_subcommand_help_contract
+
+log_success "Service-account targetUser regression suite passed"

--- a/scripts/regression/service-account-target-user.sh
+++ b/scripts/regression/service-account-target-user.sh
@@ -44,7 +44,8 @@ log_info "Service-account targetUser regression suite"
 run_tests "core request serialization" \
     cargo test -p rc-core --lib -- \
     test_create_service_account_request_includes_expiration \
-    test_create_service_account_request_serializes_target_user
+    test_create_service_account_request_serializes_target_user \
+    test_create_service_account_request_deserializes_target_user
 
 run_tests "CLI request mapping" \
     cargo test -p rustfs-cli --lib -- \
@@ -57,6 +58,7 @@ run_tests "admin create integration" \
     cargo test -p rustfs-cli --test admin_service_account -- \
     service_account_create_sends_target_user_for_another_parent \
     service_account_create_omits_target_user_when_parent_is_the_caller \
+    service_account_create_omits_empty_user_flag_from_request_body \
     service_account_create_accepts_inline_policy_json
 
 run_tests "CLI help contract includes create --user" \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Related issue

Fixes https://github.com/rustfs/cli/issues/340

## Background

RustFS `add-service-account` accepts `targetUser` so an owner credential can create a service account parented to another IAM user. The Console already sends that field. `rc admin service-account create` did not, so every key was parented to the alias identity. Listing another user's keys with `--user` already worked.

Operators that reconcile keys for managed users currently have to re-authenticate as each user. With `targetUser`, the admin alias is enough.

## Solution

- Add `target_user: Option<String>` to `CreateServiceAccountRequest`, serialized as `targetUser` and omitted when unset.
- Add `--user <USER>` to `rc admin service-account create`, matching `ls --user`.
- Empty `--user` values are omitted so accidental blank flags do not send `targetUser: ""`.

This is additive. Existing create commands without `--user` serialize the same body as before.

This PR must be marked BREAKING because `docs/reference/rc/admin.md` is a protected CLI behavior contract. The change is additive; no JSON schema or config `schema_version` bump applies.

## Tests

- Core: `targetUser` is present only when set, and deserializes when present
- CLI: `--user` is forwarded; empty values are omitted
- Integration: mock admin server receives `targetUser`, omits it without `--user`, and omits it for `--user ""`
- Help contract includes create `--user`
- Regression: `scripts/regression/service-account-target-user.sh`

## Validation

```bash
cargo fmt --all
cargo clippy --workspace -- -D warnings
cargo test --workspace
./scripts/regression/service-account-target-user.sh
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2628e5c2-11d7-4e88-a86f-5f475da4fce3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2628e5c2-11d7-4e88-a86f-5f475da4fce3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

