### PR TITLE
fix(ilm): preserve lifecycle extension fields

### DIFF
--- a/crates/cli/src/commands/ilm/rule.rs
+++ b/crates/cli/src/commands/ilm/rule.rs
@@ -270,6 +270,7 @@ async fn execute_add(args: AddRuleArgs, output_config: OutputConfig) -> ExitCode
         Some(LifecycleExpiration {
             days: args.expiry_days,
             date: args.expiry_date,
+            expired_object_all_versions: None,
         })
     } else {
         None
@@ -331,6 +332,7 @@ async fn execute_add(args: AddRuleArgs, output_config: OutputConfig) -> ExitCode
         prefix: args.prefix,
         tags: None,
         expiration,
+        del_marker_expiration: None,
         transition,
         noncurrent_version_expiration,
         noncurrent_version_transition,
@@ -415,6 +417,10 @@ async fn execute_edit(args: EditRuleArgs, output_config: OutputConfig) -> ExitCo
             date: args
                 .expiry_date
                 .or_else(|| rule.expiration.as_ref().and_then(|e| e.date.clone())),
+            expired_object_all_versions: rule
+                .expiration
+                .as_ref()
+                .and_then(|expiration| expiration.expired_object_all_versions),
         });
     }
 
@@ -526,10 +532,13 @@ async fn execute_list(args: BucketArg, output_config: OutputConfig) -> ExitCode 
         Err(code) => return code,
     };
 
-    let rules = client
-        .get_bucket_lifecycle(&bucket)
-        .await
-        .unwrap_or_default();
+    let rules = match client.get_bucket_lifecycle(&bucket).await {
+        Ok(rules) => rules,
+        Err(error) => {
+            formatter.error(&format!("Failed to get lifecycle rules: {error}"));
+            return ExitCode::GeneralError;
+        }
+    };
 
     if formatter.is_json() {
         formatter.json(&RuleListOutput { bucket, rules });
@@ -679,10 +688,13 @@ async fn execute_export(args: BucketArg, output_config: OutputConfig) -> ExitCod
         Err(code) => return code,
     };
 
-    let rules = client
-        .get_bucket_lifecycle(&bucket)
-        .await
-        .unwrap_or_default();
+    let rules = match client.get_bucket_lifecycle(&bucket).await {
+        Ok(rules) => rules,
+        Err(error) => {
+            formatter.error(&format!("Failed to get lifecycle rules: {error}"));
+            return ExitCode::GeneralError;
+        }
+    };
 
     let config = LifecycleConfiguration { rules };
     formatter.json(&config);
@@ -784,7 +796,30 @@ fn validate_expired_delete_marker_rule(rule: &LifecycleRule) -> std::result::Res
             .as_ref()
             .is_some_and(|expiration| expiration.days.is_some() || expiration.date.is_some()),
         rule.tags.as_ref().is_some_and(|tags| !tags.is_empty()),
-    )
+    )?;
+
+    if let Some(expiration) = rule.expiration.as_ref()
+        && expiration.expired_object_all_versions.is_some()
+        && (expiration.days.is_none_or(|days| days < 1) || expiration.date.is_some())
+    {
+        return Err(
+            "ExpiredObjectAllVersions requires positive expiration days and no date".to_string(),
+        );
+    }
+
+    if let Some(expiration) = rule.del_marker_expiration.as_ref()
+        && expiration.days.is_none_or(|days| days < 1)
+    {
+        return Err("delete-marker expiration days must be at least 1".to_string());
+    }
+
+    if rule.del_marker_expiration.is_some()
+        && rule.tags.as_ref().is_some_and(|tags| !tags.is_empty())
+    {
+        return Err("delete-marker expiration cannot be combined with tag filters".to_string());
+    }
+
+    Ok(())
 }
 
 async fn setup_client(
@@ -943,7 +978,9 @@ mod tests {
             expiration: Some(LifecycleExpiration {
                 days: Some(30),
                 date: None,
+                expired_object_all_versions: None,
             }),
+            del_marker_expiration: None,
             transition: None,
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
@@ -961,6 +998,7 @@ mod tests {
             prefix: None,
             tags: None,
             expiration: None,
+            del_marker_expiration: None,
             transition: None,
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
@@ -1022,6 +1060,91 @@ mod tests {
         assert!(validate_expired_delete_marker_inputs(true, false, false).is_ok());
     }
 
+    #[test]
+    fn test_lifecycle_extension_validation_rejects_invalid_values() {
+        let invalid_all_versions = LifecycleRule {
+            id: "invalid-all-versions".to_string(),
+            status: LifecycleRuleStatus::Enabled,
+            prefix: None,
+            tags: None,
+            expiration: Some(LifecycleExpiration {
+                days: Some(0),
+                date: None,
+                expired_object_all_versions: Some(true),
+            }),
+            del_marker_expiration: None,
+            transition: None,
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        };
+        assert!(validate_expired_delete_marker_rule(&invalid_all_versions).is_err());
+
+        let all_versions_with_date = LifecycleRule {
+            id: "all-versions-date".to_string(),
+            status: LifecycleRuleStatus::Enabled,
+            prefix: None,
+            tags: None,
+            expiration: Some(LifecycleExpiration {
+                days: Some(1),
+                date: Some("2026-01-01T00:00:00Z".to_string()),
+                expired_object_all_versions: Some(false),
+            }),
+            del_marker_expiration: None,
+            transition: None,
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        };
+        assert!(validate_expired_delete_marker_rule(&all_versions_with_date).is_err());
+
+        let invalid_delete_marker = LifecycleRule {
+            id: "invalid-delete-marker".to_string(),
+            status: LifecycleRuleStatus::Enabled,
+            prefix: None,
+            tags: None,
+            expiration: None,
+            del_marker_expiration: Some(rc_core::LifecycleDelMarkerExpiration { days: None }),
+            transition: None,
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        };
+        assert!(validate_expired_delete_marker_rule(&invalid_delete_marker).is_err());
+    }
+
+    #[test]
+    fn test_lifecycle_import_accepts_issue_6334_shape() {
+        let input = r#"
+        {
+          "rules": [{
+            "id": "rule-delayed-deletion",
+            "status": "Enabled",
+            "prefix": "test/",
+            "expiration": {
+              "ExpiredObjectAllVersions": true,
+              "DelMarkerExpiration": true,
+              "days": 1
+            }
+          }]
+        }
+        "#;
+
+        let config: LifecycleConfiguration =
+            serde_json::from_str(input).expect("issue lifecycle import should parse");
+        assert_eq!(config.rules.len(), 1);
+        assert_eq!(
+            config.rules[0]
+                .del_marker_expiration
+                .as_ref()
+                .and_then(|expiration| expiration.days),
+            Some(1)
+        );
+    }
+
     #[tokio::test]
     async fn test_execute_import_rejects_invalid_marker_cleanup_before_alias_lookup() {
         let temp_dir = tempfile::tempdir().expect("create lifecycle config directory");
@@ -1035,7 +1158,9 @@ mod tests {
                 expiration: Some(LifecycleExpiration {
                     days: Some(30),
                     date: None,
+                    expired_object_all_versions: None,
                 }),
+                del_marker_expiration: None,
                 transition: None,
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,

--- a/crates/cli/src/commands/ilm/rule.rs
+++ b/crates/cli/src/commands/ilm/rule.rs
@@ -312,6 +312,7 @@ async fn execute_add(args: AddRuleArgs, output_config: OutputConfig) -> ExitCode
         (Some(days), Some(sc)) => Some(NoncurrentVersionTransition {
             noncurrent_days: days,
             storage_class: sc.clone(),
+            newer_noncurrent_versions: None,
         }),
         (Some(_), None) => {
             formatter.error("--noncurrent-transition-storage-class is required when using --noncurrent-transition-days");
@@ -331,11 +332,15 @@ async fn execute_add(args: AddRuleArgs, output_config: OutputConfig) -> ExitCode
         status,
         prefix: args.prefix,
         tags: None,
+        object_size_greater_than: None,
+        object_size_less_than: None,
         expiration,
         del_marker_expiration: None,
         transition,
+        transitions: Vec::new(),
         noncurrent_version_expiration,
         noncurrent_version_transition,
+        noncurrent_version_transitions: Vec::new(),
         abort_incomplete_multipart_upload_days: None,
         expired_object_delete_marker,
     };
@@ -483,6 +488,8 @@ async fn execute_edit(args: EditRuleArgs, output_config: OutputConfig) -> ExitCo
                 .noncurrent_transition_days
                 .unwrap_or_else(|| current.map(|c| c.noncurrent_days).unwrap_or(0)),
             storage_class: sc,
+            newer_noncurrent_versions: current
+                .and_then(|transition| transition.newer_noncurrent_versions),
         });
     }
 
@@ -975,6 +982,8 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: None,
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: Some(LifecycleExpiration {
                 days: Some(30),
                 date: None,
@@ -982,8 +991,10 @@ mod tests {
             }),
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: None,
         };
@@ -997,11 +1008,15 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: None,
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: None,
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: None,
         };
@@ -1067,6 +1082,8 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: None,
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: Some(LifecycleExpiration {
                 days: Some(0),
                 date: None,
@@ -1074,8 +1091,10 @@ mod tests {
             }),
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: None,
         };
@@ -1086,6 +1105,8 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: None,
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: Some(LifecycleExpiration {
                 days: Some(1),
                 date: Some("2026-01-01T00:00:00Z".to_string()),
@@ -1093,8 +1114,10 @@ mod tests {
             }),
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: None,
         };
@@ -1105,11 +1128,15 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: None,
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: None,
             del_marker_expiration: Some(rc_core::LifecycleDelMarkerExpiration { days: None }),
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: None,
         };
@@ -1155,6 +1182,8 @@ mod tests {
                 status: LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: Some(LifecycleExpiration {
                     days: Some(30),
                     date: None,
@@ -1162,8 +1191,10 @@ mod tests {
                 }),
                 del_marker_expiration: None,
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: Some(true),
             }],

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -38,8 +38,9 @@ pub use cors::{CorsConfiguration, CorsRule};
 pub use encryption::{BucketEncryption, ObjectEncryptionRequest};
 pub use error::{Error, MultipartAbortStatus, Result};
 pub use lifecycle::{
-    LifecycleConfiguration, LifecycleExpiration, LifecycleRule, LifecycleRuleStatus,
-    LifecycleTransition, NoncurrentVersionExpiration, NoncurrentVersionTransition,
+    LifecycleConfiguration, LifecycleDelMarkerExpiration, LifecycleExpiration, LifecycleRule,
+    LifecycleRuleStatus, LifecycleTransition, NoncurrentVersionExpiration,
+    NoncurrentVersionTransition,
 };
 pub use multipart_copy::{
     DEFAULT_MULTIPART_COPY_PART_SIZE, MultipartCopyCancellation, MultipartCopyOptions,

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -34,6 +34,22 @@ pub struct LifecycleRule {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<HashMap<String, String>>,
 
+    /// Minimum object size in bytes for the rule filter.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "ObjectSizeGreaterThan",
+        alias = "object_size_greater_than"
+    )]
+    pub object_size_greater_than: Option<i64>,
+
+    /// Maximum object size in bytes for the rule filter.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "ObjectSizeLessThan",
+        alias = "object_size_less_than"
+    )]
+    pub object_size_less_than: Option<i64>,
+
     /// Expiration settings for current object versions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration: Option<LifecycleExpiration>,
@@ -46,6 +62,13 @@ pub struct LifecycleRule {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transition: Option<LifecycleTransition>,
 
+    /// Additional transition settings for current object versions.
+    ///
+    /// `transition` remains the compatibility field for the first action;
+    /// this collection carries any subsequent actions returned by S3.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transitions: Vec<LifecycleTransition>,
+
     /// Expiration settings for noncurrent object versions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub noncurrent_version_expiration: Option<NoncurrentVersionExpiration>,
@@ -53,6 +76,10 @@ pub struct LifecycleRule {
     /// Transition settings for noncurrent object versions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub noncurrent_version_transition: Option<NoncurrentVersionTransition>,
+
+    /// Additional transition settings for noncurrent object versions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub noncurrent_version_transitions: Vec<NoncurrentVersionTransition>,
 
     /// Days after initiation to abort incomplete multipart uploads
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -74,14 +101,26 @@ struct LifecycleRuleInput {
     prefix: Option<String>,
     #[serde(default, alias = "Tags")]
     tags: Option<HashMap<String, String>>,
+    #[serde(
+        default,
+        alias = "ObjectSizeGreaterThan",
+        alias = "object_size_greater_than"
+    )]
+    object_size_greater_than: Option<i64>,
+    #[serde(default, alias = "ObjectSizeLessThan", alias = "object_size_less_than")]
+    object_size_less_than: Option<i64>,
     #[serde(default, alias = "Expiration")]
     expiration: Option<LifecycleExpirationInput>,
     #[serde(default, alias = "Transition")]
     transition: Option<LifecycleTransition>,
+    #[serde(default, alias = "Transitions")]
+    transitions: Vec<LifecycleTransition>,
     #[serde(default, alias = "NoncurrentVersionExpiration")]
     noncurrent_version_expiration: Option<NoncurrentVersionExpiration>,
     #[serde(default, alias = "NoncurrentVersionTransition")]
     noncurrent_version_transition: Option<NoncurrentVersionTransition>,
+    #[serde(default, alias = "NoncurrentVersionTransitions")]
+    noncurrent_version_transitions: Vec<NoncurrentVersionTransition>,
     #[serde(default, alias = "AbortIncompleteMultipartUploadDays")]
     abort_incomplete_multipart_upload_days: Option<i32>,
     #[serde(
@@ -126,13 +165,36 @@ enum LifecycleDelMarkerInput {
     Configuration(LifecycleDelMarkerExpiration),
 }
 
+#[derive(Debug)]
+struct NormalizedDelMarkerInput {
+    enabled: bool,
+    configuration: Option<LifecycleDelMarkerExpiration>,
+}
+
 impl<'de> Deserialize<'de> for LifecycleRule {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let input = LifecycleRuleInput::deserialize(deserializer)?;
-        let (expiration, nested_del_marker) = match input.expiration {
+        let LifecycleRuleInput {
+            id,
+            status,
+            prefix,
+            tags,
+            object_size_greater_than,
+            object_size_less_than,
+            expiration: expiration_input,
+            transition,
+            transitions: mut transitions_input,
+            noncurrent_version_expiration,
+            noncurrent_version_transition,
+            noncurrent_version_transitions: mut noncurrent_version_transitions_input,
+            abort_incomplete_multipart_upload_days,
+            expired_object_delete_marker,
+            del_marker_expiration: top_level_del_marker_input,
+        } = LifecycleRuleInput::deserialize(deserializer)?;
+
+        let (expiration, nested_del_marker) = match expiration_input {
             Some(expiration) => {
                 let nested_del_marker = expiration.del_marker_expiration;
                 (
@@ -149,34 +211,45 @@ impl<'de> Deserialize<'de> for LifecycleRule {
 
         let fallback_days = expiration.as_ref().and_then(|expiration| expiration.days);
         let top_level_del_marker =
-            normalize_del_marker_input(input.del_marker_expiration, fallback_days)
+            normalize_del_marker_input(top_level_del_marker_input, fallback_days)
                 .map_err(D::Error::custom)?;
         let nested_del_marker = normalize_del_marker_input(nested_del_marker, fallback_days)
             .map_err(D::Error::custom)?;
+        let del_marker_expiration =
+            merge_del_marker_inputs(top_level_del_marker, nested_del_marker)
+                .map_err(D::Error::custom)?;
 
-        let del_marker_expiration = match (top_level_del_marker, nested_del_marker) {
-            (Some(top), Some(nested)) if top.days != nested.days => {
-                return Err(D::Error::custom(
-                    "conflicting DelMarkerExpiration values in lifecycle rule",
-                ));
-            }
-            (Some(top), _) => Some(top),
-            (_, Some(nested)) => Some(nested),
-            (None, None) => None,
-        };
+        if let Some(transition) = transition {
+            transitions_input.insert(0, transition);
+        }
+        let transition = transitions_input.first().cloned();
+        let additional_transitions = transitions_input.into_iter().skip(1).collect();
+
+        if let Some(transition) = noncurrent_version_transition {
+            noncurrent_version_transitions_input.insert(0, transition);
+        }
+        let noncurrent_version_transition = noncurrent_version_transitions_input.first().cloned();
+        let additional_noncurrent_version_transitions = noncurrent_version_transitions_input
+            .into_iter()
+            .skip(1)
+            .collect();
 
         Ok(Self {
-            id: input.id,
-            status: input.status,
-            prefix: input.prefix,
-            tags: input.tags,
+            id,
+            status,
+            prefix,
+            tags,
+            object_size_greater_than,
+            object_size_less_than,
             expiration,
             del_marker_expiration,
-            transition: input.transition,
-            noncurrent_version_expiration: input.noncurrent_version_expiration,
-            noncurrent_version_transition: input.noncurrent_version_transition,
-            abort_incomplete_multipart_upload_days: input.abort_incomplete_multipart_upload_days,
-            expired_object_delete_marker: input.expired_object_delete_marker,
+            transition,
+            transitions: additional_transitions,
+            noncurrent_version_expiration,
+            noncurrent_version_transition,
+            noncurrent_version_transitions: additional_noncurrent_version_transitions,
+            abort_incomplete_multipart_upload_days,
+            expired_object_delete_marker,
         })
     }
 }
@@ -184,17 +257,71 @@ impl<'de> Deserialize<'de> for LifecycleRule {
 fn normalize_del_marker_input(
     input: Option<LifecycleDelMarkerInput>,
     fallback_days: Option<i32>,
-) -> std::result::Result<Option<LifecycleDelMarkerExpiration>, String> {
+) -> std::result::Result<Option<NormalizedDelMarkerInput>, String> {
     match input {
         None => Ok(None),
-        Some(LifecycleDelMarkerInput::Flag(false)) => Ok(None),
+        Some(LifecycleDelMarkerInput::Flag(false)) => Ok(Some(NormalizedDelMarkerInput {
+            enabled: false,
+            configuration: None,
+        })),
         Some(LifecycleDelMarkerInput::Flag(true)) => fallback_days
-            .map(|days| Some(LifecycleDelMarkerExpiration { days: Some(days) }))
+            .map(|days| {
+                Some(NormalizedDelMarkerInput {
+                    enabled: true,
+                    configuration: Some(LifecycleDelMarkerExpiration { days: Some(days) }),
+                })
+            })
             .ok_or_else(|| {
                 "DelMarkerExpiration=true requires expiration.days for compatibility input"
                     .to_string()
             }),
-        Some(LifecycleDelMarkerInput::Configuration(configuration)) => Ok(Some(configuration)),
+        Some(LifecycleDelMarkerInput::Configuration(configuration)) => {
+            Ok(Some(NormalizedDelMarkerInput {
+                enabled: true,
+                configuration: Some(configuration),
+            }))
+        }
+    }
+}
+
+fn merge_del_marker_inputs(
+    top_level: Option<NormalizedDelMarkerInput>,
+    nested: Option<NormalizedDelMarkerInput>,
+) -> std::result::Result<Option<LifecycleDelMarkerExpiration>, String> {
+    match (top_level, nested) {
+        (None, None) => Ok(None),
+        (Some(value), None) | (None, Some(value)) => Ok(value.enabled.then(|| {
+            value
+                .configuration
+                .unwrap_or(LifecycleDelMarkerExpiration { days: None })
+        })),
+        (Some(primary), Some(secondary)) => {
+            if primary.enabled != secondary.enabled {
+                return Err(
+                    "conflicting DelMarkerExpiration values in lifecycle rule: explicit false cannot be combined with an enabled value".to_string(),
+                );
+            }
+            if !primary.enabled {
+                return Ok(None);
+            }
+
+            let primary_configuration = primary
+                .configuration
+                .unwrap_or(LifecycleDelMarkerExpiration { days: None });
+            let secondary_configuration = secondary
+                .configuration
+                .unwrap_or(LifecycleDelMarkerExpiration { days: None });
+            if primary_configuration.days.is_some()
+                && secondary_configuration.days.is_some()
+                && primary_configuration.days != secondary_configuration.days
+            {
+                return Err("conflicting DelMarkerExpiration values in lifecycle rule".to_string());
+            }
+
+            Ok(Some(LifecycleDelMarkerExpiration {
+                days: primary_configuration.days.or(secondary_configuration.days),
+            }))
+        }
     }
 }
 
@@ -293,6 +420,10 @@ pub struct NoncurrentVersionTransition {
 
     /// Target storage class (tier name)
     pub storage_class: String,
+
+    /// Maximum number of newer noncurrent versions to retain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub newer_noncurrent_versions: Option<i32>,
 }
 
 impl fmt::Display for LifecycleRule {
@@ -331,6 +462,8 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: Some("logs/".to_string()),
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: Some(LifecycleExpiration {
                 days: Some(30),
                 date: None,
@@ -338,8 +471,10 @@ mod tests {
             }),
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: Some(7),
             expired_object_delete_marker: None,
         };
@@ -377,6 +512,8 @@ mod tests {
                 status: LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: Some(LifecycleExpiration {
                     days: Some(365),
                     date: None,
@@ -384,11 +521,13 @@ mod tests {
                 }),
                 del_marker_expiration: None,
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: Some(NoncurrentVersionExpiration {
                     noncurrent_days: 30,
                     newer_noncurrent_versions: Some(3),
                 }),
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: Some(true),
             }],
@@ -413,6 +552,7 @@ mod tests {
         let nvt = NoncurrentVersionTransition {
             noncurrent_days: 60,
             storage_class: "COLD_TIER".to_string(),
+            newer_noncurrent_versions: None,
         };
 
         let json = serde_json::to_string(&nvt).unwrap();
@@ -429,6 +569,8 @@ mod tests {
                 status: LifecycleRuleStatus::Enabled,
                 prefix: Some("test/".to_string()),
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: Some(LifecycleExpiration {
                     days: Some(1),
                     date: None,
@@ -436,8 +578,10 @@ mod tests {
                 }),
                 del_marker_expiration: Some(LifecycleDelMarkerExpiration { days: Some(1) }),
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: None,
             }],
@@ -521,5 +665,102 @@ mod tests {
 
         let result = serde_json::from_str::<LifecycleConfiguration>(input);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_lifecycle_extensions_reject_explicit_false_conflicts() {
+        let inputs = [
+            r#"
+            {
+              "rules": [{
+                "id": "conflicting-false-top-level",
+                "status": "Enabled",
+                "expiration": {"days": 1, "DelMarkerExpiration": true},
+                "delMarkerExpiration": false
+              }]
+            }
+            "#,
+            r#"
+            {
+              "rules": [{
+                "id": "conflicting-false-nested",
+                "status": "Enabled",
+                "expiration": {"days": 1, "DelMarkerExpiration": false},
+                "delMarkerExpiration": {"days": 1}
+              }]
+            }
+            "#,
+        ];
+
+        for input in inputs {
+            assert!(
+                serde_json::from_str::<LifecycleConfiguration>(input).is_err(),
+                "explicit false must not be silently overridden by an enabled representation"
+            );
+        }
+
+        let explicit_false = r#"
+        {
+          "rules": [{
+            "id": "explicit-false",
+            "status": "Enabled",
+            "delMarkerExpiration": false
+          }]
+        }
+        "#;
+        let config: LifecycleConfiguration =
+            serde_json::from_str(explicit_false).expect("standalone false is compatible");
+        assert!(config.rules[0].del_marker_expiration.is_none());
+    }
+
+    #[test]
+    fn test_lifecycle_rule_accepts_additional_actions_and_size_filters() {
+        let input = r#"
+        {
+          "rules": [{
+            "id": "full-rule",
+            "status": "Enabled",
+            "objectSizeGreaterThan": 500,
+            "objectSizeLessThan": 64000,
+            "transition": {"days": 30, "storageClass": "WARM"},
+            "transitions": [{"days": 60, "storageClass": "COLD"}],
+            "noncurrentVersionTransition": {
+              "noncurrentDays": 90,
+              "storageClass": "WARM",
+              "newerNoncurrentVersions": 2
+            },
+            "noncurrentVersionTransitions": [{
+              "noncurrentDays": 180,
+              "storageClass": "COLD",
+              "newerNoncurrentVersions": 1
+            }]
+          }]
+        }
+        "#;
+
+        let config: LifecycleConfiguration =
+            serde_json::from_str(input).expect("full lifecycle rule should parse");
+        let rule = &config.rules[0];
+        assert_eq!(rule.object_size_greater_than, Some(500));
+        assert_eq!(rule.object_size_less_than, Some(64000));
+        assert_eq!(rule.transitions.len(), 1);
+        assert_eq!(rule.noncurrent_version_transitions.len(), 1);
+        assert_eq!(
+            rule.noncurrent_version_transition
+                .as_ref()
+                .and_then(|transition| transition.newer_noncurrent_versions),
+            Some(2)
+        );
+        assert_eq!(
+            rule.noncurrent_version_transitions[0].newer_noncurrent_versions,
+            Some(1)
+        );
+
+        let serialized =
+            serde_json::to_value(&config).expect("full lifecycle rule should serialize");
+        let decoded: LifecycleConfiguration =
+            serde_json::from_value(serialized).expect("full lifecycle rule should round-trip");
+        assert_eq!(decoded.rules[0].transitions.len(), 1);
+        assert_eq!(decoded.rules[0].object_size_less_than, Some(64000));
     }
 }

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -6,7 +6,8 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
+use serde::de::Error as _;
+use serde::{Deserialize, Deserializer, Serialize};
 
 /// Full lifecycle configuration for a bucket
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -16,7 +17,7 @@ pub struct LifecycleConfiguration {
 }
 
 /// A single lifecycle rule
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LifecycleRule {
     /// Rule identifier
@@ -37,6 +38,10 @@ pub struct LifecycleRule {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expiration: Option<LifecycleExpiration>,
 
+    /// Expire delete-marker history after the configured number of days.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub del_marker_expiration: Option<LifecycleDelMarkerExpiration>,
+
     /// Transition settings for current object versions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transition: Option<LifecycleTransition>,
@@ -56,6 +61,141 @@ pub struct LifecycleRule {
     /// Whether to remove expired delete markers
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expired_object_delete_marker: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LifecycleRuleInput {
+    #[serde(alias = "ID")]
+    id: String,
+    #[serde(alias = "Status")]
+    status: LifecycleRuleStatus,
+    #[serde(default, alias = "Prefix")]
+    prefix: Option<String>,
+    #[serde(default, alias = "Tags")]
+    tags: Option<HashMap<String, String>>,
+    #[serde(default, alias = "Expiration")]
+    expiration: Option<LifecycleExpirationInput>,
+    #[serde(default, alias = "Transition")]
+    transition: Option<LifecycleTransition>,
+    #[serde(default, alias = "NoncurrentVersionExpiration")]
+    noncurrent_version_expiration: Option<NoncurrentVersionExpiration>,
+    #[serde(default, alias = "NoncurrentVersionTransition")]
+    noncurrent_version_transition: Option<NoncurrentVersionTransition>,
+    #[serde(default, alias = "AbortIncompleteMultipartUploadDays")]
+    abort_incomplete_multipart_upload_days: Option<i32>,
+    #[serde(
+        default,
+        alias = "ExpiredObjectDeleteMarker",
+        alias = "expired_object_delete_marker"
+    )]
+    expired_object_delete_marker: Option<bool>,
+    #[serde(
+        default,
+        alias = "DelMarkerExpiration",
+        alias = "del_marker_expiration"
+    )]
+    del_marker_expiration: Option<LifecycleDelMarkerInput>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LifecycleExpirationInput {
+    #[serde(default, alias = "Days")]
+    days: Option<i32>,
+    #[serde(default, alias = "Date")]
+    date: Option<String>,
+    #[serde(
+        default,
+        alias = "ExpiredObjectAllVersions",
+        alias = "expired_object_all_versions"
+    )]
+    expired_object_all_versions: Option<bool>,
+    #[serde(
+        default,
+        alias = "DelMarkerExpiration",
+        alias = "del_marker_expiration"
+    )]
+    del_marker_expiration: Option<LifecycleDelMarkerInput>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum LifecycleDelMarkerInput {
+    Flag(bool),
+    Configuration(LifecycleDelMarkerExpiration),
+}
+
+impl<'de> Deserialize<'de> for LifecycleRule {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let input = LifecycleRuleInput::deserialize(deserializer)?;
+        let (expiration, nested_del_marker) = match input.expiration {
+            Some(expiration) => {
+                let nested_del_marker = expiration.del_marker_expiration;
+                (
+                    Some(LifecycleExpiration {
+                        days: expiration.days,
+                        date: expiration.date,
+                        expired_object_all_versions: expiration.expired_object_all_versions,
+                    }),
+                    nested_del_marker,
+                )
+            }
+            None => (None, None),
+        };
+
+        let fallback_days = expiration.as_ref().and_then(|expiration| expiration.days);
+        let top_level_del_marker =
+            normalize_del_marker_input(input.del_marker_expiration, fallback_days)
+                .map_err(D::Error::custom)?;
+        let nested_del_marker = normalize_del_marker_input(nested_del_marker, fallback_days)
+            .map_err(D::Error::custom)?;
+
+        let del_marker_expiration = match (top_level_del_marker, nested_del_marker) {
+            (Some(top), Some(nested)) if top.days != nested.days => {
+                return Err(D::Error::custom(
+                    "conflicting DelMarkerExpiration values in lifecycle rule",
+                ));
+            }
+            (Some(top), _) => Some(top),
+            (_, Some(nested)) => Some(nested),
+            (None, None) => None,
+        };
+
+        Ok(Self {
+            id: input.id,
+            status: input.status,
+            prefix: input.prefix,
+            tags: input.tags,
+            expiration,
+            del_marker_expiration,
+            transition: input.transition,
+            noncurrent_version_expiration: input.noncurrent_version_expiration,
+            noncurrent_version_transition: input.noncurrent_version_transition,
+            abort_incomplete_multipart_upload_days: input.abort_incomplete_multipart_upload_days,
+            expired_object_delete_marker: input.expired_object_delete_marker,
+        })
+    }
+}
+
+fn normalize_del_marker_input(
+    input: Option<LifecycleDelMarkerInput>,
+    fallback_days: Option<i32>,
+) -> std::result::Result<Option<LifecycleDelMarkerExpiration>, String> {
+    match input {
+        None => Ok(None),
+        Some(LifecycleDelMarkerInput::Flag(false)) => Ok(None),
+        Some(LifecycleDelMarkerInput::Flag(true)) => fallback_days
+            .map(|days| Some(LifecycleDelMarkerExpiration { days: Some(days) }))
+            .ok_or_else(|| {
+                "DelMarkerExpiration=true requires expiration.days for compatibility input"
+                    .to_string()
+            }),
+        Some(LifecycleDelMarkerInput::Configuration(configuration)) => Ok(Some(configuration)),
+    }
 }
 
 /// Rule status
@@ -88,14 +228,32 @@ impl std::str::FromStr for LifecycleRuleStatus {
 
 /// Expiration settings for current object versions
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LifecycleExpiration {
     /// Number of days after creation to expire
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "Days")]
     pub days: Option<i32>,
 
     /// Specific date to expire (ISO 8601 format)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none", alias = "Date")]
     pub date: Option<String>,
+
+    /// Whether all object versions should be expired together.
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        alias = "ExpiredObjectAllVersions",
+        alias = "expired_object_all_versions"
+    )]
+    pub expired_object_all_versions: Option<bool>,
+}
+
+/// Expiration settings for delete markers and their prior object versions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecycleDelMarkerExpiration {
+    /// Number of days before delete-marker history is removed.
+    #[serde(skip_serializing_if = "Option::is_none", alias = "Days")]
+    pub days: Option<i32>,
 }
 
 /// Transition settings for current object versions
@@ -176,7 +334,9 @@ mod tests {
             expiration: Some(LifecycleExpiration {
                 days: Some(30),
                 date: None,
+                expired_object_all_versions: None,
             }),
+            del_marker_expiration: None,
             transition: None,
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
@@ -220,7 +380,9 @@ mod tests {
                 expiration: Some(LifecycleExpiration {
                     days: Some(365),
                     date: None,
+                    expired_object_all_versions: None,
                 }),
+                del_marker_expiration: None,
                 transition: None,
                 noncurrent_version_expiration: Some(NoncurrentVersionExpiration {
                     noncurrent_days: 30,
@@ -257,5 +419,107 @@ mod tests {
         let decoded: NoncurrentVersionTransition = serde_json::from_str(&json).unwrap();
         assert_eq!(decoded.noncurrent_days, 60);
         assert_eq!(decoded.storage_class, "COLD_TIER");
+    }
+
+    #[test]
+    fn test_lifecycle_extensions_use_canonical_json_shape() {
+        let config = LifecycleConfiguration {
+            rules: vec![LifecycleRule {
+                id: "all-versions".to_string(),
+                status: LifecycleRuleStatus::Enabled,
+                prefix: Some("test/".to_string()),
+                tags: None,
+                expiration: Some(LifecycleExpiration {
+                    days: Some(1),
+                    date: None,
+                    expired_object_all_versions: Some(true),
+                }),
+                del_marker_expiration: Some(LifecycleDelMarkerExpiration { days: Some(1) }),
+                transition: None,
+                noncurrent_version_expiration: None,
+                noncurrent_version_transition: None,
+                abort_incomplete_multipart_upload_days: None,
+                expired_object_delete_marker: None,
+            }],
+        };
+
+        let value = serde_json::to_value(&config).expect("serialize lifecycle extensions");
+        assert_eq!(
+            value["rules"][0]["expiration"]["expiredObjectAllVersions"],
+            true
+        );
+        assert_eq!(value["rules"][0]["delMarkerExpiration"]["days"], 1);
+        assert!(
+            value["rules"][0]["expiration"]
+                .get("DelMarkerExpiration")
+                .is_none()
+        );
+        let decoded: LifecycleConfiguration =
+            serde_json::from_value(value).expect("canonical lifecycle extensions should parse");
+        assert_eq!(
+            decoded.rules[0]
+                .expiration
+                .as_ref()
+                .and_then(|expiration| expiration.expired_object_all_versions),
+            Some(true)
+        );
+        assert_eq!(
+            decoded.rules[0]
+                .del_marker_expiration
+                .as_ref()
+                .and_then(|expiration| expiration.days),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_extensions_accept_issue_6334_compatibility_shape() {
+        let input = r#"
+        {
+          "rules": [{
+            "id": "rule-delayed-deletion",
+            "status": "Enabled",
+            "prefix": "test/",
+            "expiration": {
+              "ExpiredObjectAllVersions": true,
+              "DelMarkerExpiration": true,
+              "days": 1
+            }
+          }]
+        }
+        "#;
+
+        let config: LifecycleConfiguration =
+            serde_json::from_str(input).expect("issue compatibility shape should parse");
+        let rule = &config.rules[0];
+        assert_eq!(
+            rule.expiration
+                .as_ref()
+                .and_then(|expiration| expiration.expired_object_all_versions),
+            Some(true)
+        );
+        assert_eq!(
+            rule.del_marker_expiration
+                .as_ref()
+                .and_then(|expiration| expiration.days),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn test_lifecycle_extensions_reject_ambiguous_compatibility_shape() {
+        let input = r#"
+        {
+          "rules": [{
+            "id": "conflicting",
+            "status": "Enabled",
+            "expiration": {"days": 1, "DelMarkerExpiration": true},
+            "delMarkerExpiration": {"days": 2}
+          }]
+        }
+        "#;
+
+        let result = serde_json::from_str::<LifecycleConfiguration>(input);
+        assert!(result.is_err());
     }
 }

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -63,6 +63,8 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use zeroize::Zeroizing;
 
+use crate::lifecycle_xml::{build_lifecycle_configuration_xml, parse_lifecycle_configuration_xml};
+
 /// Keep single-part uploads small to avoid backend incompatibilities with
 /// streaming aws-chunked payloads.
 const SINGLE_PUT_OBJECT_MAX_SIZE: u64 = crate::multipart::DEFAULT_PART_SIZE;
@@ -1387,106 +1389,64 @@ fn build_replication_configuration_xml(config: &ReplicationConfiguration) -> Str
     xml
 }
 
-fn parse_lifecycle_filter_prefix(
-    filter: Option<&aws_sdk_s3::types::LifecycleRuleFilter>,
-) -> Option<String> {
-    filter
-        .and_then(|filter| filter.prefix().map(str::to_string))
-        .or_else(|| filter.and_then(|filter| filter.and()?.prefix().map(str::to_string)))
-}
-
-fn parse_lifecycle_filter_tags(
-    filter: Option<&aws_sdk_s3::types::LifecycleRuleFilter>,
-) -> Option<HashMap<String, String>> {
-    filter
-        .and_then(|filter| collect_tag_map(filter.tag().map(|tag| (tag.key(), tag.value()))))
-        .or_else(|| {
-            filter.and_then(|filter| {
-                collect_tag_map(
-                    filter
-                        .and()?
-                        .tags()
-                        .iter()
-                        .map(|tag| (tag.key(), tag.value())),
-                )
-            })
-        })
-}
-
-fn build_s3_tag(key: &str, value: &str) -> Result<aws_sdk_s3::types::Tag> {
-    aws_sdk_s3::types::Tag::builder()
-        .key(key)
-        .value(value)
-        .build()
-        .map_err(|error| Error::General(format!("build filter tag: {error}")))
-}
-
-fn build_lifecycle_rule_filter(
-    prefix: Option<&str>,
-    tags: Option<&HashMap<String, String>>,
-) -> Result<Option<aws_sdk_s3::types::LifecycleRuleFilter>> {
-    let Some(tags) = tags.filter(|tags| !tags.is_empty()) else {
-        return Ok(prefix.map(|prefix| {
-            aws_sdk_s3::types::LifecycleRuleFilter::builder()
-                .prefix(prefix)
-                .build()
-        }));
-    };
-
-    let tag_values = sorted_tags(tags)
-        .into_iter()
-        .map(|(key, value)| build_s3_tag(key, value))
-        .collect::<Result<Vec<_>>>()?;
-
-    let filter = if prefix.is_some() || tag_values.len() > 1 {
-        let mut and_builder = aws_sdk_s3::types::LifecycleRuleAndOperator::builder();
-        if let Some(prefix) = prefix {
-            and_builder = and_builder.prefix(prefix);
-        }
-        for tag in tag_values {
-            and_builder = and_builder.tags(tag);
-        }
-        aws_sdk_s3::types::LifecycleRuleFilter::builder()
-            .and(and_builder.build())
-            .build()
-    } else {
-        aws_sdk_s3::types::LifecycleRuleFilter::builder()
-            .tag(
-                tag_values
-                    .into_iter()
-                    .next()
-                    .expect("non-empty tags required to build lifecycle filter"),
-            )
-            .build()
-    };
-
-    Ok(Some(filter))
-}
-
 fn validate_lifecycle_rule(rule: &LifecycleRule) -> Result<()> {
-    if rule.expired_object_delete_marker != Some(true) {
-        return Ok(());
-    }
-
-    if rule
-        .expiration
-        .as_ref()
-        .is_some_and(|expiration| expiration.days.is_some() || expiration.date.is_some())
+    if let Some(expiration) = rule.expiration.as_ref()
+        && expiration.expired_object_all_versions.is_some()
+        && (expiration.days.is_none_or(|days| days < 1) || expiration.date.is_some())
     {
         return Err(Error::InvalidPath(format!(
-            "lifecycle rule '{}' cannot combine current expiration days or date with expired delete-marker cleanup",
+            "lifecycle rule '{}' requires positive expiration days without a date when ExpiredObjectAllVersions is specified",
             rule.id
         )));
     }
 
-    if rule.tags.as_ref().is_some_and(|tags| !tags.is_empty()) {
+    if let Some(expiration) = rule.del_marker_expiration.as_ref()
+        && expiration.days.is_none_or(|days| days < 1)
+    {
         return Err(Error::InvalidPath(format!(
-            "lifecycle rule '{}' cannot combine tag filters with expired delete-marker cleanup",
+            "lifecycle rule '{}' requires positive days for delete-marker expiration",
             rule.id
         )));
+    }
+
+    if rule.del_marker_expiration.is_some()
+        && rule.tags.as_ref().is_some_and(|tags| !tags.is_empty())
+    {
+        return Err(Error::InvalidPath(format!(
+            "lifecycle rule '{}' cannot combine delete-marker expiration with tag filters",
+            rule.id
+        )));
+    }
+
+    if rule.expired_object_delete_marker == Some(true) {
+        if rule
+            .expiration
+            .as_ref()
+            .is_some_and(|expiration| expiration.days.is_some() || expiration.date.is_some())
+        {
+            return Err(Error::InvalidPath(format!(
+                "lifecycle rule '{}' cannot combine current expiration days or date with expired delete-marker cleanup",
+                rule.id
+            )));
+        }
+
+        if rule.tags.as_ref().is_some_and(|tags| !tags.is_empty()) {
+            return Err(Error::InvalidPath(format!(
+                "lifecycle rule '{}' cannot combine tag filters with expired delete-marker cleanup",
+                rule.id
+            )));
+        }
     }
 
     Ok(())
+}
+
+fn is_missing_lifecycle_configuration_error(error_text: &str) -> bool {
+    let normalized = error_text.to_ascii_lowercase();
+    normalized.contains("nosuchlifecycleconfiguration")
+        || normalized.contains("lifecycle configuration is not found")
+        || normalized.contains("lifecycle configuration was not found")
+        || normalized.contains("lifecycle configuration does not exist")
 }
 
 impl HttpConnector for ReqwestConnector {
@@ -2845,6 +2805,37 @@ impl S3Client {
         Ok(url)
     }
 
+    fn lifecycle_url(&self, bucket: &str) -> Result<reqwest::Url> {
+        let mut url =
+            reqwest::Url::parse(self.alias.endpoint.trim_end_matches('/')).map_err(|e| {
+                Error::Network(format!("Invalid endpoint '{}': {e}", self.alias.endpoint))
+            })?;
+
+        if force_path_style_for_alias(&self.alias) {
+            let mut segments = url.path_segments_mut().map_err(|_| {
+                Error::Network(format!(
+                    "Endpoint '{}' does not support path-style bucket operations",
+                    self.alias.endpoint
+                ))
+            })?;
+            segments.pop_if_empty();
+            segments.push(bucket);
+        } else {
+            let host = url
+                .host_str()
+                .ok_or_else(|| Error::Network("Missing host in lifecycle endpoint".to_string()))?;
+            let bucket_host = format!("{bucket}.{host}");
+            url.set_host(Some(&bucket_host)).map_err(|_| {
+                Error::Network(format!(
+                    "Bucket '{bucket}' cannot be used with DNS-style lifecycle requests"
+                ))
+            })?;
+        }
+
+        url.set_query(Some("lifecycle="));
+        Ok(url)
+    }
+
     fn replication_extension_url(
         &self,
         bucket: &str,
@@ -3241,6 +3232,29 @@ impl S3Client {
         content_type: Option<&str>,
         body: Option<Vec<u8>>,
     ) -> Result<String> {
+        self.xml_request_inner(method, url, content_type, body, false)
+            .await
+    }
+
+    async fn xml_request_with_content_md5(
+        &self,
+        method: Method,
+        url: reqwest::Url,
+        content_type: Option<&str>,
+        body: Option<Vec<u8>>,
+    ) -> Result<String> {
+        self.xml_request_inner(method, url, content_type, body, true)
+            .await
+    }
+
+    async fn xml_request_inner(
+        &self,
+        method: Method,
+        url: reqwest::Url,
+        content_type: Option<&str>,
+        body: Option<Vec<u8>>,
+        include_content_md5: bool,
+    ) -> Result<String> {
         let body = body.unwrap_or_default();
         let mut headers = HeaderMap::new();
         headers.insert(
@@ -3268,6 +3282,14 @@ impl S3Client {
             let value = HeaderValue::from_str(&header.value)
                 .map_err(|e| Error::Auth(format!("Invalid custom header value: {e}")))?;
             headers.insert(name, value);
+        }
+
+        if include_content_md5 {
+            headers.insert(
+                HeaderName::from_static("content-md5"),
+                HeaderValue::from_str(&BASE64_STANDARD.encode(Md5::digest(&body)))
+                    .map_err(|e| Error::Auth(format!("Invalid content MD5 header: {e}")))?,
+            );
         }
 
         let signed_headers = self
@@ -6294,232 +6316,32 @@ impl ObjectStore for S3Client {
     }
 
     async fn get_bucket_lifecycle(&self, bucket: &str) -> Result<Vec<LifecycleRule>> {
-        let response = match self
-            .inner
-            .get_bucket_lifecycle_configuration()
-            .bucket(bucket)
-            .send()
-            .await
-        {
-            Ok(resp) => resp,
+        let url = self.lifecycle_url(bucket)?;
+        let body = match self.xml_request(Method::GET, url, None, None).await {
+            Ok(body) => body,
+            Err(Error::Network(error_text))
+                if is_missing_lifecycle_configuration_error(&error_text) =>
+            {
+                return Ok(Vec::new());
+            }
             Err(error) => {
-                let error_text = Self::format_sdk_error(&error);
-                if error_text.contains("NoSuchLifecycleConfiguration")
-                    || error_text.contains("lifecycle configuration is not found")
-                {
-                    return Ok(Vec::new());
-                }
-                return Err(Error::General(format!(
-                    "get_bucket_lifecycle: {error_text}"
-                )));
+                return Err(Error::General(format!("get_bucket_lifecycle: {error}")));
             }
         };
 
-        let mut rules = Vec::new();
-        for sdk_rule in response.rules() {
-            let id = sdk_rule.id().unwrap_or("").to_string();
-            let status = match sdk_rule.status().as_str() {
-                "Enabled" => rc_core::LifecycleRuleStatus::Enabled,
-                _ => rc_core::LifecycleRuleStatus::Disabled,
-            };
-
-            let prefix = parse_lifecycle_filter_prefix(sdk_rule.filter());
-            let tags = parse_lifecycle_filter_tags(sdk_rule.filter());
-
-            let expiration = sdk_rule
-                .expiration()
-                .map(|exp| rc_core::LifecycleExpiration {
-                    days: exp.days(),
-                    date: exp.date().map(|d| d.to_string()),
-                });
-
-            let transition = sdk_rule
-                .transitions()
-                .first()
-                .map(|t| rc_core::LifecycleTransition {
-                    days: t.days(),
-                    date: t.date().map(|d| d.to_string()),
-                    storage_class: t
-                        .storage_class()
-                        .map(|sc| sc.as_str().to_string())
-                        .unwrap_or_default(),
-                });
-
-            let noncurrent_version_expiration =
-                sdk_rule.noncurrent_version_expiration().map(|nve| {
-                    rc_core::NoncurrentVersionExpiration {
-                        noncurrent_days: nve.noncurrent_days().unwrap_or(0),
-                        newer_noncurrent_versions: nve.newer_noncurrent_versions(),
-                    }
-                });
-
-            let noncurrent_version_transition = sdk_rule
-                .noncurrent_version_transitions()
-                .first()
-                .map(|nvt| rc_core::NoncurrentVersionTransition {
-                    noncurrent_days: nvt.noncurrent_days().unwrap_or(0),
-                    storage_class: nvt
-                        .storage_class()
-                        .map(|sc| sc.as_str().to_string())
-                        .unwrap_or_default(),
-                });
-
-            let abort_incomplete_multipart_upload_days = sdk_rule
-                .abort_incomplete_multipart_upload()
-                .and_then(|a| a.days_after_initiation());
-
-            let expired_object_delete_marker = sdk_rule
-                .expiration()
-                .and_then(|e| e.expired_object_delete_marker())
-                .filter(|v| *v);
-
-            rules.push(LifecycleRule {
-                id,
-                status,
-                prefix,
-                tags,
-                expiration,
-                transition,
-                noncurrent_version_expiration,
-                noncurrent_version_transition,
-                abort_incomplete_multipart_upload_days,
-                expired_object_delete_marker,
-            });
-        }
-
-        Ok(rules)
+        parse_lifecycle_configuration_xml(&body)
     }
 
     async fn set_bucket_lifecycle(&self, bucket: &str, rules: Vec<LifecycleRule>) -> Result<()> {
-        use aws_sdk_s3::types::{
-            AbortIncompleteMultipartUpload, BucketLifecycleConfiguration, ExpirationStatus,
-            LifecycleExpiration as SdkExpiration, LifecycleRule as SdkRule,
-            NoncurrentVersionExpiration as SdkNve, NoncurrentVersionTransition as SdkNvt,
-            Transition, TransitionStorageClass,
-        };
-
-        let mut sdk_rules = Vec::new();
-        for rule in rules {
-            validate_lifecycle_rule(&rule)?;
-            let status = match rule.status {
-                rc_core::LifecycleRuleStatus::Enabled => ExpirationStatus::Enabled,
-                rc_core::LifecycleRuleStatus::Disabled => ExpirationStatus::Disabled,
-            };
-
-            let filter = build_lifecycle_rule_filter(rule.prefix.as_deref(), rule.tags.as_ref())?;
-
-            let expiration =
-                if rule.expiration.is_some() || rule.expired_object_delete_marker == Some(true) {
-                    let mut builder = SdkExpiration::builder();
-                    if let Some(days) = rule
-                        .expiration
-                        .as_ref()
-                        .and_then(|expiration| expiration.days)
-                    {
-                        builder = builder.days(days);
-                    }
-                    if let Some(date_str) = rule
-                        .expiration
-                        .as_ref()
-                        .and_then(|expiration| expiration.date.as_deref())
-                        && let Ok(dt) = aws_smithy_types::DateTime::from_str(
-                            date_str,
-                            aws_smithy_types::date_time::Format::DateTime,
-                        )
-                    {
-                        builder = builder.date(dt);
-                    }
-                    if let Some(true) = rule.expired_object_delete_marker {
-                        builder = builder.expired_object_delete_marker(true);
-                    }
-                    Some(builder.build())
-                } else {
-                    None
-                };
-
-            let transitions = rule.transition.map(|t| {
-                #[allow(deprecated)]
-                let sc = TransitionStorageClass::from(t.storage_class.as_str());
-                let mut builder = Transition::builder().storage_class(sc);
-                if let Some(days) = t.days {
-                    builder = builder.days(days);
-                }
-                if let Some(ref date_str) = t.date
-                    && let Ok(dt) = aws_smithy_types::DateTime::from_str(
-                        date_str,
-                        aws_smithy_types::date_time::Format::DateTime,
-                    )
-                {
-                    builder = builder.date(dt);
-                }
-                vec![builder.build()]
-            });
-
-            let nve = rule.noncurrent_version_expiration.map(|nve| {
-                let mut builder = SdkNve::builder().noncurrent_days(nve.noncurrent_days);
-                if let Some(newer) = nve.newer_noncurrent_versions {
-                    builder = builder.newer_noncurrent_versions(newer);
-                }
-                builder.build()
-            });
-
-            let nvt = rule.noncurrent_version_transition.map(|nvt| {
-                let sc = TransitionStorageClass::from(nvt.storage_class.as_str());
-                let builder = SdkNvt::builder()
-                    .noncurrent_days(nvt.noncurrent_days)
-                    .storage_class(sc);
-                vec![builder.build()]
-            });
-
-            let abort = rule.abort_incomplete_multipart_upload_days.map(|days| {
-                AbortIncompleteMultipartUpload::builder()
-                    .days_after_initiation(days)
-                    .build()
-            });
-
-            let mut builder = SdkRule::builder().id(&rule.id).status(status);
-            if let Some(filter) = filter {
-                builder = builder.filter(filter);
-            }
-            if let Some(expiration) = expiration {
-                builder = builder.expiration(expiration);
-            }
-            if let Some(transitions) = transitions {
-                builder = builder.set_transitions(Some(transitions));
-            }
-            if let Some(nve) = nve {
-                builder = builder.noncurrent_version_expiration(nve);
-            }
-            if let Some(nvt) = nvt {
-                builder = builder.set_noncurrent_version_transitions(Some(nvt));
-            }
-            if let Some(abort) = abort {
-                builder = builder.abort_incomplete_multipart_upload(abort);
-            }
-
-            let sdk_rule = builder
-                .build()
-                .map_err(|e| Error::General(format!("build lifecycle rule: {e}")))?;
-            sdk_rules.push(sdk_rule);
+        for rule in &rules {
+            validate_lifecycle_rule(rule)?;
         }
 
-        let config = BucketLifecycleConfiguration::builder()
-            .set_rules(Some(sdk_rules))
-            .build()
-            .map_err(|e| Error::General(format!("build lifecycle config: {e}")))?;
-
-        self.inner
-            .put_bucket_lifecycle_configuration()
-            .bucket(bucket)
-            .lifecycle_configuration(config)
-            .send()
+        let url = self.lifecycle_url(bucket)?;
+        let body = build_lifecycle_configuration_xml(&rules).into_bytes();
+        self.xml_request_with_content_md5(Method::PUT, url, Some("application/xml"), Some(body))
             .await
-            .map_err(|e| {
-                Error::General(format!(
-                    "set_bucket_lifecycle: {}",
-                    Self::format_sdk_error(&e)
-                ))
-            })?;
+            .map_err(|error| Error::General(format!("set_bucket_lifecycle: {error}")))?;
 
         Ok(())
     }
@@ -6737,6 +6559,7 @@ mod tests {
         method: String,
         target: String,
         headers: Vec<(String, String)>,
+        body: Vec<u8>,
     }
 
     fn test_s3_client(
@@ -7046,6 +6869,7 @@ mod tests {
             method,
             target,
             headers,
+            body: buffer[header_end..header_end + content_length].to_vec(),
         }
     }
 
@@ -7435,37 +7259,108 @@ mod tests {
     }
 
     #[test]
-    fn build_lifecycle_rule_filter_preserves_prefix_and_tags() {
-        let mut tags = HashMap::new();
-        tags.insert("env".to_string(), "prod".to_string());
-        tags.insert("team".to_string(), "core".to_string());
+    fn missing_lifecycle_configuration_detection_does_not_hide_missing_bucket() {
+        assert!(is_missing_lifecycle_configuration_error(
+            "HTTP 404: <Code>NoSuchLifecycleConfiguration</Code>"
+        ));
+        assert!(is_missing_lifecycle_configuration_error(
+            "lifecycle configuration is not found"
+        ));
+        assert!(is_missing_lifecycle_configuration_error(
+            "The lifecycle configuration was not found"
+        ));
+        assert!(is_missing_lifecycle_configuration_error(
+            "HTTP 404: The lifecycle configuration does not exist"
+        ));
+        assert!(!is_missing_lifecycle_configuration_error(
+            "HTTP 404: <Code>NoSuchBucket</Code>"
+        ));
+        assert!(!is_missing_lifecycle_configuration_error("HTTP 404"));
+    }
 
-        let filter = build_lifecycle_rule_filter(Some("logs/"), Some(&tags))
-            .expect("build lifecycle filter")
-            .expect("lifecycle filter");
+    #[tokio::test]
+    async fn get_bucket_lifecycle_maps_only_missing_configuration_to_empty_rules() {
+        let missing_config_body = b"<Error><Code>NoSuchLifecycleConfiguration</Code></Error>";
+        let mut missing_config_response = format!(
+            "HTTP/1.1 404 Not Found\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            missing_config_body.len()
+        )
+        .into_bytes();
+        missing_config_response.extend_from_slice(missing_config_body);
+        let (missing_config_endpoint, missing_config_receiver, missing_config_server) =
+            start_replication_extension_test_server(missing_config_response);
+        let (missing_config_client, _) =
+            test_s3_client_with_endpoint(&missing_config_endpoint, None);
+        let rules = ObjectStore::get_bucket_lifecycle(&missing_config_client, "bucket")
+            .await
+            .expect("missing lifecycle configuration should be empty");
+        assert!(rules.is_empty());
+        missing_config_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("missing configuration request should be captured");
+        missing_config_server
+            .join()
+            .expect("missing configuration server should finish");
 
-        assert_eq!(
-            parse_lifecycle_filter_prefix(Some(&filter)).as_deref(),
-            Some("logs/")
+        let missing_bucket_body = b"<Error><Code>NoSuchBucket</Code></Error>";
+        let mut missing_bucket_response = format!(
+            "HTTP/1.1 404 Not Found\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            missing_bucket_body.len()
+        )
+        .into_bytes();
+        missing_bucket_response.extend_from_slice(missing_bucket_body);
+        let (missing_bucket_endpoint, missing_bucket_receiver, missing_bucket_server) =
+            start_replication_extension_test_server(missing_bucket_response);
+        let (missing_bucket_client, _) =
+            test_s3_client_with_endpoint(&missing_bucket_endpoint, None);
+        let result = ObjectStore::get_bucket_lifecycle(&missing_bucket_client, "bucket").await;
+        assert!(
+            matches!(result, Err(Error::General(ref message)) if message.contains("NoSuchBucket")),
+            "missing bucket must not be reported as an empty lifecycle configuration: {result:?}"
         );
-        let parsed_tags = parse_lifecycle_filter_tags(Some(&filter)).expect("parsed tags");
-        assert_eq!(parsed_tags.get("env").map(String::as_str), Some("prod"));
-        assert_eq!(parsed_tags.get("team").map(String::as_str), Some("core"));
+        missing_bucket_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("missing bucket request should be captured");
+        missing_bucket_server
+            .join()
+            .expect("missing bucket server should finish");
+
+        let malformed_body = b"<LifecycleConfiguration><Rule>";
+        let mut malformed_response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            malformed_body.len()
+        )
+        .into_bytes();
+        malformed_response.extend_from_slice(malformed_body);
+        let (malformed_endpoint, malformed_receiver, malformed_server) =
+            start_replication_extension_test_server(malformed_response);
+        let (malformed_client, _) = test_s3_client_with_endpoint(&malformed_endpoint, None);
+        let result = ObjectStore::get_bucket_lifecycle(&malformed_client, "bucket").await;
+        assert!(
+            matches!(result, Err(Error::General(ref message)) if message.contains("parse bucket lifecycle xml")),
+            "malformed lifecycle XML must not become an empty configuration: {result:?}"
+        );
+        malformed_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("malformed lifecycle request should be captured");
+        malformed_server
+            .join()
+            .expect("malformed lifecycle server should finish");
     }
 
     #[tokio::test]
     async fn set_bucket_lifecycle_serializes_marker_only_expiration() {
-        let response = http::Response::builder()
-            .status(200)
-            .body(SdkBody::empty())
-            .expect("build lifecycle response");
-        let (client, request_receiver) = test_s3_client(Some(response));
+        let (endpoint, request_receiver, server_handle) = start_replication_extension_test_server(
+            b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec(),
+        );
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
         let rule = LifecycleRule {
             id: "marker-only".to_string(),
             status: rc_core::LifecycleRuleStatus::Enabled,
             prefix: Some(String::new()),
             tags: None,
             expiration: None,
+            del_marker_expiration: None,
             transition: None,
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
@@ -7477,27 +7372,31 @@ mod tests {
             .await
             .expect("set marker-only lifecycle rule");
 
-        let request = request_receiver.expect_request();
-        let body = request.body().bytes().expect("request body bytes");
-        let body = std::str::from_utf8(body).expect("request body is utf8");
+        let request = request_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("server should capture lifecycle request");
+        let body = std::str::from_utf8(&request.body).expect("request body is utf8");
+        assert_eq!(request.method, "PUT");
+        assert_eq!(request.target, "/bucket?lifecycle=");
         assert!(body.contains(
             "<Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>"
         ));
+        server_handle.join().expect("server thread should finish");
     }
 
     #[tokio::test]
     async fn set_bucket_lifecycle_serializes_noncurrent_expiration_with_marker_cleanup() {
-        let response = http::Response::builder()
-            .status(200)
-            .body(SdkBody::empty())
-            .expect("build lifecycle response");
-        let (client, request_receiver) = test_s3_client(Some(response));
+        let (endpoint, request_receiver, server_handle) = start_replication_extension_test_server(
+            b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec(),
+        );
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
         let rule = LifecycleRule {
             id: "noncurrent-marker".to_string(),
             status: rc_core::LifecycleRuleStatus::Enabled,
             prefix: Some(String::new()),
             tags: None,
             expiration: None,
+            del_marker_expiration: None,
             transition: None,
             noncurrent_version_expiration: Some(rc_core::NoncurrentVersionExpiration {
                 noncurrent_days: 1,
@@ -7512,9 +7411,10 @@ mod tests {
             .await
             .expect("set noncurrent lifecycle rule with marker cleanup");
 
-        let request = request_receiver.expect_request();
-        let body = request.body().bytes().expect("request body bytes");
-        let body = std::str::from_utf8(body).expect("request body is utf8");
+        let request = request_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("server should capture lifecycle request");
+        let body = std::str::from_utf8(&request.body).expect("request body is utf8");
         assert!(body.contains(
             "<NoncurrentVersionExpiration><NoncurrentDays>1</NoncurrentDays></NoncurrentVersionExpiration>"
         ));
@@ -7523,14 +7423,54 @@ mod tests {
         ));
         assert!(!body.contains("<Expiration><Days>"));
         assert!(!body.contains("<Expiration><Date>"));
+        server_handle.join().expect("server thread should finish");
+    }
+
+    #[tokio::test]
+    async fn set_bucket_lifecycle_serializes_extension_expirations_and_content_md5() {
+        let (endpoint, request_receiver, server_handle) = start_replication_extension_test_server(
+            b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec(),
+        );
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
+        let rule = LifecycleRule {
+            id: "extensions".to_string(),
+            status: rc_core::LifecycleRuleStatus::Enabled,
+            prefix: Some("test/".to_string()),
+            tags: None,
+            expiration: Some(rc_core::LifecycleExpiration {
+                days: Some(1),
+                date: None,
+                expired_object_all_versions: Some(true),
+            }),
+            del_marker_expiration: Some(rc_core::LifecycleDelMarkerExpiration { days: Some(1) }),
+            transition: None,
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        };
+
+        ObjectStore::set_bucket_lifecycle(&client, "bucket", vec![rule])
+            .await
+            .expect("set extension lifecycle rule");
+
+        let request = request_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("server should capture lifecycle request");
+        let body = std::str::from_utf8(&request.body).expect("request body is utf8");
+        assert!(body.contains("<ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>"));
+        assert!(body.contains("<DelMarkerExpiration><Days>1</Days></DelMarkerExpiration>"));
+        let expected_md5 = BASE64_STANDARD.encode(Md5::digest(&request.body));
+        assert_eq!(
+            header_value(&request.headers, "content-md5"),
+            Some(expected_md5.as_str())
+        );
+        server_handle.join().expect("server thread should finish");
     }
 
     #[tokio::test]
     async fn get_then_set_bucket_lifecycle_preserves_marker_cleanup() {
-        let get_response = http::Response::builder()
-            .status(200)
-            .body(SdkBody::from(
-                r#"<?xml version="1.0" encoding="UTF-8"?>
+        let get_body = br#"<?xml version="1.0" encoding="UTF-8"?>
 <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <Rule>
     <ID>noncurrent-marker</ID>
@@ -7538,31 +7478,53 @@ mod tests {
     <Filter><Prefix></Prefix></Filter>
     <NoncurrentVersionExpiration><NoncurrentDays>1</NoncurrentDays></NoncurrentVersionExpiration>
     <Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>
+    <DelMarkerExpiration><Days>2</Days></DelMarkerExpiration>
   </Rule>
-</LifecycleConfiguration>"#,
-            ))
-            .expect("build get lifecycle response");
-        let (read_client, _read_request_receiver) = test_s3_client(Some(get_response));
+</LifecycleConfiguration>"#;
+        let mut get_response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/xml\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            get_body.len()
+        )
+        .into_bytes();
+        get_response.extend_from_slice(get_body);
+        let (get_endpoint, _get_request_receiver, get_server_handle) =
+            start_replication_extension_test_server(get_response);
+        let (read_client, _) = test_s3_client_with_endpoint(&get_endpoint, None);
         let rules = ObjectStore::get_bucket_lifecycle(&read_client, "bucket")
             .await
             .expect("get lifecycle rules");
         assert_eq!(rules[0].expired_object_delete_marker, Some(true));
+        assert_eq!(
+            rules[0]
+                .del_marker_expiration
+                .as_ref()
+                .and_then(|expiration| expiration.days),
+            Some(2)
+        );
+        get_server_handle
+            .join()
+            .expect("get server thread should finish");
 
-        let set_response = http::Response::builder()
-            .status(200)
-            .body(SdkBody::empty())
-            .expect("build set lifecycle response");
-        let (write_client, write_request_receiver) = test_s3_client(Some(set_response));
+        let (put_endpoint, put_request_receiver, put_server_handle) =
+            start_replication_extension_test_server(
+                b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec(),
+            );
+        let (write_client, _) = test_s3_client_with_endpoint(&put_endpoint, None);
         ObjectStore::set_bucket_lifecycle(&write_client, "bucket", rules)
             .await
             .expect("write lifecycle rules back");
 
-        let request = write_request_receiver.expect_request();
-        let body = request.body().bytes().expect("request body bytes");
-        let body = std::str::from_utf8(body).expect("request body is utf8");
+        let request = put_request_receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("put server should capture lifecycle request");
+        let body = std::str::from_utf8(&request.body).expect("request body is utf8");
         assert!(body.contains(
             "<Expiration><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration>"
         ));
+        assert!(body.contains("<DelMarkerExpiration><Days>2</Days></DelMarkerExpiration>"));
+        put_server_handle
+            .join()
+            .expect("put server thread should finish");
     }
 
     #[tokio::test]
@@ -7579,7 +7541,9 @@ mod tests {
                 expiration: Some(rc_core::LifecycleExpiration {
                     days: Some(30),
                     date: None,
+                    expired_object_all_versions: None,
                 }),
+                del_marker_expiration: None,
                 transition: None,
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
@@ -7592,6 +7556,7 @@ mod tests {
                 prefix: None,
                 tags: Some(tags),
                 expiration: None,
+                del_marker_expiration: None,
                 transition: None,
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
@@ -7603,6 +7568,68 @@ mod tests {
         for rule in rules {
             let result = ObjectStore::set_bucket_lifecycle(&client, "bucket", vec![rule]).await;
             assert!(matches!(result, Err(Error::InvalidPath(_))));
+        }
+        request_receiver.expect_no_request();
+    }
+
+    #[tokio::test]
+    async fn set_bucket_lifecycle_rejects_invalid_extension_values() {
+        let (client, request_receiver) = test_s3_client(None);
+        let rules = [
+            LifecycleRule {
+                id: "all-versions-without-days".to_string(),
+                status: rc_core::LifecycleRuleStatus::Enabled,
+                prefix: None,
+                tags: None,
+                expiration: Some(rc_core::LifecycleExpiration {
+                    days: None,
+                    date: None,
+                    expired_object_all_versions: Some(true),
+                }),
+                del_marker_expiration: None,
+                transition: None,
+                noncurrent_version_expiration: None,
+                noncurrent_version_transition: None,
+                abort_incomplete_multipart_upload_days: None,
+                expired_object_delete_marker: None,
+            },
+            LifecycleRule {
+                id: "all-versions-with-date".to_string(),
+                status: rc_core::LifecycleRuleStatus::Enabled,
+                prefix: None,
+                tags: None,
+                expiration: Some(rc_core::LifecycleExpiration {
+                    days: Some(1),
+                    date: Some("2026-01-01T00:00:00Z".to_string()),
+                    expired_object_all_versions: Some(false),
+                }),
+                del_marker_expiration: None,
+                transition: None,
+                noncurrent_version_expiration: None,
+                noncurrent_version_transition: None,
+                abort_incomplete_multipart_upload_days: None,
+                expired_object_delete_marker: None,
+            },
+            LifecycleRule {
+                id: "delete-marker-without-days".to_string(),
+                status: rc_core::LifecycleRuleStatus::Enabled,
+                prefix: None,
+                tags: None,
+                expiration: None,
+                del_marker_expiration: Some(rc_core::LifecycleDelMarkerExpiration { days: None }),
+                transition: None,
+                noncurrent_version_expiration: None,
+                noncurrent_version_transition: None,
+                abort_incomplete_multipart_upload_days: None,
+                expired_object_delete_marker: None,
+            },
+        ];
+
+        for rule in rules {
+            assert!(matches!(
+                ObjectStore::set_bucket_lifecycle(&client, "bucket", vec![rule]).await,
+                Err(Error::InvalidPath(_))
+            ));
         }
         request_receiver.expect_no_request();
     }
@@ -8117,6 +8144,20 @@ mod tests {
         let url = client.cors_url("bucket-name").expect("build cors url");
 
         assert_eq!(url.as_str(), "https://example.com/bucket-name?cors=");
+    }
+
+    #[test]
+    fn lifecycle_url_uses_dns_style_when_alias_requests_dns() {
+        let (mut client, _) = test_s3_client(None);
+        client.alias.bucket_lookup = "dns".to_string();
+
+        let url = client
+            .lifecycle_url("bucket-name")
+            .expect("build lifecycle url");
+
+        assert_eq!(url.host_str(), Some("bucket-name.example.com"));
+        assert_eq!(url.path(), "/");
+        assert_eq!(url.query(), Some("lifecycle="));
     }
 
     #[test]

--- a/crates/s3/src/client.rs
+++ b/crates/s3/src/client.rs
@@ -49,10 +49,10 @@ use rc_core::{
     ReplicationResyncStartResult, ReplicationResyncState, ReplicationResyncStatus,
     ReplicationResyncTargetStatus, RequestHeader, Result, RetentionDuration, RetentionDurationUnit,
     RetentionMode, SelectOptions, SseCustomerKey, TransferCopyOptions, TransferReadOptions,
-    global_request_headers,
+    global_request_headers, is_retryable_error, retry_with_backoff,
 };
 use reqwest::Method;
-use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue};
+use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderName, HeaderValue, LOCATION};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -63,7 +63,10 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use zeroize::Zeroizing;
 
-use crate::lifecycle_xml::{build_lifecycle_configuration_xml, parse_lifecycle_configuration_xml};
+use crate::lifecycle_xml::{
+    build_lifecycle_configuration_xml, parse_lifecycle_configuration_xml,
+    validate_lifecycle_configuration_xml_response,
+};
 
 /// Keep single-part uploads small to avoid backend incompatibilities with
 /// streaming aws-chunked payloads.
@@ -75,6 +78,7 @@ const REPLICATION_EXTENSION_BODY_LIMIT: u64 = 1024 * 1024;
 const REPLICATION_CHECK_PROBE_NAMESPACE: &str = ".rustfs.sys/replication-check/";
 const REPLICATION_CHECK_ERROR_LIMIT: usize = 512;
 const REPLICATION_CHECK_DESCRIPTION_LIMIT: usize = 1024;
+const MAX_LIFECYCLE_REDIRECTS: u32 = 5;
 
 fn contains_control_characters(value: &str) -> bool {
     value.chars().any(char::is_control)
@@ -163,6 +167,19 @@ enum BucketPolicyErrorKind {
     MissingPolicy,
     MissingBucket,
     Other,
+}
+
+#[derive(Debug)]
+struct XmlResponse {
+    status: reqwest::StatusCode,
+    headers: HeaderMap,
+    body: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct XmlRequestOptions {
+    include_content_md5: bool,
+    include_custom_headers: bool,
 }
 
 /// Custom HTTP connector using reqwest, supporting insecure TLS (skip cert verification)
@@ -270,6 +287,93 @@ fn sdk_retry_config(
         .initial_backoff(Duration::from_millis(config.initial_backoff_ms))
         .max_backoff(Duration::from_millis(config.max_backoff_ms))
         .build())
+}
+
+fn is_lifecycle_redirect(status: reqwest::StatusCode) -> bool {
+    matches!(
+        status,
+        reqwest::StatusCode::MOVED_PERMANENTLY
+            | reqwest::StatusCode::TEMPORARY_REDIRECT
+            | reqwest::StatusCode::PERMANENT_REDIRECT
+    )
+}
+
+fn is_lifecycle_retryable_error(error: &Error) -> bool {
+    let Error::Network(message) = error else {
+        return is_retryable_error(error);
+    };
+    if message.starts_with("Request failed:") || message.starts_with("Failed to read response:") {
+        return true;
+    }
+    if let Some(status) = message
+        .strip_prefix("HTTP ")
+        .and_then(|message| message.split(':').next())
+        .and_then(|status| status.parse::<u16>().ok())
+    {
+        return (500..600).contains(&status)
+            || status == reqwest::StatusCode::TOO_MANY_REQUESTS.as_u16();
+    }
+    is_retryable_error(error)
+}
+
+fn recognized_s3_provider(host: &str) -> Option<&'static str> {
+    let host = host.to_ascii_lowercase();
+    [
+        ("amazonaws.com.cn", "s3"),
+        ("amazonaws.com", "s3"),
+        ("aliyuncs.com", "oss"),
+    ]
+    .into_iter()
+    .find_map(|(suffix, service)| {
+        let belongs_to_provider = host == suffix || host.ends_with(&format!(".{suffix}"));
+        let is_service_host = host
+            .split('.')
+            .any(|label| label == service || label.starts_with(&format!("{service}-")));
+        (belongs_to_provider && is_service_host).then_some(suffix)
+    })
+}
+
+fn lifecycle_redirect_host_is_trusted(current: &str, next: &str) -> bool {
+    current.eq_ignore_ascii_case(next)
+        || recognized_s3_provider(current)
+            .zip(recognized_s3_provider(next))
+            .is_some_and(|(current, next)| current == next)
+}
+
+fn resolve_lifecycle_redirect(
+    current_url: &reqwest::Url,
+    headers: &HeaderMap,
+) -> Result<reqwest::Url> {
+    let location = headers
+        .get(LOCATION)
+        .ok_or_else(|| Error::Network("lifecycle redirect missing Location header".to_string()))?
+        .to_str()
+        .map_err(|_| {
+            Error::Network("lifecycle redirect has an invalid Location header".to_string())
+        })?;
+    let next_url = current_url
+        .join(location)
+        .map_err(|error| Error::Network(format!("invalid lifecycle redirect Location: {error}")))?;
+    if !matches!(next_url.scheme(), "http" | "https")
+        || !next_url.username().is_empty()
+        || next_url.password().is_some()
+    {
+        return Err(Error::Network(
+            "lifecycle redirect must target an HTTP(S) URL without credentials".to_string(),
+        ));
+    }
+    let trusted_host = current_url
+        .host_str()
+        .zip(next_url.host_str())
+        .is_some_and(|(current, next)| lifecycle_redirect_host_is_trusted(current, next));
+    let same_port = current_url.port_or_known_default() == next_url.port_or_known_default();
+    let downgraded = current_url.scheme() == "https" && next_url.scheme() != "https";
+    if !trusted_host || !same_port || downgraded {
+        return Err(Error::Network(
+            "lifecycle redirect must stay on the configured endpoint host or a recognized S3 provider, and must not downgrade HTTPS".to_string(),
+        ));
+    }
+    Ok(next_url)
 }
 
 fn sdk_timeout_config(
@@ -3171,6 +3275,18 @@ impl S3Client {
         headers: &HeaderMap,
         body: &[u8],
     ) -> Result<HeaderMap> {
+        self.sign_xml_request_for_region(method, url, headers, body, &self.alias.region)
+            .await
+    }
+
+    async fn sign_xml_request_for_region(
+        &self,
+        method: &Method,
+        url: &str,
+        headers: &HeaderMap,
+        body: &[u8],
+        region: &str,
+    ) -> Result<HeaderMap> {
         if self.alias.anonymous {
             return Ok(headers.clone());
         }
@@ -3189,7 +3305,7 @@ impl S3Client {
 
         let signing_params = v4::SigningParams::builder()
             .identity(&identity)
-            .region(&self.alias.region)
+            .region(region)
             .name(S3_SERVICE_NAME)
             .time(std::time::SystemTime::now())
             .settings(signing_settings)
@@ -3236,17 +3352,6 @@ impl S3Client {
             .await
     }
 
-    async fn xml_request_with_content_md5(
-        &self,
-        method: Method,
-        url: reqwest::Url,
-        content_type: Option<&str>,
-        body: Option<Vec<u8>>,
-    ) -> Result<String> {
-        self.xml_request_inner(method, url, content_type, body, true)
-            .await
-    }
-
     async fn xml_request_inner(
         &self,
         method: Method,
@@ -3256,15 +3361,125 @@ impl S3Client {
         include_content_md5: bool,
     ) -> Result<String> {
         let body = body.unwrap_or_default();
+        let response = self
+            .xml_request_once(
+                &method,
+                &url,
+                content_type,
+                &body,
+                &self.alias.region,
+                XmlRequestOptions {
+                    include_content_md5,
+                    include_custom_headers: true,
+                },
+            )
+            .await?;
+
+        if !response.status.is_success() {
+            return Err(self.xml_response_error(&response));
+        }
+
+        Ok(response.body)
+    }
+
+    async fn lifecycle_xml_request(
+        &self,
+        method: Method,
+        url: reqwest::Url,
+        content_type: Option<&str>,
+        body: Option<Vec<u8>>,
+        include_content_md5: bool,
+    ) -> Result<String> {
+        let body = body.unwrap_or_default();
+        let retry = self.alias.retry_config();
+        // Reuse the same validation as the SDK transport so malformed alias retry
+        // settings cannot silently disable lifecycle retries.
+        sdk_retry_config(&retry)?;
+
+        let initial_region = self.alias.region.clone();
+        let initial_host = url.host_str().map(str::to_owned);
+        retry_with_backoff(
+            &retry,
+            || {
+                let method = method.clone();
+                let body = body.clone();
+                let mut current_url = url.clone();
+                let mut signing_region = initial_region.clone();
+                let initial_host = initial_host.clone();
+                async move {
+                    let mut redirects = 0;
+                    loop {
+                        let response = self
+                            .xml_request_once(
+                                &method,
+                                &current_url,
+                                content_type,
+                                &body,
+                                &signing_region,
+                                XmlRequestOptions {
+                                    include_content_md5,
+                                    include_custom_headers: current_url
+                                        .host_str()
+                                        .zip(initial_host.as_deref())
+                                        .is_some_and(|(current, initial)| {
+                                            current.eq_ignore_ascii_case(initial)
+                                        }),
+                                },
+                            )
+                            .await?;
+
+                        if is_lifecycle_redirect(response.status) {
+                            if redirects >= MAX_LIFECYCLE_REDIRECTS {
+                                return Err(self.xml_response_error(&response));
+                            }
+                            if let Some(region) = response
+                                .headers
+                                .get("x-amz-bucket-region")
+                                .and_then(|value| value.to_str().ok())
+                                .map(str::trim)
+                                .filter(|value| {
+                                    !value.is_empty() && !contains_control_characters(value)
+                                })
+                            {
+                                signing_region = region.to_string();
+                            }
+                            current_url =
+                                resolve_lifecycle_redirect(&current_url, &response.headers)?;
+                            redirects += 1;
+                            continue;
+                        }
+
+                        if response.status.is_success() {
+                            return Ok(response.body);
+                        }
+
+                        return Err(self.xml_response_error(&response));
+                    }
+                }
+            },
+            is_lifecycle_retryable_error,
+        )
+        .await
+    }
+
+    async fn xml_request_once(
+        &self,
+        method: &Method,
+        url: &reqwest::Url,
+        content_type: Option<&str>,
+        body: &[u8],
+        signing_region: &str,
+        options: XmlRequestOptions,
+    ) -> Result<XmlResponse> {
         let mut headers = HeaderMap::new();
         headers.insert(
             "x-amz-content-sha256",
-            HeaderValue::from_str(&Self::sha256_hash(&body))
+            HeaderValue::from_str(&Self::sha256_hash(body))
                 .map_err(|e| Error::Auth(format!("Invalid content hash header: {e}")))?,
         );
         headers.insert(
             "host",
-            HeaderValue::from_str(&self.request_host(&url)?)
+            HeaderValue::from_str(&self.request_host(url)?)
                 .map_err(|e| Error::Auth(format!("Invalid host header: {e}")))?,
         );
 
@@ -3276,32 +3491,36 @@ impl S3Client {
             );
         }
 
-        for header in &self.request_headers {
-            let name = HeaderName::from_bytes(header.name.as_bytes())
-                .map_err(|e| Error::Auth(format!("Invalid custom header name: {e}")))?;
-            let value = HeaderValue::from_str(&header.value)
-                .map_err(|e| Error::Auth(format!("Invalid custom header value: {e}")))?;
-            headers.insert(name, value);
+        // Caller-supplied x-amz headers can contain credentials; keep them on the
+        // configured host when a provider redirect changes the authority.
+        if options.include_custom_headers {
+            for header in &self.request_headers {
+                let name = HeaderName::from_bytes(header.name.as_bytes())
+                    .map_err(|e| Error::Auth(format!("Invalid custom header name: {e}")))?;
+                let value = HeaderValue::from_str(&header.value)
+                    .map_err(|e| Error::Auth(format!("Invalid custom header value: {e}")))?;
+                headers.insert(name, value);
+            }
         }
 
-        if include_content_md5 {
+        if options.include_content_md5 {
             headers.insert(
                 HeaderName::from_static("content-md5"),
-                HeaderValue::from_str(&BASE64_STANDARD.encode(Md5::digest(&body)))
+                HeaderValue::from_str(&BASE64_STANDARD.encode(Md5::digest(body)))
                     .map_err(|e| Error::Auth(format!("Invalid content MD5 header: {e}")))?,
             );
         }
 
         let signed_headers = self
-            .sign_xml_request(&method, url.as_str(), &headers, &body)
+            .sign_xml_request_for_region(method, url.as_str(), &headers, body, signing_region)
             .await?;
 
-        let mut request_builder = self.xml_http_client.request(method, url);
+        let mut request_builder = self.xml_http_client.request(method.clone(), url.clone());
         for (name, value) in &signed_headers {
             request_builder = request_builder.header(name, value);
         }
         if !body.is_empty() {
-            request_builder = request_builder.body(body);
+            request_builder = request_builder.body(body.to_vec());
         }
 
         let response = request_builder
@@ -3310,20 +3529,25 @@ impl S3Client {
             .map_err(|e| Error::Network(format!("Request failed: {e}")))?;
 
         let status = response.status();
+        let response_headers = response.headers().clone();
         let text = response
             .text()
             .await
             .map_err(|e| Error::Network(format!("Failed to read response: {e}")))?;
 
-        if !status.is_success() {
-            return Err(Error::Network(format!(
-                "HTTP {}: {}",
-                status.as_u16(),
-                text
-            )));
-        }
+        Ok(XmlResponse {
+            status,
+            headers: response_headers,
+            body: text,
+        })
+    }
 
-        Ok(text)
+    fn xml_response_error(&self, response: &XmlResponse) -> Error {
+        Error::Network(self.redact_sensitive_text(format!(
+            "HTTP {}: {}",
+            response.status.as_u16(),
+            response.body
+        )))
     }
 
     fn bucket_policy_error_kind(
@@ -6317,7 +6541,10 @@ impl ObjectStore for S3Client {
 
     async fn get_bucket_lifecycle(&self, bucket: &str) -> Result<Vec<LifecycleRule>> {
         let url = self.lifecycle_url(bucket)?;
-        let body = match self.xml_request(Method::GET, url, None, None).await {
+        let body = match self
+            .lifecycle_xml_request(Method::GET, url, None, None, false)
+            .await
+        {
             Ok(body) => body,
             Err(Error::Network(error_text))
                 if is_missing_lifecycle_configuration_error(&error_text) =>
@@ -6339,8 +6566,11 @@ impl ObjectStore for S3Client {
 
         let url = self.lifecycle_url(bucket)?;
         let body = build_lifecycle_configuration_xml(&rules).into_bytes();
-        self.xml_request_with_content_md5(Method::PUT, url, Some("application/xml"), Some(body))
+        let response = self
+            .lifecycle_xml_request(Method::PUT, url, Some("application/xml"), Some(body), true)
             .await
+            .map_err(|error| Error::General(format!("set_bucket_lifecycle: {error}")))?;
+        validate_lifecycle_configuration_xml_response(&response)
             .map_err(|error| Error::General(format!("set_bucket_lifecycle: {error}")))?;
 
         Ok(())
@@ -6939,6 +7169,34 @@ mod tests {
         (endpoint, receiver, handle)
     }
 
+    fn start_lifecycle_sequence_test_server(
+        responses: Vec<Vec<u8>>,
+    ) -> (
+        String,
+        mpsc::Receiver<CapturedXmlRequest>,
+        thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind lifecycle test server");
+        let endpoint = format!("http://{}", listener.local_addr().expect("local addr"));
+        let (sender, receiver) = mpsc::channel();
+
+        let handle = thread::spawn(move || {
+            for response in responses {
+                let (mut stream, _) = listener.accept().expect("accept lifecycle request");
+                stream
+                    .set_read_timeout(Some(Duration::from_secs(5)))
+                    .expect("set lifecycle request timeout");
+                let request = read_xml_request(&mut stream);
+                sender.send(request).expect("send lifecycle request");
+                stream
+                    .write_all(&response)
+                    .expect("write lifecycle response");
+            }
+        });
+
+        (endpoint, receiver, handle)
+    }
+
     fn start_repeated_replication_extension_test_server(
         response: Vec<u8>,
         request_count: usize,
@@ -7349,6 +7607,196 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_bucket_lifecycle_rejects_success_error_envelope() {
+        let body = b"<Error><Code>InternalError</Code><Message>unexpected</Message></Error>";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        )
+        .into_bytes();
+        let mut response = response;
+        response.extend_from_slice(body);
+        let (endpoint, receiver, server) = start_replication_extension_test_server(response);
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
+
+        let result = ObjectStore::get_bucket_lifecycle(&client, "bucket").await;
+        assert!(
+            matches!(result, Err(Error::General(ref message)) if message.contains("unexpected lifecycle root")),
+            "success Error envelope must not be treated as an empty lifecycle: {result:?}"
+        );
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("error response request should be captured");
+        server.join().expect("error response server should finish");
+    }
+
+    #[tokio::test]
+    async fn set_bucket_lifecycle_rejects_success_error_envelope() {
+        let body = b"<Error><Code>InternalError</Code><Message>unexpected</Message></Error>";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            body.len()
+        )
+        .into_bytes();
+        let mut response = response;
+        response.extend_from_slice(body);
+        let (endpoint, receiver, server) = start_replication_extension_test_server(response);
+        let (client, _) = test_s3_client_with_endpoint(&endpoint, None);
+        let rule = LifecycleRule {
+            id: "error-response".to_string(),
+            status: rc_core::LifecycleRuleStatus::Enabled,
+            prefix: None,
+            tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
+            expiration: None,
+            del_marker_expiration: None,
+            transition: None,
+            transitions: Vec::new(),
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        };
+
+        let result = ObjectStore::set_bucket_lifecycle(&client, "bucket", vec![rule]).await;
+        assert!(
+            matches!(result, Err(Error::General(ref message)) if message.contains("unexpected lifecycle root")),
+            "success Error envelope must not be treated as a successful PUT: {result:?}"
+        );
+        receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("error response request should be captured");
+        server.join().expect("error response server should finish");
+    }
+
+    #[tokio::test]
+    async fn lifecycle_get_retries_transient_failure() {
+        let success_body = br#"<LifecycleConfiguration><Rule><ID>retry</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"#;
+        let first = b"<Error><Code>InternalError</Code></Error>";
+        let first_response = format!(
+            "HTTP/1.1 500 Internal Server Error\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            first.len()
+        )
+        .into_bytes();
+        let mut first_response = first_response;
+        first_response.extend_from_slice(first);
+        let second_response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            success_body.len()
+        )
+        .into_bytes();
+        let mut second_response = second_response;
+        second_response.extend_from_slice(success_body);
+        let (endpoint, receiver, server) =
+            start_lifecycle_sequence_test_server(vec![first_response, second_response]);
+        let (mut client, _) = test_s3_client_with_endpoint(&endpoint, None);
+        client.alias.retry = Some(rc_core::alias::RetryConfig {
+            max_attempts: 2,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+        });
+
+        let rules = ObjectStore::get_bucket_lifecycle(&client, "bucket")
+            .await
+            .expect("transient lifecycle failure should be retried");
+        assert_eq!(rules[0].id, "retry");
+        let first_request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("first lifecycle request should be captured");
+        let second_request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("retry lifecycle request should be captured");
+        assert_eq!(first_request.method, "GET");
+        assert_eq!(second_request.method, "GET");
+        server.join().expect("retry server should finish");
+    }
+
+    #[tokio::test]
+    async fn lifecycle_get_retries_dropped_connection() {
+        let success_body = br#"<LifecycleConfiguration><Rule><ID>network-retry</ID><Status>Enabled</Status></Rule></LifecycleConfiguration>"#;
+        let success_response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            success_body.len()
+        )
+        .into_bytes();
+        let mut success_response = success_response;
+        success_response.extend_from_slice(success_body);
+        let (endpoint, receiver, server) =
+            start_lifecycle_sequence_test_server(vec![Vec::new(), success_response]);
+        let (mut client, _) = test_s3_client_with_endpoint(&endpoint, None);
+        client.alias.retry = Some(rc_core::alias::RetryConfig {
+            max_attempts: 2,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+        });
+
+        let rules = ObjectStore::get_bucket_lifecycle(&client, "bucket")
+            .await
+            .expect("dropped lifecycle connection should be retried");
+        assert_eq!(rules[0].id, "network-retry");
+        for _ in 0..2 {
+            let request = receiver
+                .recv_timeout(Duration::from_secs(5))
+                .expect("lifecycle request should be captured");
+            assert_eq!(request.method, "GET");
+        }
+        server.join().expect("network retry server should finish");
+    }
+
+    #[tokio::test]
+    async fn lifecycle_put_follows_redirect_and_resigns_request() {
+        let redirect = b"HTTP/1.1 307 Temporary Redirect\r\nlocation: /redirected?lifecycle=\r\nx-amz-bucket-region: eu-west-1\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec();
+        let success = b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec();
+        let (endpoint, receiver, server) =
+            start_lifecycle_sequence_test_server(vec![redirect, success]);
+        let (mut client, _) = test_s3_client_with_endpoint(&endpoint, None);
+        client.alias.retry = Some(rc_core::alias::RetryConfig {
+            max_attempts: 1,
+            initial_backoff_ms: 1,
+            max_backoff_ms: 1,
+        });
+        let rule = LifecycleRule {
+            id: "redirect".to_string(),
+            status: rc_core::LifecycleRuleStatus::Enabled,
+            prefix: None,
+            tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
+            expiration: None,
+            del_marker_expiration: None,
+            transition: None,
+            transitions: Vec::new(),
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        };
+
+        ObjectStore::set_bucket_lifecycle(&client, "bucket", vec![rule])
+            .await
+            .expect("lifecycle PUT should follow endpoint redirect");
+        let first_request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("redirect request should be captured");
+        let second_request = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("redirect follow-up should be captured");
+        assert_eq!(first_request.method, "PUT");
+        assert_eq!(second_request.method, "PUT");
+        assert_eq!(second_request.target, "/redirected?lifecycle=");
+        let first_signature = header_value(&first_request.headers, "authorization")
+            .expect("redirect request should be signed");
+        let second_signature = header_value(&second_request.headers, "authorization")
+            .expect("redirect follow-up should be signed");
+        assert_ne!(first_signature, second_signature);
+        assert!(second_signature.contains("/eu-west-1/s3/aws4_request"));
+        server.join().expect("redirect server should finish");
+    }
+
+    #[tokio::test]
     async fn set_bucket_lifecycle_serializes_marker_only_expiration() {
         let (endpoint, request_receiver, server_handle) = start_replication_extension_test_server(
             b"HTTP/1.1 200 OK\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_vec(),
@@ -7359,11 +7807,15 @@ mod tests {
             status: rc_core::LifecycleRuleStatus::Enabled,
             prefix: Some(String::new()),
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: None,
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: Some(true),
         };
@@ -7395,14 +7847,18 @@ mod tests {
             status: rc_core::LifecycleRuleStatus::Enabled,
             prefix: Some(String::new()),
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: None,
             del_marker_expiration: None,
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: Some(rc_core::NoncurrentVersionExpiration {
                 noncurrent_days: 1,
                 newer_noncurrent_versions: None,
             }),
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: Some(true),
         };
@@ -7437,6 +7893,8 @@ mod tests {
             status: rc_core::LifecycleRuleStatus::Enabled,
             prefix: Some("test/".to_string()),
             tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: Some(rc_core::LifecycleExpiration {
                 days: Some(1),
                 date: None,
@@ -7444,8 +7902,10 @@ mod tests {
             }),
             del_marker_expiration: Some(rc_core::LifecycleDelMarkerExpiration { days: Some(1) }),
             transition: None,
+            transitions: Vec::new(),
             noncurrent_version_expiration: None,
             noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: None,
             expired_object_delete_marker: None,
         };
@@ -7538,6 +7998,8 @@ mod tests {
                 status: rc_core::LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: Some(rc_core::LifecycleExpiration {
                     days: Some(30),
                     date: None,
@@ -7545,8 +8007,10 @@ mod tests {
                 }),
                 del_marker_expiration: None,
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: Some(true),
             },
@@ -7555,11 +8019,15 @@ mod tests {
                 status: rc_core::LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: Some(tags),
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: None,
                 del_marker_expiration: None,
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: Some(true),
             },
@@ -7581,6 +8049,8 @@ mod tests {
                 status: rc_core::LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: Some(rc_core::LifecycleExpiration {
                     days: None,
                     date: None,
@@ -7588,8 +8058,10 @@ mod tests {
                 }),
                 del_marker_expiration: None,
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: None,
             },
@@ -7598,6 +8070,8 @@ mod tests {
                 status: rc_core::LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: Some(rc_core::LifecycleExpiration {
                     days: Some(1),
                     date: Some("2026-01-01T00:00:00Z".to_string()),
@@ -7605,8 +8079,10 @@ mod tests {
                 }),
                 del_marker_expiration: None,
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: None,
             },
@@ -7615,11 +8091,15 @@ mod tests {
                 status: rc_core::LifecycleRuleStatus::Enabled,
                 prefix: None,
                 tags: None,
+                object_size_greater_than: None,
+                object_size_less_than: None,
                 expiration: None,
                 del_marker_expiration: Some(rc_core::LifecycleDelMarkerExpiration { days: None }),
                 transition: None,
+                transitions: Vec::new(),
                 noncurrent_version_expiration: None,
                 noncurrent_version_transition: None,
+                noncurrent_version_transitions: Vec::new(),
                 abort_incomplete_multipart_upload_days: None,
                 expired_object_delete_marker: None,
             },
@@ -8158,6 +8638,65 @@ mod tests {
         assert_eq!(url.host_str(), Some("bucket-name.example.com"));
         assert_eq!(url.path(), "/");
         assert_eq!(url.query(), Some("lifecycle="));
+    }
+
+    #[test]
+    fn lifecycle_redirect_rejects_cross_host_locations() {
+        let current = reqwest::Url::parse("https://s3.example.com/bucket?lifecycle=")
+            .expect("valid current lifecycle URL");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            LOCATION,
+            HeaderValue::from_static("https://attacker.example/collect"),
+        );
+
+        let result = resolve_lifecycle_redirect(&current, &headers);
+        assert!(
+            matches!(result, Err(Error::Network(message)) if message.contains("configured endpoint host"))
+        );
+    }
+
+    #[test]
+    fn lifecycle_redirect_allows_recognized_s3_provider_hosts() {
+        let current = reqwest::Url::parse("https://s3.amazonaws.com/bucket?lifecycle=")
+            .expect("valid current lifecycle URL");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            LOCATION,
+            HeaderValue::from_static("https://bucket.s3.eu-west-1.amazonaws.com/?lifecycle="),
+        );
+
+        let result = resolve_lifecycle_redirect(&current, &headers)
+            .expect("AWS S3 endpoint redirects should be supported");
+        assert_eq!(result.host_str(), Some("bucket.s3.eu-west-1.amazonaws.com"));
+    }
+
+    #[test]
+    fn lifecycle_redirect_statuses_are_limited_to_s3_endpoint_redirects() {
+        assert!(is_lifecycle_redirect(
+            reqwest::StatusCode::MOVED_PERMANENTLY
+        ));
+        assert!(is_lifecycle_redirect(
+            reqwest::StatusCode::TEMPORARY_REDIRECT
+        ));
+        assert!(is_lifecycle_redirect(
+            reqwest::StatusCode::PERMANENT_REDIRECT
+        ));
+        assert!(!is_lifecycle_redirect(reqwest::StatusCode::FOUND));
+        assert!(!is_lifecycle_redirect(reqwest::StatusCode::SEE_OTHER));
+    }
+
+    #[test]
+    fn lifecycle_retry_classification_uses_http_status_before_error_text() {
+        assert!(is_lifecycle_retryable_error(&Error::Network(
+            "HTTP 500: InternalError".to_string(),
+        )));
+        assert!(is_lifecycle_retryable_error(&Error::Network(
+            "HTTP 429: throttled".to_string(),
+        )));
+        assert!(!is_lifecycle_retryable_error(&Error::Network(
+            "HTTP 404: SlowDown".to_string(),
+        )));
     }
 
     #[test]

--- a/crates/s3/src/lib.rs
+++ b/crates/s3/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod admin;
 pub mod client;
+mod lifecycle_xml;
 pub mod multipart;
 mod ops;
 mod select;

--- a/crates/s3/src/lifecycle_xml.rs
+++ b/crates/s3/src/lifecycle_xml.rs
@@ -1,0 +1,492 @@
+use std::collections::HashMap;
+
+use quick_xml::de::from_str as from_xml_str;
+use rc_core::{
+    Error, LifecycleDelMarkerExpiration, LifecycleExpiration, LifecycleRule, LifecycleRuleStatus,
+    LifecycleTransition, NoncurrentVersionExpiration, NoncurrentVersionTransition, Result,
+};
+use serde::Deserialize;
+
+const S3_LIFECYCLE_XML_NAMESPACE: &str = "http://s3.amazonaws.com/doc/2006-03-01/";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleConfigurationXml {
+    #[serde(rename = "Rule", default)]
+    rules: Vec<LifecycleRuleXml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleRuleXml {
+    #[serde(rename = "ID")]
+    id: Option<String>,
+    status: Option<String>,
+    #[serde(rename = "Prefix")]
+    legacy_prefix: Option<String>,
+    filter: Option<LifecycleFilterXml>,
+    expiration: Option<LifecycleExpirationXml>,
+    #[serde(rename = "Transition", default)]
+    transitions: Vec<LifecycleTransitionXml>,
+    noncurrent_version_expiration: Option<NoncurrentVersionExpirationXml>,
+    #[serde(rename = "NoncurrentVersionTransition", default)]
+    noncurrent_version_transitions: Vec<NoncurrentVersionTransitionXml>,
+    abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUploadXml>,
+    del_marker_expiration: Option<LifecycleDelMarkerExpirationXml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleFilterXml {
+    prefix: Option<String>,
+    tag: Option<LifecycleTagXml>,
+    and: Option<LifecycleAndXml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleAndXml {
+    prefix: Option<String>,
+    #[serde(rename = "Tag", default)]
+    tags: Vec<LifecycleTagXml>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleTagXml {
+    key: Option<String>,
+    value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleExpirationXml {
+    date: Option<String>,
+    days: Option<i32>,
+    expired_object_all_versions: Option<bool>,
+    expired_object_delete_marker: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleTransitionXml {
+    date: Option<String>,
+    days: Option<i32>,
+    storage_class: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct NoncurrentVersionExpirationXml {
+    noncurrent_days: Option<i32>,
+    newer_noncurrent_versions: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct NoncurrentVersionTransitionXml {
+    noncurrent_days: Option<i32>,
+    storage_class: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct AbortIncompleteMultipartUploadXml {
+    days_after_initiation: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct LifecycleDelMarkerExpirationXml {
+    days: Option<i32>,
+}
+
+pub(crate) fn parse_lifecycle_configuration_xml(body: &str) -> Result<Vec<LifecycleRule>> {
+    let config: LifecycleConfigurationXml = from_xml_str(body)
+        .map_err(|error| Error::General(format!("parse bucket lifecycle xml: {error}")))?;
+
+    config
+        .rules
+        .into_iter()
+        .map(convert_lifecycle_rule)
+        .collect()
+}
+
+fn convert_lifecycle_rule(rule: LifecycleRuleXml) -> Result<LifecycleRule> {
+    let prefix = rule
+        .filter
+        .as_ref()
+        .and_then(parse_filter_prefix)
+        .or(rule.legacy_prefix);
+    let tags = rule.filter.as_ref().and_then(parse_filter_tags);
+
+    let (expiration, expired_object_delete_marker) = match rule.expiration {
+        Some(expiration) => (
+            Some(LifecycleExpiration {
+                days: expiration.days,
+                date: expiration.date,
+                expired_object_all_versions: expiration.expired_object_all_versions,
+            }),
+            expiration
+                .expired_object_delete_marker
+                .filter(|value| *value),
+        ),
+        None => (None, None),
+    };
+
+    let transition = rule
+        .transitions
+        .into_iter()
+        .next()
+        .map(|transition| LifecycleTransition {
+            days: transition.days,
+            date: transition.date,
+            storage_class: transition.storage_class.unwrap_or_default(),
+        });
+
+    let noncurrent_version_expiration =
+        rule.noncurrent_version_expiration
+            .map(|expiration| NoncurrentVersionExpiration {
+                noncurrent_days: expiration.noncurrent_days.unwrap_or_default(),
+                newer_noncurrent_versions: expiration.newer_noncurrent_versions,
+            });
+
+    let noncurrent_version_transition =
+        rule.noncurrent_version_transitions
+            .into_iter()
+            .next()
+            .map(|transition| NoncurrentVersionTransition {
+                noncurrent_days: transition.noncurrent_days.unwrap_or_default(),
+                storage_class: transition.storage_class.unwrap_or_default(),
+            });
+
+    Ok(LifecycleRule {
+        id: rule.id.unwrap_or_default(),
+        status: parse_rule_status(rule.status.as_deref()),
+        prefix,
+        tags,
+        expiration,
+        del_marker_expiration: rule.del_marker_expiration.map(|expiration| {
+            LifecycleDelMarkerExpiration {
+                days: expiration.days,
+            }
+        }),
+        transition,
+        noncurrent_version_expiration,
+        noncurrent_version_transition,
+        abort_incomplete_multipart_upload_days: rule
+            .abort_incomplete_multipart_upload
+            .and_then(|upload| upload.days_after_initiation),
+        expired_object_delete_marker,
+    })
+}
+
+fn parse_rule_status(status: Option<&str>) -> LifecycleRuleStatus {
+    match status {
+        Some(value) if value.eq_ignore_ascii_case("enabled") => LifecycleRuleStatus::Enabled,
+        _ => LifecycleRuleStatus::Disabled,
+    }
+}
+
+fn parse_filter_prefix(filter: &LifecycleFilterXml) -> Option<String> {
+    filter
+        .prefix
+        .clone()
+        .or_else(|| filter.and.as_ref().and_then(|and| and.prefix.clone()))
+}
+
+fn parse_filter_tags(filter: &LifecycleFilterXml) -> Option<HashMap<String, String>> {
+    let mut tags = HashMap::new();
+    if let Some(tag) = &filter.tag
+        && let (Some(key), Some(value)) = (&tag.key, &tag.value)
+    {
+        tags.insert(key.clone(), value.clone());
+    }
+    if let Some(and) = &filter.and {
+        for tag in &and.tags {
+            if let (Some(key), Some(value)) = (&tag.key, &tag.value) {
+                tags.insert(key.clone(), value.clone());
+            }
+        }
+    }
+    (!tags.is_empty()).then_some(tags)
+}
+
+pub(crate) fn build_lifecycle_configuration_xml(rules: &[LifecycleRule]) -> String {
+    let mut xml =
+        String::from(r#"<?xml version="1.0" encoding="UTF-8"?><LifecycleConfiguration xmlns=""#);
+    xml.push_str(S3_LIFECYCLE_XML_NAMESPACE);
+    xml.push_str(r#"">"#);
+
+    for rule in rules {
+        xml.push_str("<Rule>");
+
+        if !rule.id.is_empty() {
+            append_xml_element(&mut xml, "ID", &rule.id);
+        }
+        append_xml_element(
+            &mut xml,
+            "Status",
+            match rule.status {
+                LifecycleRuleStatus::Enabled => "Enabled",
+                LifecycleRuleStatus::Disabled => "Disabled",
+            },
+        );
+        append_filter_xml(&mut xml, rule.prefix.as_deref(), rule.tags.as_ref());
+        append_expiration_xml(
+            &mut xml,
+            rule.expiration.as_ref(),
+            rule.expired_object_delete_marker,
+        );
+
+        if let Some(transition) = &rule.transition {
+            xml.push_str("<Transition>");
+            append_optional_i32(&mut xml, "Days", transition.days);
+            append_optional_string(&mut xml, "Date", transition.date.as_deref());
+            append_xml_element(&mut xml, "StorageClass", &transition.storage_class);
+            xml.push_str("</Transition>");
+        }
+
+        if let Some(expiration) = &rule.noncurrent_version_expiration {
+            xml.push_str("<NoncurrentVersionExpiration>");
+            append_xml_element(
+                &mut xml,
+                "NoncurrentDays",
+                &expiration.noncurrent_days.to_string(),
+            );
+            append_optional_i32(
+                &mut xml,
+                "NewerNoncurrentVersions",
+                expiration.newer_noncurrent_versions,
+            );
+            xml.push_str("</NoncurrentVersionExpiration>");
+        }
+
+        if let Some(transition) = &rule.noncurrent_version_transition {
+            xml.push_str("<NoncurrentVersionTransition>");
+            append_xml_element(
+                &mut xml,
+                "NoncurrentDays",
+                &transition.noncurrent_days.to_string(),
+            );
+            append_xml_element(&mut xml, "StorageClass", &transition.storage_class);
+            xml.push_str("</NoncurrentVersionTransition>");
+        }
+
+        if let Some(days) = rule.abort_incomplete_multipart_upload_days {
+            xml.push_str("<AbortIncompleteMultipartUpload>");
+            append_xml_element(&mut xml, "DaysAfterInitiation", &days.to_string());
+            xml.push_str("</AbortIncompleteMultipartUpload>");
+        }
+
+        if let Some(expiration) = &rule.del_marker_expiration {
+            xml.push_str("<DelMarkerExpiration>");
+            append_optional_i32(&mut xml, "Days", expiration.days);
+            xml.push_str("</DelMarkerExpiration>");
+        }
+
+        xml.push_str("</Rule>");
+    }
+
+    xml.push_str("</LifecycleConfiguration>");
+    xml
+}
+
+fn append_filter_xml(
+    xml: &mut String,
+    prefix: Option<&str>,
+    tags: Option<&HashMap<String, String>>,
+) {
+    let tags = tags.filter(|tags| !tags.is_empty());
+    match (prefix, tags) {
+        (None, None) => {}
+        (Some(prefix), None) => {
+            xml.push_str("<Filter>");
+            append_xml_element(xml, "Prefix", prefix);
+            xml.push_str("</Filter>");
+        }
+        (None, Some(tags)) if tags.len() == 1 => {
+            xml.push_str("<Filter>");
+            if let Some((key, value)) = sorted_tags(tags).into_iter().next() {
+                append_tag_xml(xml, key, value);
+            }
+            xml.push_str("</Filter>");
+        }
+        (prefix, Some(tags)) => {
+            xml.push_str("<Filter><And>");
+            if let Some(prefix) = prefix {
+                append_xml_element(xml, "Prefix", prefix);
+            }
+            for (key, value) in sorted_tags(tags) {
+                append_tag_xml(xml, key, value);
+            }
+            xml.push_str("</And></Filter>");
+        }
+    }
+}
+
+fn append_expiration_xml(
+    xml: &mut String,
+    expiration: Option<&LifecycleExpiration>,
+    expired_object_delete_marker: Option<bool>,
+) {
+    let marker_enabled = expired_object_delete_marker == Some(true);
+    let Some(expiration) = expiration else {
+        if marker_enabled {
+            xml.push_str("<Expiration>");
+            append_xml_element(xml, "ExpiredObjectDeleteMarker", "true");
+            xml.push_str("</Expiration>");
+        }
+        return;
+    };
+
+    xml.push_str("<Expiration>");
+    append_optional_i32(xml, "Days", expiration.days);
+    append_optional_string(xml, "Date", expiration.date.as_deref());
+    append_optional_bool(
+        xml,
+        "ExpiredObjectAllVersions",
+        expiration.expired_object_all_versions,
+    );
+    if marker_enabled {
+        append_xml_element(xml, "ExpiredObjectDeleteMarker", "true");
+    }
+    xml.push_str("</Expiration>");
+}
+
+fn append_tag_xml(xml: &mut String, key: &str, value: &str) {
+    xml.push_str("<Tag>");
+    append_xml_element(xml, "Key", key);
+    append_xml_element(xml, "Value", value);
+    xml.push_str("</Tag>");
+}
+
+fn append_optional_i32(xml: &mut String, tag: &str, value: Option<i32>) {
+    if let Some(value) = value {
+        append_xml_element(xml, tag, &value.to_string());
+    }
+}
+
+fn append_optional_string(xml: &mut String, tag: &str, value: Option<&str>) {
+    if let Some(value) = value {
+        append_xml_element(xml, tag, value);
+    }
+}
+
+fn append_optional_bool(xml: &mut String, tag: &str, value: Option<bool>) {
+    if let Some(value) = value {
+        append_xml_element(xml, tag, if value { "true" } else { "false" });
+    }
+}
+
+fn append_xml_element(xml: &mut String, tag: &str, value: &str) {
+    xml.push('<');
+    xml.push_str(tag);
+    xml.push('>');
+    xml.push_str(&xml_escape(value));
+    xml.push_str("</");
+    xml.push_str(tag);
+    xml.push('>');
+}
+
+fn sorted_tags(tags: &HashMap<String, String>) -> Vec<(&str, &str)> {
+    let mut pairs: Vec<(&str, &str)> = tags
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    pairs.sort_unstable();
+    pairs
+}
+
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lifecycle_xml_roundtrip_preserves_extension_fields_and_standard_actions() {
+        let mut tags = HashMap::new();
+        tags.insert("env".to_string(), "prod&blue".to_string());
+        let rules = vec![LifecycleRule {
+            id: "rule<&".to_string(),
+            status: LifecycleRuleStatus::Enabled,
+            prefix: Some("logs/".to_string()),
+            tags: Some(tags),
+            expiration: Some(LifecycleExpiration {
+                days: Some(1),
+                date: None,
+                expired_object_all_versions: Some(true),
+            }),
+            del_marker_expiration: Some(LifecycleDelMarkerExpiration { days: Some(2) }),
+            transition: Some(LifecycleTransition {
+                days: Some(30),
+                date: None,
+                storage_class: "WARM<&".to_string(),
+            }),
+            noncurrent_version_expiration: Some(NoncurrentVersionExpiration {
+                noncurrent_days: 3,
+                newer_noncurrent_versions: Some(1),
+            }),
+            noncurrent_version_transition: None,
+            abort_incomplete_multipart_upload_days: Some(4),
+            expired_object_delete_marker: None,
+        }];
+
+        let xml = build_lifecycle_configuration_xml(&rules);
+        assert!(xml.contains("<ExpiredObjectAllVersions>true</ExpiredObjectAllVersions>"));
+        assert!(xml.contains("<DelMarkerExpiration><Days>2</Days></DelMarkerExpiration>"));
+        assert!(xml.contains("rule&lt;&amp;"));
+        assert!(xml.contains("prod&amp;blue"));
+
+        let parsed = parse_lifecycle_configuration_xml(&xml).expect("parse lifecycle XML");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].id, "rule<&");
+        assert_eq!(
+            parsed[0]
+                .expiration
+                .as_ref()
+                .and_then(|expiration| expiration.expired_object_all_versions),
+            Some(true)
+        );
+        assert_eq!(
+            parsed[0]
+                .del_marker_expiration
+                .as_ref()
+                .and_then(|expiration| expiration.days),
+            Some(2)
+        );
+        assert_eq!(
+            parsed[0].tags.as_ref().and_then(|tags| tags.get("env")),
+            Some(&"prod&blue".to_string())
+        );
+    }
+
+    #[test]
+    fn lifecycle_xml_parser_accepts_legacy_prefix_and_marker_expiration() {
+        let xml = r#"
+        <LifecycleConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+          <Rule>
+            <ID>legacy</ID>
+            <Prefix>logs/</Prefix>
+            <Status>Enabled</Status>
+            <Expiration>
+              <Days>1</Days>
+              <ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker>
+            </Expiration>
+          </Rule>
+        </LifecycleConfiguration>
+        "#;
+
+        let rules = parse_lifecycle_configuration_xml(xml).expect("parse legacy lifecycle XML");
+        assert_eq!(rules[0].prefix.as_deref(), Some("logs/"));
+        assert_eq!(rules[0].expired_object_delete_marker, Some(true));
+    }
+}

--- a/crates/s3/src/lifecycle_xml.rs
+++ b/crates/s3/src/lifecycle_xml.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
+use quick_xml::Reader;
 use quick_xml::de::from_str as from_xml_str;
+use quick_xml::events::Event;
 use rc_core::{
     Error, LifecycleDelMarkerExpiration, LifecycleExpiration, LifecycleRule, LifecycleRuleStatus,
     LifecycleTransition, NoncurrentVersionExpiration, NoncurrentVersionTransition, Result,
@@ -40,6 +42,8 @@ struct LifecycleRuleXml {
 struct LifecycleFilterXml {
     prefix: Option<String>,
     tag: Option<LifecycleTagXml>,
+    object_size_greater_than: Option<i64>,
+    object_size_less_than: Option<i64>,
     and: Option<LifecycleAndXml>,
 }
 
@@ -49,6 +53,8 @@ struct LifecycleAndXml {
     prefix: Option<String>,
     #[serde(rename = "Tag", default)]
     tags: Vec<LifecycleTagXml>,
+    object_size_greater_than: Option<i64>,
+    object_size_less_than: Option<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -87,6 +93,7 @@ struct NoncurrentVersionExpirationXml {
 struct NoncurrentVersionTransitionXml {
     noncurrent_days: Option<i32>,
     storage_class: Option<String>,
+    newer_noncurrent_versions: Option<i32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -102,6 +109,7 @@ struct LifecycleDelMarkerExpirationXml {
 }
 
 pub(crate) fn parse_lifecycle_configuration_xml(body: &str) -> Result<Vec<LifecycleRule>> {
+    validate_lifecycle_root(body)?;
     let config: LifecycleConfigurationXml = from_xml_str(body)
         .map_err(|error| Error::General(format!("parse bucket lifecycle xml: {error}")))?;
 
@@ -112,6 +120,16 @@ pub(crate) fn parse_lifecycle_configuration_xml(body: &str) -> Result<Vec<Lifecy
         .collect()
 }
 
+pub(crate) fn validate_lifecycle_configuration_xml_response(body: &str) -> Result<()> {
+    if body.trim().is_empty() {
+        return Ok(());
+    }
+    validate_lifecycle_root(body)?;
+    from_xml_str::<LifecycleConfigurationXml>(body)
+        .map(|_| ())
+        .map_err(|error| Error::General(format!("parse bucket lifecycle xml: {error}")))
+}
+
 fn convert_lifecycle_rule(rule: LifecycleRuleXml) -> Result<LifecycleRule> {
     let prefix = rule
         .filter
@@ -119,6 +137,11 @@ fn convert_lifecycle_rule(rule: LifecycleRuleXml) -> Result<LifecycleRule> {
         .and_then(parse_filter_prefix)
         .or(rule.legacy_prefix);
     let tags = rule.filter.as_ref().and_then(parse_filter_tags);
+    let (object_size_greater_than, object_size_less_than) = rule
+        .filter
+        .as_ref()
+        .map(parse_filter_object_sizes)
+        .unwrap_or((None, None));
 
     let (expiration, expired_object_delete_marker) = match rule.expiration {
         Some(expiration) => (
@@ -134,15 +157,17 @@ fn convert_lifecycle_rule(rule: LifecycleRuleXml) -> Result<LifecycleRule> {
         None => (None, None),
     };
 
-    let transition = rule
+    let transitions = rule
         .transitions
         .into_iter()
-        .next()
         .map(|transition| LifecycleTransition {
             days: transition.days,
             date: transition.date,
             storage_class: transition.storage_class.unwrap_or_default(),
-        });
+        })
+        .collect::<Vec<_>>();
+    let transition = transitions.first().cloned();
+    let additional_transitions = transitions.into_iter().skip(1).collect();
 
     let noncurrent_version_expiration =
         rule.noncurrent_version_expiration
@@ -151,20 +176,26 @@ fn convert_lifecycle_rule(rule: LifecycleRuleXml) -> Result<LifecycleRule> {
                 newer_noncurrent_versions: expiration.newer_noncurrent_versions,
             });
 
-    let noncurrent_version_transition =
-        rule.noncurrent_version_transitions
-            .into_iter()
-            .next()
-            .map(|transition| NoncurrentVersionTransition {
-                noncurrent_days: transition.noncurrent_days.unwrap_or_default(),
-                storage_class: transition.storage_class.unwrap_or_default(),
-            });
+    let noncurrent_version_transitions = rule
+        .noncurrent_version_transitions
+        .into_iter()
+        .map(|transition| NoncurrentVersionTransition {
+            noncurrent_days: transition.noncurrent_days.unwrap_or_default(),
+            storage_class: transition.storage_class.unwrap_or_default(),
+            newer_noncurrent_versions: transition.newer_noncurrent_versions,
+        })
+        .collect::<Vec<_>>();
+    let noncurrent_version_transition = noncurrent_version_transitions.first().cloned();
+    let additional_noncurrent_version_transitions =
+        noncurrent_version_transitions.into_iter().skip(1).collect();
 
     Ok(LifecycleRule {
         id: rule.id.unwrap_or_default(),
         status: parse_rule_status(rule.status.as_deref()),
         prefix,
         tags,
+        object_size_greater_than,
+        object_size_less_than,
         expiration,
         del_marker_expiration: rule.del_marker_expiration.map(|expiration| {
             LifecycleDelMarkerExpiration {
@@ -172,13 +203,46 @@ fn convert_lifecycle_rule(rule: LifecycleRuleXml) -> Result<LifecycleRule> {
             }
         }),
         transition,
+        transitions: additional_transitions,
         noncurrent_version_expiration,
         noncurrent_version_transition,
+        noncurrent_version_transitions: additional_noncurrent_version_transitions,
         abort_incomplete_multipart_upload_days: rule
             .abort_incomplete_multipart_upload
             .and_then(|upload| upload.days_after_initiation),
         expired_object_delete_marker,
     })
+}
+
+fn validate_lifecycle_root(body: &str) -> Result<()> {
+    let mut reader = Reader::from_str(body);
+    reader.config_mut().trim_text(true);
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) | Ok(Event::Empty(element)) => {
+                let root = element.local_name();
+                if root.as_ref() == b"LifecycleConfiguration" {
+                    return Ok(());
+                }
+                return Err(Error::General(format!(
+                    "unexpected lifecycle root '{}', expected 'LifecycleConfiguration'",
+                    String::from_utf8_lossy(root.as_ref())
+                )));
+            }
+            Ok(Event::Eof) => {
+                return Err(Error::General(
+                    "parse bucket lifecycle xml: missing root element".to_string(),
+                ));
+            }
+            Ok(_) => {}
+            Err(error) => {
+                return Err(Error::General(format!(
+                    "parse bucket lifecycle xml: {error}"
+                )));
+            }
+        }
+    }
 }
 
 fn parse_rule_status(status: Option<&str>) -> LifecycleRuleStatus {
@@ -212,6 +276,23 @@ fn parse_filter_tags(filter: &LifecycleFilterXml) -> Option<HashMap<String, Stri
     (!tags.is_empty()).then_some(tags)
 }
 
+fn parse_filter_object_sizes(filter: &LifecycleFilterXml) -> (Option<i64>, Option<i64>) {
+    (
+        filter.object_size_greater_than.or_else(|| {
+            filter
+                .and
+                .as_ref()
+                .and_then(|and| and.object_size_greater_than)
+        }),
+        filter.object_size_less_than.or_else(|| {
+            filter
+                .and
+                .as_ref()
+                .and_then(|and| and.object_size_less_than)
+        }),
+    )
+}
+
 pub(crate) fn build_lifecycle_configuration_xml(rules: &[LifecycleRule]) -> String {
     let mut xml =
         String::from(r#"<?xml version="1.0" encoding="UTF-8"?><LifecycleConfiguration xmlns=""#);
@@ -232,19 +313,22 @@ pub(crate) fn build_lifecycle_configuration_xml(rules: &[LifecycleRule]) -> Stri
                 LifecycleRuleStatus::Disabled => "Disabled",
             },
         );
-        append_filter_xml(&mut xml, rule.prefix.as_deref(), rule.tags.as_ref());
+        append_filter_xml(
+            &mut xml,
+            rule.prefix.as_deref(),
+            rule.tags.as_ref(),
+            rule.object_size_greater_than,
+            rule.object_size_less_than,
+        );
         append_expiration_xml(
             &mut xml,
             rule.expiration.as_ref(),
             rule.expired_object_delete_marker,
         );
 
-        if let Some(transition) = &rule.transition {
-            xml.push_str("<Transition>");
-            append_optional_i32(&mut xml, "Days", transition.days);
-            append_optional_string(&mut xml, "Date", transition.date.as_deref());
-            append_xml_element(&mut xml, "StorageClass", &transition.storage_class);
-            xml.push_str("</Transition>");
+        append_transition_xml(&mut xml, rule.transition.as_ref());
+        for transition in &rule.transitions {
+            append_transition_xml(&mut xml, Some(transition));
         }
 
         if let Some(expiration) = &rule.noncurrent_version_expiration {
@@ -262,15 +346,12 @@ pub(crate) fn build_lifecycle_configuration_xml(rules: &[LifecycleRule]) -> Stri
             xml.push_str("</NoncurrentVersionExpiration>");
         }
 
-        if let Some(transition) = &rule.noncurrent_version_transition {
-            xml.push_str("<NoncurrentVersionTransition>");
-            append_xml_element(
-                &mut xml,
-                "NoncurrentDays",
-                &transition.noncurrent_days.to_string(),
-            );
-            append_xml_element(&mut xml, "StorageClass", &transition.storage_class);
-            xml.push_str("</NoncurrentVersionTransition>");
+        append_noncurrent_version_transition_xml(
+            &mut xml,
+            rule.noncurrent_version_transition.as_ref(),
+        );
+        for transition in &rule.noncurrent_version_transitions {
+            append_noncurrent_version_transition_xml(&mut xml, Some(transition));
         }
 
         if let Some(days) = rule.abort_incomplete_multipart_upload_days {
@@ -296,33 +377,84 @@ fn append_filter_xml(
     xml: &mut String,
     prefix: Option<&str>,
     tags: Option<&HashMap<String, String>>,
+    object_size_greater_than: Option<i64>,
+    object_size_less_than: Option<i64>,
 ) {
     let tags = tags.filter(|tags| !tags.is_empty());
-    match (prefix, tags) {
-        (None, None) => {}
-        (Some(prefix), None) => {
-            xml.push_str("<Filter>");
+    let tag_count = tags.map_or(0, HashMap::len);
+    let predicate_count = usize::from(prefix.is_some())
+        + tag_count
+        + usize::from(object_size_greater_than.is_some())
+        + usize::from(object_size_less_than.is_some());
+    if predicate_count == 0 {
+        return;
+    }
+
+    xml.push_str("<Filter>");
+    if predicate_count == 1 {
+        if let Some(prefix) = prefix {
             append_xml_element(xml, "Prefix", prefix);
-            xml.push_str("</Filter>");
-        }
-        (None, Some(tags)) if tags.len() == 1 => {
-            xml.push_str("<Filter>");
+        } else if let Some(tags) = tags {
             if let Some((key, value)) = sorted_tags(tags).into_iter().next() {
                 append_tag_xml(xml, key, value);
             }
-            xml.push_str("</Filter>");
+        } else if let Some(value) = object_size_greater_than {
+            append_xml_element(xml, "ObjectSizeGreaterThan", &value.to_string());
+        } else if let Some(value) = object_size_less_than {
+            append_xml_element(xml, "ObjectSizeLessThan", &value.to_string());
         }
-        (prefix, Some(tags)) => {
-            xml.push_str("<Filter><And>");
-            if let Some(prefix) = prefix {
-                append_xml_element(xml, "Prefix", prefix);
-            }
+    } else {
+        xml.push_str("<And>");
+        if let Some(prefix) = prefix {
+            append_xml_element(xml, "Prefix", prefix);
+        }
+        if let Some(tags) = tags {
             for (key, value) in sorted_tags(tags) {
                 append_tag_xml(xml, key, value);
             }
-            xml.push_str("</And></Filter>");
         }
+        if let Some(value) = object_size_greater_than {
+            append_xml_element(xml, "ObjectSizeGreaterThan", &value.to_string());
+        }
+        if let Some(value) = object_size_less_than {
+            append_xml_element(xml, "ObjectSizeLessThan", &value.to_string());
+        }
+        xml.push_str("</And>");
     }
+    xml.push_str("</Filter>");
+}
+
+fn append_transition_xml(xml: &mut String, transition: Option<&LifecycleTransition>) {
+    let Some(transition) = transition else {
+        return;
+    };
+    xml.push_str("<Transition>");
+    append_optional_i32(xml, "Days", transition.days);
+    append_optional_string(xml, "Date", transition.date.as_deref());
+    append_xml_element(xml, "StorageClass", &transition.storage_class);
+    xml.push_str("</Transition>");
+}
+
+fn append_noncurrent_version_transition_xml(
+    xml: &mut String,
+    transition: Option<&NoncurrentVersionTransition>,
+) {
+    let Some(transition) = transition else {
+        return;
+    };
+    xml.push_str("<NoncurrentVersionTransition>");
+    append_xml_element(
+        xml,
+        "NoncurrentDays",
+        &transition.noncurrent_days.to_string(),
+    );
+    append_xml_element(xml, "StorageClass", &transition.storage_class);
+    append_optional_i32(
+        xml,
+        "NewerNoncurrentVersions",
+        transition.newer_noncurrent_versions,
+    );
+    xml.push_str("</NoncurrentVersionTransition>");
 }
 
 fn append_expiration_xml(
@@ -420,6 +552,8 @@ mod tests {
             status: LifecycleRuleStatus::Enabled,
             prefix: Some("logs/".to_string()),
             tags: Some(tags),
+            object_size_greater_than: None,
+            object_size_less_than: None,
             expiration: Some(LifecycleExpiration {
                 days: Some(1),
                 date: None,
@@ -436,6 +570,8 @@ mod tests {
                 newer_noncurrent_versions: Some(1),
             }),
             noncurrent_version_transition: None,
+            transitions: Vec::new(),
+            noncurrent_version_transitions: Vec::new(),
             abort_incomplete_multipart_upload_days: Some(4),
             expired_object_delete_marker: None,
         }];
@@ -488,5 +624,112 @@ mod tests {
         let rules = parse_lifecycle_configuration_xml(xml).expect("parse legacy lifecycle XML");
         assert_eq!(rules[0].prefix.as_deref(), Some("logs/"));
         assert_eq!(rules[0].expired_object_delete_marker, Some(true));
+    }
+
+    #[test]
+    fn lifecycle_xml_parser_rejects_error_and_unexpected_roots() {
+        for xml in [
+            "<Error><Code>InternalError</Code></Error>",
+            "<Unexpected><Rule /></Unexpected>",
+        ] {
+            let result = parse_lifecycle_configuration_xml(xml);
+            assert!(
+                matches!(result, Err(Error::General(message)) if message.contains("unexpected lifecycle root")),
+                "unexpected root should fail with a root-validation error: {xml}"
+            );
+        }
+    }
+
+    #[test]
+    fn lifecycle_xml_response_validator_rejects_malformed_success_body() {
+        assert!(
+            validate_lifecycle_configuration_xml_response("<LifecycleConfiguration><Rule>")
+                .is_err()
+        );
+        assert!(
+            validate_lifecycle_configuration_xml_response("<LifecycleConfiguration />").is_ok()
+        );
+        assert!(validate_lifecycle_configuration_xml_response(" ").is_ok());
+    }
+
+    #[test]
+    fn lifecycle_xml_roundtrip_preserves_size_filters_and_all_actions() {
+        let rules = vec![LifecycleRule {
+            id: "full-rule".to_string(),
+            status: LifecycleRuleStatus::Enabled,
+            prefix: Some("logs/".to_string()),
+            tags: None,
+            object_size_greater_than: Some(500),
+            object_size_less_than: Some(64000),
+            expiration: None,
+            del_marker_expiration: None,
+            transition: Some(LifecycleTransition {
+                days: Some(30),
+                date: None,
+                storage_class: "WARM".to_string(),
+            }),
+            transitions: vec![LifecycleTransition {
+                days: Some(60),
+                date: None,
+                storage_class: "COLD".to_string(),
+            }],
+            noncurrent_version_expiration: Some(NoncurrentVersionExpiration {
+                noncurrent_days: 90,
+                newer_noncurrent_versions: Some(2),
+            }),
+            noncurrent_version_transition: Some(NoncurrentVersionTransition {
+                noncurrent_days: 90,
+                storage_class: "WARM".to_string(),
+                newer_noncurrent_versions: Some(2),
+            }),
+            noncurrent_version_transitions: vec![NoncurrentVersionTransition {
+                noncurrent_days: 180,
+                storage_class: "COLD".to_string(),
+                newer_noncurrent_versions: Some(1),
+            }],
+            abort_incomplete_multipart_upload_days: None,
+            expired_object_delete_marker: None,
+        }];
+
+        let xml = build_lifecycle_configuration_xml(&rules);
+        assert!(xml.contains("<ObjectSizeGreaterThan>500</ObjectSizeGreaterThan>"));
+        assert!(xml.contains("<ObjectSizeLessThan>64000</ObjectSizeLessThan>"));
+        assert_eq!(xml.matches("<Transition>").count(), 2);
+        assert_eq!(xml.matches("<NoncurrentVersionTransition>").count(), 2);
+        assert!(xml.contains("<NewerNoncurrentVersions>2</NewerNoncurrentVersions>"));
+        assert!(xml.contains("<NewerNoncurrentVersions>1</NewerNoncurrentVersions>"));
+
+        let parsed = parse_lifecycle_configuration_xml(&xml).expect("parse full lifecycle XML");
+        let rule = &parsed[0];
+        assert_eq!(rule.object_size_greater_than, Some(500));
+        assert_eq!(rule.object_size_less_than, Some(64000));
+        assert_eq!(rule.transitions.len(), 1);
+        assert_eq!(rule.noncurrent_version_transitions.len(), 1);
+        assert_eq!(
+            rule.noncurrent_version_transition
+                .as_ref()
+                .and_then(|transition| transition.newer_noncurrent_versions),
+            Some(2)
+        );
+        assert_eq!(
+            rule.noncurrent_version_transitions[0].newer_noncurrent_versions,
+            Some(1)
+        );
+
+        let mut direct_filter = String::new();
+        append_filter_xml(&mut direct_filter, None, None, Some(7), None);
+        assert_eq!(
+            direct_filter,
+            "<Filter><ObjectSizeGreaterThan>7</ObjectSizeGreaterThan></Filter>"
+        );
+        let direct_xml = format!(
+            "<LifecycleConfiguration><Rule><ID>direct-size</ID><Status>Enabled</Status>{direct_filter}</Rule></LifecycleConfiguration>"
+        );
+        let direct_rule = parse_lifecycle_configuration_xml(&direct_xml)
+            .expect("direct size filter should parse")
+            .into_iter()
+            .next()
+            .expect("direct size rule should be present");
+        assert_eq!(direct_rule.object_size_greater_than, Some(7));
     }
 }


### PR DESCRIPTION
## Related Issues

Addresses rustfs/rustfs#6334, where `rc bucket lifecycle rule import` accepts MinIO-compatible lifecycle extensions but a subsequent export drops them.

## Summary of Changes

- Extend the core lifecycle model and XML codec to preserve `ExpiredObjectAllVersions`, `DelMarkerExpiration`, object-size predicates, repeated current/noncurrent transitions, and `NewerNoncurrentVersions`.
- Reject contradictory compatibility representations, including explicit `DelMarkerExpiration: false` combined with an enabled form.
- Validate lifecycle XML roots and successful response bodies so 2xx S3 `<Error>` envelopes cannot be treated as empty configurations.
- Add bounded alias-configured retries for lifecycle GET/PUT, 301/307/308 endpoint redirect handling, region refresh from `x-amz-bucket-region`, and fresh SigV4 signing for every request.
- Keep existing CLI read-modify-write operations lossless for extended lifecycle rules.

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `make pre-commit` (workspace formatting, Clippy, tests, and doctests)
- `CARGO_BUILD_JOBS=2 cargo test -p rc-core --lib lifecycle::tests --no-fail-fast`
- `CARGO_BUILD_JOBS=2 cargo test -p rc-s3 --lib lifecycle --no-fail-fast`
- `CARGO_BUILD_JOBS=2 cargo test -p rustfs-cli --lib lifecycle --no-fail-fast`
- Manual import/export verification against the previously built RustFS main binary at commit `017ffb92f`; the fixed client preserves both lifecycle extensions.

### Adversarial review verdicts

- Correctness: PASS — success envelopes, filter predicates, action multiplicity, and compatibility conflicts are validated or preserved.
- Test coverage: PASS — focused regressions cover each review finding plus retry, dropped connections, redirects, and XML round-trips; workspace tests pass.
- Compatibility: PASS — legacy prefix/JSON shapes remain accepted; additive fields preserve newer S3/RustFS configurations.
- Security: PASS — XML roots are validated; redirects reject userinfo, HTTPS downgrade, untrusted hosts, and port changes; cross-authority custom x-amz headers are not forwarded.
- Concurrency / durability: PASS — PUT retries replay the exact idempotent body and re-sign each attempt; no partial local state is committed.
- Performance: PASS — lifecycle payloads are bounded configuration XML; retry/redirect loops are bounded and XML parsing overhead is linear.
- Simplicity: PASS — transport concerns are isolated in `lifecycle_xml_request`/`xml_request_once`; no unrelated paths changed.

## Impact

- Lifecycle import, export, list, and update now round-trip RustFS/MinIO delete-all and delete-marker expiration semantics, object-size filters, and all standard S3 lifecycle actions without loss.
- Existing standard S3 filters/actions remain supported.
- No RustFS server code, S3 object data, or output schema files are changed.

## Risks / Rollback

- Lifecycle GET/PUT uses a small raw XML path because the AWS SDK model does not expose the RustFS/MinIO extensions; requests remain SigV4-signed, Content-MD5 protected for PUT, and path/DNS-style aware.
- Redirect targets are restricted to the configured host or recognized S3 provider domains; custom x-amz headers are intentionally withheld across provider authority changes to avoid leaking credential-bearing values.
- Rollback is a normal client rollback by reverting the new commit; no server-side migration is required.
