### PR TITLE
docs(readme): fix command syntax for share and policy create

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ rc anonymous list local/bucket
 rc anonymous set public local/bucket/public
 
 # Generate download link
-rc share download local/bucket/file.txt --expire 24h
+rc share local/bucket/file.txt --expire 24h
 
 # View directory tree
 rc tree local/bucket -L 3
@@ -168,7 +168,7 @@ rc admin user list local/
 rc admin user add local/ newuser secretpassword
 
 # Create a policy
-rc admin policy create local/ readonly --file policy.json
+rc admin policy create local/ readonly policy.json
 
 # Attach policy to user
 rc admin policy attach local/ readonly --user newuser


### PR DESCRIPTION
## Summary

Fixes incorrect CLI command syntax examples in `README.md` for `rc share` and `rc admin policy create`.

## Problem Background & Root Cause

Users following the examples in `README.md` encountered argument parsing errors when executing the commands:
1. `rc admin policy create local/ readonly --file policy.json` failed with `error: unexpected argument '--file' found`. The CLI command expects 3 positional arguments `<ALIAS> <NAME> <POLICY_FILE>` rather than a `--file` flag.
2. `rc share download local/bucket/file.txt --expire 24h` failed with `error: unexpected argument 'local/bucket/file.txt' found`. The `rc share` command accepts `<PATH>` directly without a `download` subcommand.

## Solution

- Updated `README.md` line 133 to `rc share local/bucket/file.txt --expire 24h`.
- Updated `README.md` line 171 to `rc admin policy create local/ readonly policy.json`.

## Test Status & Validation

- Validated all command examples in `README.md` by parsing them directly against the compiled `rc` binary (`cargo run --bin rc -- ...`).
- Confirmed zero argument parsing errors across all `README.md` commands.