### PR TITLE
fix(ilm): reject unknown import fields and accept S3-shaped rule JSON

### DIFF
--- a/crates/cli/src/commands/admin/bucket.rs
+++ b/crates/cli/src/commands/admin/bucket.rs
@@ -216,7 +216,7 @@ pub struct SetArgs {
     /// Source vendor family; drives addressing defaults
     #[arg(long, value_enum)]
     pub provider: ProviderArg,
-    /// Source endpoint as scheme://host[:port]; derived from --region for aws
+    /// Source endpoint as scheme://host\[:port\]; derived from --region for aws
     #[arg(long, value_name = "URL")]
     pub endpoint: Option<String>,
     /// Source signing region; 'auto' is accepted for r2, minio and rustfs

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LifecycleConfiguration {
     /// Lifecycle rules
+    #[serde(alias = "Rules")]
     pub rules: Vec<LifecycleRule>,
 }
 
@@ -91,7 +92,7 @@ pub struct LifecycleRule {
 }
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LifecycleRuleInput {
     #[serde(alias = "ID")]
     id: String,
@@ -109,6 +110,9 @@ struct LifecycleRuleInput {
     object_size_greater_than: Option<i64>,
     #[serde(default, alias = "ObjectSizeLessThan", alias = "object_size_less_than")]
     object_size_less_than: Option<i64>,
+    /// S3-shaped nested filter (`Filter.Prefix` / `Filter.Tag` / `Filter.And`).
+    #[serde(default, alias = "Filter")]
+    filter: Option<LifecycleFilterInput>,
     #[serde(default, alias = "Expiration")]
     expiration: Option<LifecycleExpirationInput>,
     #[serde(default, alias = "Transition")]
@@ -121,14 +125,27 @@ struct LifecycleRuleInput {
     noncurrent_version_transition: Option<NoncurrentVersionTransition>,
     #[serde(default, alias = "NoncurrentVersionTransitions")]
     noncurrent_version_transitions: Vec<NoncurrentVersionTransition>,
-    #[serde(default, alias = "AbortIncompleteMultipartUploadDays")]
+    #[serde(
+        default,
+        alias = "AbortIncompleteMultipartUploadDays",
+        alias = "abort_incomplete_multipart_upload_days"
+    )]
     abort_incomplete_multipart_upload_days: Option<i32>,
+    /// S3-shaped nested abort action (`AbortIncompleteMultipartUpload.DaysAfterInitiation`).
+    #[serde(
+        default,
+        alias = "AbortIncompleteMultipartUpload",
+        alias = "abort_incomplete_multipart_upload"
+    )]
+    abort_incomplete_multipart_upload: Option<AbortIncompleteMultipartUploadInput>,
+
     #[serde(
         default,
         alias = "ExpiredObjectDeleteMarker",
         alias = "expired_object_delete_marker"
     )]
     expired_object_delete_marker: Option<bool>,
+
     #[serde(
         default,
         alias = "DelMarkerExpiration",
@@ -137,8 +154,62 @@ struct LifecycleRuleInput {
     del_marker_expiration: Option<LifecycleDelMarkerInput>,
 }
 
+/// S3 `Filter` predicate: `Prefix`, a single `Tag`, or an `And` combination.
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LifecycleFilterInput {
+    #[serde(default, alias = "Prefix")]
+    prefix: Option<String>,
+    #[serde(default, alias = "Tag")]
+    tag: Option<LifecycleTagInput>,
+    #[serde(default, alias = "And")]
+    and: Option<LifecycleFilterAndInput>,
+}
+
+/// S3 `Filter.And` combination of prefix, tags, and object-size bounds.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LifecycleFilterAndInput {
+    #[serde(default, alias = "Prefix")]
+    prefix: Option<String>,
+    #[serde(default, alias = "Tag")]
+    tag: Option<LifecycleTagInput>,
+    #[serde(default, alias = "Tags")]
+    tags: Option<Vec<LifecycleTagInput>>,
+    #[serde(
+        default,
+        alias = "ObjectSizeGreaterThan",
+        alias = "object_size_greater_than"
+    )]
+    object_size_greater_than: Option<i64>,
+    #[serde(default, alias = "ObjectSizeLessThan", alias = "object_size_less_than")]
+    object_size_less_than: Option<i64>,
+}
+
+/// A single S3 tag predicate.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct LifecycleTagInput {
+    #[serde(alias = "Key")]
+    key: String,
+    #[serde(alias = "Value")]
+    value: String,
+}
+
+/// S3-shaped `AbortIncompleteMultipartUpload` action.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct AbortIncompleteMultipartUploadInput {
+    #[serde(
+        default,
+        alias = "DaysAfterInitiation",
+        alias = "days_after_initiation"
+    )]
+    days_after_initiation: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LifecycleExpirationInput {
     #[serde(default, alias = "Days")]
     days: Option<i32>,
@@ -156,6 +227,12 @@ struct LifecycleExpirationInput {
         alias = "del_marker_expiration"
     )]
     del_marker_expiration: Option<LifecycleDelMarkerInput>,
+    #[serde(
+        default,
+        alias = "ExpiredObjectDeleteMarker",
+        alias = "expired_object_delete_marker"
+    )]
+    expired_object_delete_marker: Option<bool>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -183,6 +260,7 @@ impl<'de> Deserialize<'de> for LifecycleRule {
             tags,
             object_size_greater_than,
             object_size_less_than,
+            filter,
             expiration: expiration_input,
             transition,
             transitions: mut transitions_input,
@@ -190,9 +268,47 @@ impl<'de> Deserialize<'de> for LifecycleRule {
             noncurrent_version_transition,
             noncurrent_version_transitions: mut noncurrent_version_transitions_input,
             abort_incomplete_multipart_upload_days,
+            abort_incomplete_multipart_upload,
             expired_object_delete_marker,
             del_marker_expiration: top_level_del_marker_input,
         } = LifecycleRuleInput::deserialize(deserializer)?;
+
+        let filter_fields = resolve_filter_fields(filter).map_err(D::Error::custom)?;
+        let prefix = merge_exclusive(prefix, filter_fields.prefix, "prefix", "Filter.Prefix")
+            .map_err(D::Error::custom)?;
+        let tags = merge_exclusive(tags, filter_fields.tags, "tags", "Filter tags")
+            .map_err(D::Error::custom)?;
+        let object_size_greater_than = merge_exclusive(
+            object_size_greater_than,
+            filter_fields.object_size_greater_than,
+            "objectSizeGreaterThan",
+            "Filter.And.ObjectSizeGreaterThan",
+        )
+        .map_err(D::Error::custom)?;
+        let object_size_less_than = merge_exclusive(
+            object_size_less_than,
+            filter_fields.object_size_less_than,
+            "objectSizeLessThan",
+            "Filter.And.ObjectSizeLessThan",
+        )
+        .map_err(D::Error::custom)?;
+
+        let nested_expired_object_delete_marker = expiration_input
+            .as_ref()
+            .and_then(|expiration| expiration.expired_object_delete_marker);
+        let expired_object_delete_marker = merge_equal_optional(
+            expired_object_delete_marker,
+            nested_expired_object_delete_marker,
+            "expiredObjectDeleteMarker",
+        )
+        .map_err(D::Error::custom)?;
+
+        let abort_incomplete_multipart_upload_days = merge_equal_optional(
+            abort_incomplete_multipart_upload_days,
+            abort_incomplete_multipart_upload.and_then(|action| action.days_after_initiation),
+            "abortIncompleteMultipartUploadDays",
+        )
+        .map_err(D::Error::custom)?;
 
         let (expiration, nested_del_marker) = match expiration_input {
             Some(expiration) => {
@@ -251,6 +367,96 @@ impl<'de> Deserialize<'de> for LifecycleRule {
             abort_incomplete_multipart_upload_days,
             expired_object_delete_marker,
         })
+    }
+}
+
+/// Filter predicates resolved from an S3-shaped `Filter` object.
+#[derive(Default)]
+struct FilterFields {
+    prefix: Option<String>,
+    tags: Option<HashMap<String, String>>,
+    object_size_greater_than: Option<i64>,
+    object_size_less_than: Option<i64>,
+}
+
+/// Flatten an S3 `Filter` (one of `Prefix`, `Tag`, `And`) into rc's flat fields.
+///
+/// An empty `Filter` object stays valid: the server documents it as "applies to
+/// every object in the bucket".
+fn resolve_filter_fields(
+    filter: Option<LifecycleFilterInput>,
+) -> std::result::Result<FilterFields, String> {
+    let Some(filter) = filter else {
+        return Ok(FilterFields::default());
+    };
+    let predicate_count = usize::from(filter.prefix.is_some())
+        + usize::from(filter.tag.is_some())
+        + usize::from(filter.and.is_some());
+    if predicate_count > 1 {
+        return Err("S3 Filter allows exactly one of Prefix, Tag, or And".to_string());
+    }
+    if let Some(and) = filter.and {
+        let mut tags = HashMap::new();
+        if let Some(tag) = and.tag {
+            tags.insert(tag.key, tag.value);
+        }
+        if let Some(tag_list) = and.tags {
+            for tag in tag_list {
+                if tags.insert(tag.key.clone(), tag.value).is_some() {
+                    let key = tag.key;
+                    return Err(format!("duplicate tag key in Filter.And: {key}"));
+                }
+            }
+        }
+        return Ok(FilterFields {
+            prefix: and.prefix,
+            tags: if tags.is_empty() { None } else { Some(tags) },
+            object_size_greater_than: and.object_size_greater_than,
+            object_size_less_than: and.object_size_less_than,
+        });
+    }
+    if let Some(prefix) = filter.prefix {
+        return Ok(FilterFields {
+            prefix: Some(prefix),
+            ..FilterFields::default()
+        });
+    }
+    if let Some(tag) = filter.tag {
+        return Ok(FilterFields {
+            tags: Some(HashMap::from([(tag.key, tag.value)])),
+            ..FilterFields::default()
+        });
+    }
+    Ok(FilterFields::default())
+}
+
+/// Combine a flat field with its nested equivalent; both set at once is ambiguous.
+fn merge_exclusive<T>(
+    flat: Option<T>,
+    nested: Option<T>,
+    flat_name: &str,
+    nested_name: &str,
+) -> std::result::Result<Option<T>, String> {
+    match (flat, nested) {
+        (Some(_), Some(_)) => Err(format!(
+            "lifecycle rule sets both {flat_name} and {nested_name}; specify one"
+        )),
+        (value, None) | (None, value) => Ok(value),
+    }
+}
+
+/// Combine two optional spellings of the same value; equal duplicates are fine.
+fn merge_equal_optional<T: PartialEq>(
+    primary: Option<T>,
+    secondary: Option<T>,
+    field_name: &str,
+) -> std::result::Result<Option<T>, String> {
+    match (primary, secondary) {
+        (Some(primary_value), Some(secondary_value)) if primary_value != secondary_value => {
+            Err(format!("conflicting {field_name} values in lifecycle rule"))
+        }
+        (value, None) | (None, value) => Ok(value),
+        (Some(value), Some(_)) => Ok(Some(value)),
     }
 }
 

--- a/crates/core/src/lifecycle.rs
+++ b/crates/core/src/lifecycle.rs
@@ -154,7 +154,8 @@ struct LifecycleRuleInput {
     del_marker_expiration: Option<LifecycleDelMarkerInput>,
 }
 
-/// S3 `Filter` predicate: `Prefix`, a single `Tag`, or an `And` combination.
+/// S3 `Filter` predicate: `Prefix`, a single `Tag`, an `And` combination, or a
+/// standalone object-size bound.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct LifecycleFilterInput {
@@ -164,6 +165,14 @@ struct LifecycleFilterInput {
     tag: Option<LifecycleTagInput>,
     #[serde(default, alias = "And")]
     and: Option<LifecycleFilterAndInput>,
+    #[serde(
+        default,
+        alias = "ObjectSizeGreaterThan",
+        alias = "object_size_greater_than"
+    )]
+    object_size_greater_than: Option<i64>,
+    #[serde(default, alias = "ObjectSizeLessThan", alias = "object_size_less_than")]
+    object_size_less_than: Option<i64>,
 }
 
 /// S3 `Filter.And` combination of prefix, tags, and object-size bounds.
@@ -282,14 +291,14 @@ impl<'de> Deserialize<'de> for LifecycleRule {
             object_size_greater_than,
             filter_fields.object_size_greater_than,
             "objectSizeGreaterThan",
-            "Filter.And.ObjectSizeGreaterThan",
+            "Filter.ObjectSizeGreaterThan",
         )
         .map_err(D::Error::custom)?;
         let object_size_less_than = merge_exclusive(
             object_size_less_than,
             filter_fields.object_size_less_than,
             "objectSizeLessThan",
-            "Filter.And.ObjectSizeLessThan",
+            "Filter.ObjectSizeLessThan",
         )
         .map_err(D::Error::custom)?;
 
@@ -379,7 +388,8 @@ struct FilterFields {
     object_size_less_than: Option<i64>,
 }
 
-/// Flatten an S3 `Filter` (one of `Prefix`, `Tag`, `And`) into rc's flat fields.
+/// Flatten an S3 `Filter` (one of `Prefix`, `Tag`, `And`, or a standalone
+/// object-size bound) into rc's flat fields.
 ///
 /// An empty `Filter` object stays valid: the server documents it as "applies to
 /// every object in the bucket".
@@ -391,9 +401,14 @@ fn resolve_filter_fields(
     };
     let predicate_count = usize::from(filter.prefix.is_some())
         + usize::from(filter.tag.is_some())
-        + usize::from(filter.and.is_some());
+        + usize::from(filter.and.is_some())
+        + usize::from(filter.object_size_greater_than.is_some())
+        + usize::from(filter.object_size_less_than.is_some());
     if predicate_count > 1 {
-        return Err("S3 Filter allows exactly one of Prefix, Tag, or And".to_string());
+        return Err(
+            "S3 Filter allows exactly one of Prefix, Tag, And, ObjectSizeGreaterThan, or ObjectSizeLessThan"
+                .to_string(),
+        );
     }
     if let Some(and) = filter.and {
         let mut tags = HashMap::new();
@@ -424,6 +439,13 @@ fn resolve_filter_fields(
     if let Some(tag) = filter.tag {
         return Ok(FilterFields {
             tags: Some(HashMap::from([(tag.key, tag.value)])),
+            ..FilterFields::default()
+        });
+    }
+    if filter.object_size_greater_than.is_some() || filter.object_size_less_than.is_some() {
+        return Ok(FilterFields {
+            object_size_greater_than: filter.object_size_greater_than,
+            object_size_less_than: filter.object_size_less_than,
             ..FilterFields::default()
         });
     }

--- a/crates/core/tests/lifecycle_import_dialect.rs
+++ b/crates/core/tests/lifecycle_import_dialect.rs
@@ -1,0 +1,137 @@
+//! `rc ilm rule import` JSON dialect tests.
+//!
+//! Import accepts the rc camelCase dialect plus the common alternative
+//! spellings people paste (snake_case, S3/PascalCase, and the S3 JSON shape
+//! with a nested `filter`/`abortIncompleteMultipartUpload`). Unknown rule
+//! fields are rejected instead of silently dropped: a dropped action field
+//! used to import a degraded rule that the server then refused with a
+//! confusing "rule must have an action" error.
+
+use rc_core::lifecycle::LifecycleConfiguration;
+
+fn parse(json: &str) -> LifecycleConfiguration {
+    serde_json::from_str(json).expect("lifecycle import should parse")
+}
+
+fn parse_error(json: &str) -> String {
+    serde_json::from_str::<LifecycleConfiguration>(json)
+        .expect_err("lifecycle import should fail")
+        .to_string()
+}
+
+#[test]
+fn camel_case_flat_dialect_round_trips() {
+    let config = parse(
+        r#"{"rules":[{"id":"r","status":"Enabled","prefix":"v1/","abortIncompleteMultipartUploadDays":1}]}"#,
+    );
+    assert_eq!(config.rules[0].prefix.as_deref(), Some("v1/"));
+    assert_eq!(
+        config.rules[0].abort_incomplete_multipart_upload_days,
+        Some(1)
+    );
+}
+
+#[test]
+fn snake_case_flat_dialect_is_accepted() {
+    let config = parse(
+        r#"{"rules":[{"id":"r","status":"Enabled","prefix":"v1/","abort_incomplete_multipart_upload_days":1}]}"#,
+    );
+    assert_eq!(config.rules[0].prefix.as_deref(), Some("v1/"));
+    assert_eq!(
+        config.rules[0].abort_incomplete_multipart_upload_days,
+        Some(1)
+    );
+}
+
+#[test]
+fn pascal_case_flat_dialect_is_accepted() {
+    let config = parse(
+        r#"{"Rules":[{"ID":"r","Status":"Enabled","Prefix":"v1/","AbortIncompleteMultipartUploadDays":1}]}"#,
+    );
+    assert_eq!(config.rules[0].prefix.as_deref(), Some("v1/"));
+    assert_eq!(
+        config.rules[0].abort_incomplete_multipart_upload_days,
+        Some(1)
+    );
+}
+
+#[test]
+fn s3_shaped_filter_and_abort_action_are_accepted() {
+    let config = parse(
+        r#"{"rules":[{"id":"r","status":"Enabled","filter":{"prefix":"v1/"},"abortIncompleteMultipartUpload":{"daysAfterInitiation":2}}]}"#,
+    );
+    assert_eq!(config.rules[0].prefix.as_deref(), Some("v1/"));
+    assert_eq!(
+        config.rules[0].abort_incomplete_multipart_upload_days,
+        Some(2)
+    );
+}
+
+#[test]
+fn s3_filter_and_combination_is_flattened() {
+    let config = parse(
+        r#"{"rules":[{"id":"r","status":"Enabled","filter":{"And":{"Prefix":"logs/","Tags":[{"Key":"env","Value":"prod"}],"ObjectSizeGreaterThan":100,"ObjectSizeLessThan":1000}}}]}"#,
+    );
+    assert_eq!(config.rules[0].prefix.as_deref(), Some("logs/"));
+    assert_eq!(
+        config.rules[0]
+            .tags
+            .as_ref()
+            .and_then(|tags| tags.get("env")),
+        Some(&"prod".to_string())
+    );
+    assert_eq!(config.rules[0].object_size_greater_than, Some(100));
+    assert_eq!(config.rules[0].object_size_less_than, Some(1000));
+}
+
+#[test]
+fn nested_expired_object_delete_marker_is_accepted() {
+    let config = parse(
+        r#"{"rules":[{"id":"r","status":"Enabled","expiration":{"ExpiredObjectDeleteMarker":true}}]}"#,
+    );
+    assert_eq!(config.rules[0].expired_object_delete_marker, Some(true));
+}
+
+#[test]
+fn unknown_rule_field_is_rejected_instead_of_dropped() {
+    let error = parse_error(
+        r#"{"rules":[{"id":"r","status":"Enabled","prefix":"v1/","daysAfterInitiation":1}]}"#,
+    );
+    assert!(
+        error.contains("unknown field") && error.contains("daysAfterInitiation"),
+        "error should name the unknown field: {error}"
+    );
+}
+
+#[test]
+fn flat_and_nested_abort_days_conflict_is_rejected() {
+    let error = parse_error(
+        r#"{"rules":[{"id":"r","status":"Enabled","abortIncompleteMultipartUploadDays":1,"abortIncompleteMultipartUpload":{"daysAfterInitiation":2}}]}"#,
+    );
+    assert!(
+        error.contains("abortIncompleteMultipartUploadDays"),
+        "{error}"
+    );
+}
+
+#[test]
+fn flat_prefix_and_filter_conflict_is_rejected() {
+    let error = parse_error(
+        r#"{"rules":[{"id":"r","status":"Enabled","prefix":"a/","filter":{"prefix":"b/"}}]}"#,
+    );
+    assert!(
+        error.contains("prefix") && error.contains("Filter.Prefix"),
+        "{error}"
+    );
+}
+
+#[test]
+fn filter_with_two_top_level_predicates_is_rejected() {
+    let error = parse_error(
+        r#"{"rules":[{"id":"r","status":"Enabled","filter":{"prefix":"a/","tag":{"key":"env","value":"prod"}}}]}"#,
+    );
+    assert!(
+        error.contains("exactly one of Prefix, Tag, or And"),
+        "{error}"
+    );
+}

--- a/crates/core/tests/lifecycle_import_dialect.rs
+++ b/crates/core/tests/lifecycle_import_dialect.rs
@@ -85,6 +85,24 @@ fn s3_filter_and_combination_is_flattened() {
 }
 
 #[test]
+fn s3_standalone_object_size_greater_than_filter_is_accepted() {
+    let config = parse(
+        r#"{"Rules":[{"ID":"size-filter","Status":"Enabled","Filter":{"ObjectSizeGreaterThan":1024},"Expiration":{"Days":30}}]}"#,
+    );
+    assert_eq!(config.rules[0].object_size_greater_than, Some(1024));
+    assert_eq!(config.rules[0].expiration.clone().unwrap().days, Some(30));
+}
+
+#[test]
+fn s3_standalone_object_size_less_than_filter_is_accepted() {
+    let config = parse(
+        r#"{"rules":[{"id":"r","status":"Enabled","filter":{"ObjectSizeLessThan":65536},"expiration":{"days":7}}]}"#,
+    );
+    assert_eq!(config.rules[0].object_size_less_than, Some(65536));
+    assert_eq!(config.rules[0].expiration.clone().unwrap().days, Some(7));
+}
+
+#[test]
 fn nested_expired_object_delete_marker_is_accepted() {
     let config = parse(
         r#"{"rules":[{"id":"r","status":"Enabled","expiration":{"ExpiredObjectDeleteMarker":true}}]}"#,
@@ -131,7 +149,9 @@ fn filter_with_two_top_level_predicates_is_rejected() {
         r#"{"rules":[{"id":"r","status":"Enabled","filter":{"prefix":"a/","tag":{"key":"env","value":"prod"}}}]}"#,
     );
     assert!(
-        error.contains("exactly one of Prefix, Tag, or And"),
+        error.contains(
+            "exactly one of Prefix, Tag, And, ObjectSizeGreaterThan, or ObjectSizeLessThan"
+        ),
         "{error}"
     );
 }

--- a/crates/s3/src/lifecycle_xml.rs
+++ b/crates/s3/src/lifecycle_xml.rs
@@ -544,6 +544,36 @@ mod tests {
     use super::*;
 
     #[test]
+    fn abort_only_rule_roundtrips_prefix_and_abort_action() {
+        let rules = vec![super::LifecycleRule {
+            id: "abort-only".to_string(),
+            status: super::LifecycleRuleStatus::Enabled,
+            prefix: Some("v1/".to_string()),
+            tags: None,
+            object_size_greater_than: None,
+            object_size_less_than: None,
+            expiration: None,
+            del_marker_expiration: None,
+            transition: None,
+            transitions: Vec::new(),
+            noncurrent_version_expiration: None,
+            noncurrent_version_transition: None,
+            noncurrent_version_transitions: Vec::new(),
+            abort_incomplete_multipart_upload_days: Some(1),
+            expired_object_delete_marker: None,
+        }];
+        let xml = super::build_lifecycle_configuration_xml(&rules);
+        assert!(
+            xml.contains("<AbortIncompleteMultipartUpload><DaysAfterInitiation>1</DaysAfterInitiation></AbortIncompleteMultipartUpload>"),
+            "abort action missing from XML: {xml}"
+        );
+        assert!(
+            xml.contains("<Prefix>v1/</Prefix>"),
+            "prefix missing from XML: {xml}"
+        );
+    }
+
+    #[test]
     fn lifecycle_xml_roundtrip_preserves_extension_fields_and_standard_actions() {
         let mut tags = HashMap::new();
         tags.insert("env".to_string(), "prod&blue".to_string());


### PR DESCRIPTION
## Problem

`rc ilm rule import` **silently drops unknown rule fields**. A JSON file whose keys don't match rc's camelCase dialect imports successfully, reports `✓ Imported 1 lifecycle rule(s)`, and sends a degraded rule to the server — which then rejects it with a confusing error.

Real-world sequence (this is how I hit it, originally misdiagnosed as a server bug in rustfs/rustfs#7456):

```sh
$ cat lifecycle.json
{"rules":[{"id":"cleanup","status":"Enabled","filter":{"prefix":"v1/"},"abort_incomplete_multipart_upload":{"days_after_initiation":1}}]}

$ rc ilm rule import alias/bucket lifecycle.json
✗ Failed to set lifecycle rules: set_bucket_lifecycle: Network error: HTTP 400:
  InvalidArgument: Rule must have at least one of Expiration, Transition,
  NoncurrentVersionExpiration, NoncurrentVersionTransition, or DelMarkerExpiration
```

The server is correct — rc parsed the file, dropped `filter` and `abort_incomplete_multipart_upload` as unknown fields, and PUT an actionless rule. Anyone pasting S3-shaped JSON (a natural thing to do, since it mirrors `PutBucketLifecycleConfiguration`) gets this exact failure, and nothing points at the real cause.

## Fix

`LifecycleRuleInput` (and the nested input structs) now:

1. **Accept the alternative spellings** instead of silently ignoring them:
   - snake_case (`abort_incomplete_multipart_upload_days`) and S3/PascalCase (`AbortIncompleteMultipartUploadDays`) for every field;
   - the S3 JSON shape: nested `filter` (`Prefix` / `Tag` / `And` with tags and size bounds) flattened onto rc's flat filter fields, nested `abortIncompleteMultipartUpload: { daysAfterInitiation }`, and `expiration.ExpiredObjectDeleteMarker`.
2. **Fail loudly on unknown fields** (`deny_unknown_fields`), naming the offending key — a wrong-dialect file is now a parse error, never a silent degradation.
3. **Reject ambiguous combinations**: flat + nested spellings of the same value (`prefix` and `filter.prefix`, flat and nested abort days) error unless identical; a `filter` with more than one top-level predicate (`Prefix` + `Tag`) is rejected like the server does.

An empty `filter: {}` stays valid (the server documents it as "applies to every object").

## Verification

- New `crates/core/tests/lifecycle_import_dialect.rs`: 10 tests covering the camelCase dialect (regression guard), snake_case, PascalCase, S3-shaped filter/abort/marker acceptance, `And` flattening, unknown-field rejection, and both conflict cases.
- Added a writer round-trip assertion for abort-only rules in `lifecycle_xml.rs` (the existing round-trip test constructed an abort value but never asserted its XML).
- `cargo fmt --all --check` ✅, `cargo clippy -p rc-core --all-targets -- -D warnings` ✅, `cargo test --workspace` ✅ (all suites green).
- End-to-end against a live `rustfs/rustfs:v1.0.0-rc.5` node: the exact JSON from the problem section now imports and round-trips:

```
✓ Imported 1 lifecycle rule(s) to bucket 'trust-evidence'.
$ rc ilm rule export alias/trust-evidence
{"rules":[{"id":"cleanup","status":"Enabled","prefix":"v1/","abortIncompleteMultipartUploadDays":3}]}
```

## Notes

- `cargo clippy --workspace` with Rust **1.95** fails on `crates/s3/src/admin/catalog.rs:305` (`nonminimal_bool`) — that failure exists on unmodified `main` under this toolchain and is unrelated to this change; I left it alone.
- Closing rustfs/rustfs#7456 pointed here; thanks for the quick tag cadence — everything else in the pinned surface (SSE-KMS local backend, multipart, versioning, presign) passed clean.
