### PR TITLE
fix(ci): stabilize macOS versioned-object mock

### DIFF
--- a/crates/cli/tests/versioned_objects.rs
+++ b/crates/cli/tests/versioned_objects.rs
@@ -63,6 +63,10 @@ impl TestServer {
             while !thread_stop.load(Ordering::SeqCst) {
                 match listener.accept() {
                     Ok((mut stream, _)) => {
+                        // Accepted sockets can inherit nonblocking mode on some platforms.
+                        stream
+                            .set_nonblocking(false)
+                            .expect("set accepted stream blocking");
                         if let Some(request) = read_request(&mut stream) {
                             let response = response_for(mode, &request);
                             thread_requests


### PR DESCRIPTION
## Summary

- Fix the macOS-only flake in the versioned object integration test mock.
- Restore accepted TCP streams to blocking mode before reading requests.

## Root cause

The mock listener is nonblocking so its shutdown loop can poll. On macOS, accepted sockets can inherit nonblocking mode. `read_request` then returned on `WouldBlock` and closed the connection, causing the governance-denial case to surface as network exit code 3 instead of conflict exit code 6.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

This addresses the failure in [CI run 32805753693](https://github.com/rustfs/cli/actions/runs/32805753693).